### PR TITLE
Add configurable and safer Windows Dream Skin flow

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -40,7 +40,7 @@
 | 启动 + 注入 | ✅ | ✅ |
 | 一键恢复 | ✅ | ✅ |
 | 实机 verify / 截图 | ✅ | ✅ |
-| 用户选图定制 | ✅ | ❌ |
+| 用户选图定制 | ✅ | ✅（`windows/scripts/set-dream-theme.ps1`） |
 | 官方签名校验 | ✅ | 部分（Store 包发现） |
 | 客户部署提示词 | ✅ | ❌（可用 Mac 文案改写） |
 | 打客户 ZIP | ✅ `build-client-release.sh` | 手动压缩 `windows/` |

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Windows Changelog
+
+## Unreleased
+
+### 新增
+
+- 新增用户主题配置，Windows 版现在可以通过 `scripts/set-dream-theme.ps1` 自定义图片、标题、标语、签名和主题色。
+- 新增 `windows/assets/theme.json` 作为默认主题，注入器会优先读取 `%LOCALAPPDATA%\CodexDreamSkin\theme\theme.json`。
+
+### 改进
+
+- 启动快捷方式不再默认强制重启已经打开的 Codex；需要重启时显式使用 `-RestartExisting`。
+- 还原快捷方式会同时传入 `-RestoreBaseTheme`，更接近完整恢复。
+- Windows 注入器加强了 CDP WebSocket 端口和本机地址校验。

--- a/windows/SKILL.md
+++ b/windows/SKILL.md
@@ -9,11 +9,12 @@ Apply a reversible renderer skin through Chromium DevTools Protocol while launch
 
 ## Workflow
 
-1. Run `scripts/install-dream-skin.ps1` once to set the matching official base colors and create launch/restore shortcuts.
-2. Run `scripts/start-dream-skin.ps1`. Add `-RestartExisting` only when the user authorized restarting an already-open Codex app.
-3. Run `scripts/verify-dream-skin.ps1 -ScreenshotPath <absolute-path>` after launch. Treat a missing hero, native composer, sidebar skin, or injection marker as failure. The native suggestion count is responsive and may be two to four.
-4. Inspect the screenshot against `references/qa-inventory.md`. Verify both the home screen and a normal task before signing off.
-5. Run `scripts/restore-dream-skin.ps1` for live removal. Add `-Uninstall` to delete shortcuts; add `-RestoreBaseTheme` when the user also wants the pre-install config backup restored.
+1. Run `scripts/install-dream-skin.ps1` once to set the matching official base colors and create launch/restore/theme shortcuts. Use `-SkipBaseTheme` if the user does not want `.codex/config.toml` touched.
+2. Optional: run `scripts/set-dream-theme.ps1 -ImagePath <image> -Name <name> -Accent <#hex> -Apply` to save a custom Windows theme. The interactive shortcut uses the same script with `-Interactive`.
+3. Run `scripts/start-dream-skin.ps1`. Add `-RestartExisting` only when the user authorized restarting an already-open Codex app.
+4. Run `scripts/verify-dream-skin.ps1 -ScreenshotPath <absolute-path>` after launch. Treat a missing hero, native composer, sidebar skin, or injection marker as failure. The native suggestion count is responsive and may be two to four.
+5. Inspect the screenshot against `references/qa-inventory.md`. Verify both the home screen and a normal task before signing off.
+6. Run `scripts/restore-dream-skin.ps1` for live removal. Add `-Uninstall` to delete shortcuts; add `-RestoreBaseTheme` when the user also wants the pre-install config backup restored.
 
 ## Guardrails
 
@@ -28,9 +29,11 @@ Apply a reversible renderer skin through Chromium DevTools Protocol while launch
 
 ## Resources
 
-- `scripts/injector.mjs`: CDP connection, renderer injection, verification, screenshot, and removal.
+- `scripts/injector.mjs`: CDP connection, renderer injection, theme loading, verification, screenshot, and removal.
+- `scripts/set-dream-theme.ps1`: Windows theme image/text/color customization.
 - `assets/dream-skin.css`: full visual layer.
 - `assets/renderer-inject.js`: idempotent DOM integration and cleanup.
+- `assets/theme.json`: bundled fallback theme.
 - `assets/dream-reference.png`: user-provided visual reference used only in cropped decorative regions.
 - `references/qa-inventory.md`: required functional and visual signoff coverage.
 - `references/runtime-notes.md`: troubleshooting and update behavior.

--- a/windows/assets/dream-skin.css
+++ b/windows/assets/dream-skin.css
@@ -7,13 +7,19 @@
   --dream-blush: #fff3f9;
   --dream-pearl: rgba(255, 251, 253, .92);
   --dream-line: rgba(221, 122, 184, .42);
+  --dream-panel-alt: #fff7fb;
+  --dream-accent-alt: #cf61f0;
+  --dream-muted: #9e58bd;
+  --dream-tagline-content: "与灵感一起，把每天写成作品 ♡";
+  --dream-project-prefix-content: "选择项目 · ";
+  --dream-project-label-content: "♡  选择项目";
 }
 
 html.codex-dream-skin body {
   background:
     radial-gradient(circle at 78% 2%, rgba(255, 184, 215, .66), transparent 25%),
     radial-gradient(circle at 24% 12%, rgba(210, 171, 255, .48), transparent 28%),
-    linear-gradient(135deg, #fff9fc 0%, #fceef8 48%, #f3eafd 100%) !important;
+    linear-gradient(135deg, #fff9fc 0%, var(--dream-blush) 48%, #f3eafd 100%) !important;
   color: var(--dream-ink) !important;
   font-family: "Microsoft YaHei UI", "Microsoft YaHei", system-ui, sans-serif !important;
 }
@@ -181,6 +187,7 @@ html.codex-dream-skin main.main-surface > header.app-header-tint {
   filter: drop-shadow(0 4px 5px rgba(166,66,137,.26));
 }
 #codex-dream-skin-chrome.dream-home-shell .dream-ribbon { display: flex; }
+.dream-ribbon strong { font-size: 15px; font-weight: 700; color: var(--dream-muted); max-width: min(420px, 44vw); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .dream-ribbon span { font-size: 15px; color: #c36dff; }
 
 html.codex-dream-skin [role="main"] {
@@ -273,7 +280,7 @@ html.codex-dream-skin .dream-home {
 }
 
 .dream-home [data-feature="game-source"]::after {
-  content: "与凯琪一起，把灵感写进每一天 ♡";
+  content: var(--dream-tagline-content);
   display: block;
   margin-top: 13px;
   color: rgba(255,248,255,.94);
@@ -296,7 +303,7 @@ html.codex-dream-skin .dream-home {
 }
 
 .dream-home [data-feature="game-source"] button::before {
-  content: "选择项目 · ";
+  content: var(--dream-project-prefix-content);
   font-size: .48em;
   font-weight: 600;
   vertical-align: middle;
@@ -399,7 +406,7 @@ html.codex-dream-skin .composer-surface-chrome::before {
 }
 
 .dream-home div:has(> .horizontal-scroll-fade-mask .group\/project-selector)::before {
-  content: "♡  选择项目";
+  content: var(--dream-project-label-content);
   position: absolute;
   left: 13px;
   top: 6px;

--- a/windows/assets/renderer-inject.js
+++ b/windows/assets/renderer-inject.js
@@ -1,25 +1,92 @@
-((cssText, artDataUrl) => {
+((cssText, themeConfig, artDataUrl) => {
   const STATE_KEY = "__CODEX_DREAM_SKIN_STATE__";
   const STYLE_ID = "codex-dream-skin-style";
   const CHROME_ID = "codex-dream-skin-chrome";
+  const VERSION = "1.1.0";
   window.__CODEX_DREAM_SKIN_DISABLED__ = false;
+
+  const defaults = {
+    name: "Codex Dream Skin",
+    brandSubtitle: "CODEX DREAM SKIN",
+    tagline: "与灵感一起，把每天写成作品 ♡",
+    projectPrefix: "选择项目 · ",
+    projectLabel: "♡  选择项目",
+    quote: "Make something wonderful",
+    signature: "Dream Skin ♡",
+    colors: {
+      background: "#fff3f9",
+      panel: "#ffffff",
+      panelAlt: "#fff7fb",
+      accent: "#b65cff",
+      accentAlt: "#cf61f0",
+      secondary: "#ff73bd",
+      highlight: "#8b3dce",
+      text: "#4c2364",
+      muted: "#9e58bd",
+      line: "rgba(221, 122, 184, .42)",
+    },
+  };
+  const theme = {
+    ...defaults,
+    ...(themeConfig || {}),
+    colors: { ...defaults.colors, ...((themeConfig || {}).colors || {}) },
+  };
+
+  const text = (value, fallback, max = 120) => {
+    const next = typeof value === "string" && value.trim() ? value : fallback;
+    return next.length > max ? next.slice(0, max) : next;
+  };
+  const cssString = (value, fallback) => JSON.stringify(text(value, fallback, 160));
 
   const previous = window[STATE_KEY];
   if (previous?.observer) previous.observer.disconnect();
   if (previous?.timer) clearInterval(previous.timer);
   if (previous?.scheduler?.timeout) clearTimeout(previous.scheduler.timeout);
-  const artUrl = previous?.artUrl || (() => {
-    const comma = artDataUrl.indexOf(",");
-    const binary = atob(artDataUrl.slice(comma + 1));
-    const bytes = new Uint8Array(binary.length);
-    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
-    return URL.createObjectURL(new Blob([bytes], { type: "image/png" }));
-  })();
+  if (previous?.artUrl) URL.revokeObjectURL(previous.artUrl);
+
+  const comma = artDataUrl.indexOf(",");
+  const binary = atob(artDataUrl.slice(comma + 1));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  const mime = artDataUrl.slice(5, comma).split(";")[0] || "image/png";
+  const artUrl = URL.createObjectURL(new Blob([bytes], { type: mime }));
+
   const existingStyle = document.getElementById(STYLE_ID);
   if (existingStyle) {
     existingStyle.textContent = cssText;
-    existingStyle.dataset.dreamVersion = "1";
+    existingStyle.dataset.dreamVersion = VERSION;
   }
+
+  const themeVars = [
+    ["--dream-ink", theme.colors.text],
+    ["--dream-purple", theme.colors.accent],
+    ["--dream-violet", theme.colors.highlight],
+    ["--dream-pink", theme.colors.secondary],
+    ["--dream-blush", theme.colors.background],
+    ["--dream-pearl", theme.colors.panel],
+    ["--dream-line", theme.colors.line],
+    ["--dream-panel-alt", theme.colors.panelAlt],
+    ["--dream-accent-alt", theme.colors.accentAlt],
+    ["--dream-muted", theme.colors.muted],
+    ["--dream-tagline-content", cssString(theme.tagline, defaults.tagline)],
+    ["--dream-project-prefix-content", cssString(theme.projectPrefix, defaults.projectPrefix)],
+    ["--dream-project-label-content", cssString(theme.projectLabel, defaults.projectLabel)],
+  ];
+
+  const applyThemeVars = (root) => {
+    for (const [name, value] of themeVars) root.style.setProperty(name, value);
+  };
+
+  const removeThemeVars = (root) => {
+    for (const [name] of themeVars) root.style.removeProperty(name);
+  };
+
+  const setChromeText = (chrome) => {
+    chrome.querySelector(".dream-brand b").textContent = text(theme.name, defaults.name, 80);
+    chrome.querySelector(".dream-brand small").textContent = text(theme.brandSubtitle, defaults.brandSubtitle, 80);
+    chrome.querySelector(".dream-signature").textContent = text(theme.signature, defaults.signature, 80);
+    chrome.querySelector(".dream-ribbon strong").textContent = text(theme.quote, defaults.quote, 100);
+  };
 
   const ensure = () => {
     if (window.__CODEX_DREAM_SKIN_DISABLED__) return;
@@ -27,6 +94,7 @@
     if (!root) return;
     root.classList.add("codex-dream-skin");
     root.style.setProperty("--dream-art", `url("${artUrl}")`);
+    applyThemeVars(root);
 
     let style = document.getElementById(STYLE_ID);
     if (!style) {
@@ -34,9 +102,9 @@
       style.id = STYLE_ID;
       (document.head || root).appendChild(style);
     }
-    if (style.dataset.dreamVersion !== "1") {
+    if (style.dataset.dreamVersion !== VERSION) {
       style.textContent = cssText;
-      style.dataset.dreamVersion = "1";
+      style.dataset.dreamVersion = VERSION;
     }
 
     const shellMain = document.querySelector("main.main-surface") || document.querySelector("main");
@@ -55,13 +123,14 @@
       chrome.id = CHROME_ID;
       chrome.setAttribute("aria-hidden", "true");
       chrome.innerHTML = `
-        <div class="dream-brand"><span class="dream-note">♫</span><span><b>薛凯琪专属定制皮肤</b><small>Codex App 限定版 ✦</small></span></div>
-        <div class="dream-signature">Fiona Sit ♡</div>
+        <div class="dream-brand"><span class="dream-note">♫</span><span><b></b><small></small></span></div>
+        <div class="dream-signature"></div>
         <div class="dream-sparkles"><i></i><i></i><i></i><i></i><i></i><i></i></div>
-        <div class="dream-ribbon"><span>♡</span>🎀<span>✦</span></div>
+        <div class="dream-ribbon"><span>♡</span><strong></strong><span>✦</span></div>
         <div class="dream-polaroid"></div>`;
       document.body.appendChild(chrome);
     }
+    setChromeText(chrome);
     const shellBox = shellMain.getBoundingClientRect();
     chrome.style.left = `${Math.round(shellBox.left)}px`;
     chrome.style.top = `${Math.round(shellBox.top)}px`;
@@ -74,6 +143,7 @@
     window.__CODEX_DREAM_SKIN_DISABLED__ = true;
     document.documentElement?.classList.remove("codex-dream-skin");
     document.documentElement?.style.removeProperty("--dream-art");
+    if (document.documentElement) removeThemeVars(document.documentElement);
     document.querySelectorAll(".dream-home").forEach((node) => node.classList.remove("dream-home"));
     document.querySelectorAll(".dream-home-shell").forEach((node) => node.classList.remove("dream-home-shell"));
     document.getElementById(STYLE_ID)?.remove();
@@ -98,7 +168,16 @@
   const observer = new MutationObserver(scheduleEnsure);
   observer.observe(document.documentElement, { childList: true, subtree: true });
   const timer = setInterval(ensure, 5000);
-  window[STATE_KEY] = { ensure, cleanup, observer, timer, scheduler, artUrl, version: "1.0.0" };
+  window[STATE_KEY] = {
+    ensure,
+    cleanup,
+    observer,
+    timer,
+    scheduler,
+    artUrl,
+    version: VERSION,
+    themeName: text(theme.name, defaults.name, 80),
+  };
   ensure();
-  return { installed: true, version: "1.0.0" };
-})(__DREAM_CSS_JSON__, __DREAM_ART_JSON__)
+  return { installed: true, version: VERSION, themeName: window[STATE_KEY].themeName };
+})(__DREAM_CSS_JSON__, __DREAM_THEME_JSON__, __DREAM_ART_JSON__)

--- a/windows/assets/theme.json
+++ b/windows/assets/theme.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "name": "Codex Dream Skin",
+  "brandSubtitle": "CODEX DREAM SKIN",
+  "tagline": "与灵感一起，把每天写成作品 ♡",
+  "projectPrefix": "选择项目 · ",
+  "projectLabel": "♡  选择项目",
+  "statusText": "DREAM SKIN ONLINE",
+  "quote": "Make something wonderful",
+  "signature": "Dream Skin ♡",
+  "image": "dream-reference.png",
+  "colors": {
+    "background": "#fff3f9",
+    "panel": "#ffffff",
+    "panelAlt": "#fff7fb",
+    "accent": "#b65cff",
+    "accentAlt": "#cf61f0",
+    "secondary": "#ff73bd",
+    "highlight": "#8b3dce",
+    "text": "#4c2364",
+    "muted": "#9e58bd",
+    "line": "rgba(221, 122, 184, .42)"
+  }
+}

--- a/windows/references/qa-inventory.md
+++ b/windows/references/qa-inventory.md
@@ -8,6 +8,7 @@
 4. The skin survives route changes and renderer reloads while the injector daemon runs.
 5. The official Store package and `app.asar` remain unchanged.
 6. Restore removes the injected DOM/CSS and install/restore can be repeated.
+7. A custom Windows theme image, name, tagline, signature, and accent palette can be saved and applied without editing source files.
 
 ## Functional checks
 
@@ -17,6 +18,7 @@
 - Composer: type text, verify caret/readability, then clear it without sending.
 - Reload: use CDP `Page.reload`, wait, and confirm the injection marker returns.
 - Restore/reapply cycle: remove live skin, verify marker absent, apply again, verify marker present.
+- Custom theme cycle: run `set-dream-theme.ps1` with a test image and colors, launch/apply, verify the theme name appears in injector verification output, then reset the theme.
 - Update resilience: resolve the current `OpenAI.Codex` Appx location dynamically; never store a versioned WindowsApps path.
 
 ## Visual checks

--- a/windows/references/runtime-notes.md
+++ b/windows/references/runtime-notes.md
@@ -1,8 +1,10 @@
 # Runtime notes
 
-- The skin launches the Store-installed `ChatGPT.exe` with `--remote-debugging-port=<port>` and injects through CDP.
+- The skin launches the Store-installed `ChatGPT.exe` with `--remote-debugging-address=127.0.0.1 --remote-debugging-port=<port>` and injects through CDP.
 - The default production port is `9335`; test instances may use another port plus an isolated `--user-data-dir`.
-- CDP is bound to loopback. Do not expose it on a LAN interface.
+- CDP is bound to `127.0.0.1`, and the injector refuses WebSocket targets that are not loopback or do not match the selected port. Do not expose it on a LAN interface.
+- User theme state lives under `%LOCALAPPDATA%\CodexDreamSkin\theme\theme.json` plus the selected image. If that file is absent, the bundled `assets/theme.json` and `dream-reference.png` are used.
+- Customize Windows themes with `scripts/set-dream-theme.ps1 -ImagePath <image> -Name <name> -Accent <#hex> -Apply`; use `-Interactive` for a guided local prompt.
 - The injector polls page targets and reinjects after document loads. In-page route changes use a debounced observer plus a low-frequency safety check to avoid CPU churn during streamed tasks.
 - `%LOCALAPPDATA%\CodexDreamSkin\state.json` records the port and daemon PID. Logs stay in the same directory.
 - If Codex is already running without the chosen debugging port, close it first or explicitly use `-RestartExisting`.

--- a/windows/scripts/injector.mjs
+++ b/windows/scripts/injector.mjs
@@ -4,9 +4,28 @@ import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(here, "..");
+const assetsRoot = path.join(root, "assets");
+const defaultThemePath = path.join(assetsRoot, "theme.json");
+const stateRoot = process.env.LOCALAPPDATA
+  ? path.join(process.env.LOCALAPPDATA, "CodexDreamSkin")
+  : path.join(root, ".state");
+const defaultThemeDir = path.join(stateRoot, "theme");
+const imageTypes = new Map([
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".webp", "image/webp"],
+]);
 
 function parseArgs(argv) {
-  const options = { port: 9335, mode: "watch", timeoutMs: 30000, screenshot: null, reload: false };
+  const options = {
+    port: 9335,
+    mode: "watch",
+    timeoutMs: 30000,
+    screenshot: null,
+    reload: false,
+    themeDir: defaultThemeDir,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--port") options.port = Number(argv[++i]);
@@ -16,13 +35,117 @@ function parseArgs(argv) {
     else if (arg === "--remove") options.mode = "remove";
     else if (arg === "--timeout-ms") options.timeoutMs = Number(argv[++i]);
     else if (arg === "--screenshot") options.screenshot = path.resolve(argv[++i]);
+    else if (arg === "--theme-dir") options.themeDir = path.resolve(argv[++i]);
     else if (arg === "--reload") options.reload = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
   if (!Number.isInteger(options.port) || options.port < 1024 || options.port > 65535) {
     throw new Error(`Invalid port: ${options.port}`);
   }
+  if (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1) {
+    throw new Error(`Invalid timeout: ${options.timeoutMs}`);
+  }
   return options;
+}
+
+function validateWebSocketUrl(value, port) {
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase();
+    return url.protocol === "ws:" &&
+      Number(url.port) === port &&
+      (host === "127.0.0.1" || host === "localhost" || host === "[::1]" || host === "::1");
+  } catch {
+    return false;
+  }
+}
+
+function cleanText(value, fallback, maxLength) {
+  const next = typeof value === "string" && value.trim() ? value.trim() : fallback;
+  return next.length > maxLength ? next.slice(0, maxLength) : next;
+}
+
+function cleanHex(value, fallback) {
+  return typeof value === "string" && /^#[0-9a-f]{6}$/i.test(value) ? value.toLowerCase() : fallback;
+}
+
+function cleanCssColor(value, fallback) {
+  return typeof value === "string" && value.length <= 80 ? value : fallback;
+}
+
+async function readJson(pathname) {
+  return JSON.parse(await fs.readFile(pathname, "utf8"));
+}
+
+async function pathExists(pathname) {
+  try {
+    await fs.access(pathname);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function mergeTheme(defaultTheme, userTheme = {}) {
+  const defaultColors = defaultTheme.colors || {};
+  const userColors = userTheme.colors || {};
+  return {
+    schemaVersion: 1,
+    name: cleanText(userTheme.name, defaultTheme.name || "Codex Dream Skin", 80),
+    brandSubtitle: cleanText(userTheme.brandSubtitle, defaultTheme.brandSubtitle || "CODEX DREAM SKIN", 80),
+    tagline: cleanText(userTheme.tagline, defaultTheme.tagline || "Make something wonderful", 160),
+    projectPrefix: cleanText(userTheme.projectPrefix, defaultTheme.projectPrefix || "选择项目 · ", 40),
+    projectLabel: cleanText(userTheme.projectLabel, defaultTheme.projectLabel || "♡  选择项目", 40),
+    statusText: cleanText(userTheme.statusText, defaultTheme.statusText || "DREAM SKIN ONLINE", 80),
+    quote: cleanText(userTheme.quote, defaultTheme.quote || "Make something wonderful", 100),
+    signature: cleanText(userTheme.signature, defaultTheme.signature || "Dream Skin ♡", 80),
+    image: path.basename(cleanText(userTheme.image, defaultTheme.image || "dream-reference.png", 160)),
+    colors: {
+      background: cleanHex(userColors.background, cleanHex(defaultColors.background, "#fff3f9")),
+      panel: cleanHex(userColors.panel, cleanHex(defaultColors.panel, "#ffffff")),
+      panelAlt: cleanHex(userColors.panelAlt, cleanHex(defaultColors.panelAlt, "#fff7fb")),
+      accent: cleanHex(userColors.accent, cleanHex(defaultColors.accent, "#b65cff")),
+      accentAlt: cleanHex(userColors.accentAlt, cleanHex(defaultColors.accentAlt, "#cf61f0")),
+      secondary: cleanHex(userColors.secondary, cleanHex(defaultColors.secondary, "#ff73bd")),
+      highlight: cleanHex(userColors.highlight, cleanHex(defaultColors.highlight, "#8b3dce")),
+      text: cleanHex(userColors.text, cleanHex(defaultColors.text, "#4c2364")),
+      muted: cleanHex(userColors.muted, cleanHex(defaultColors.muted, "#9e58bd")),
+      line: cleanCssColor(userColors.line, cleanCssColor(defaultColors.line, "rgba(221, 122, 184, .42)")),
+    },
+  };
+}
+
+async function loadTheme(themeDir) {
+  const defaultTheme = await readJson(defaultThemePath);
+  let theme = mergeTheme(defaultTheme);
+  let imageBase = assetsRoot;
+  const customThemePath = path.join(themeDir, "theme.json");
+
+  if (await pathExists(customThemePath)) {
+    theme = mergeTheme(defaultTheme, await readJson(customThemePath));
+    imageBase = themeDir;
+  }
+
+  const extension = path.extname(theme.image).toLowerCase();
+  if (!imageTypes.has(extension)) {
+    throw new Error(`Unsupported theme image extension: ${extension || "(none)"}`);
+  }
+
+  let imagePath = path.join(imageBase, theme.image);
+  if (!(await pathExists(imagePath))) {
+    imagePath = path.join(assetsRoot, theme.image);
+  }
+  if (!(await pathExists(imagePath))) {
+    imagePath = path.join(assetsRoot, defaultTheme.image || "dream-reference.png");
+    theme.image = path.basename(imagePath);
+  }
+
+  const imageStat = await fs.stat(imagePath);
+  if (!imageStat.isFile() || imageStat.size < 1 || imageStat.size > 16 * 1024 * 1024) {
+    throw new Error("Theme image must be non-empty and no larger than 16 MB.");
+  }
+
+  return { theme, imagePath, mime: imageTypes.get(path.extname(imagePath).toLowerCase()) };
 }
 
 class CdpSession {
@@ -107,7 +230,11 @@ async function waitForTargets(port, timeoutMs) {
       const response = await fetch(`http://127.0.0.1:${port}/json/list`);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const targets = await response.json();
-      const pages = targets.filter((item) => item.type === "page" && item.url.startsWith("app://"));
+      const pages = targets.filter((item) =>
+        item.type === "page" &&
+        typeof item.url === "string" &&
+        item.url.startsWith("app://") &&
+        validateWebSocketUrl(item.webSocketDebuggerUrl, port));
       if (pages.length) return pages;
     } catch (error) {
       lastError = error;
@@ -117,20 +244,54 @@ async function waitForTargets(port, timeoutMs) {
   throw new Error(`No Codex renderer target on 127.0.0.1:${port}: ${lastError?.message ?? "timed out"}`);
 }
 
-async function loadPayload() {
-  const [css, template, art] = await Promise.all([
-    fs.readFile(path.join(root, "assets", "dream-skin.css"), "utf8"),
-    fs.readFile(path.join(root, "assets", "renderer-inject.js"), "utf8"),
-    fs.readFile(path.join(root, "assets", "dream-reference.png")),
+async function loadPayload(themeDir) {
+  const [{ theme, imagePath, mime }, css, template] = await Promise.all([
+    loadTheme(themeDir),
+    fs.readFile(path.join(assetsRoot, "dream-skin.css"), "utf8"),
+    fs.readFile(path.join(assetsRoot, "renderer-inject.js"), "utf8"),
   ]);
-  const artDataUrl = `data:image/png;base64,${art.toString("base64")}`;
+  const art = await fs.readFile(imagePath);
+  const artDataUrl = `data:${mime};base64,${art.toString("base64")}`;
   return template
     .replace("__DREAM_CSS_JSON__", JSON.stringify(css))
+    .replace("__DREAM_THEME_JSON__", JSON.stringify(theme))
     .replace("__DREAM_ART_JSON__", JSON.stringify(artDataUrl));
 }
 
-async function connectTarget(target) {
+async function connectTarget(target, port) {
+  if (!validateWebSocketUrl(target.webSocketDebuggerUrl, port)) {
+    throw new Error(`Refusing non-loopback or mismatched CDP target: ${target.webSocketDebuggerUrl}`);
+  }
   return new CdpSession(target).open();
+}
+
+async function probeCodexSession(session) {
+  return session.evaluate(`(() => {
+    const hasCodexShell = Boolean(
+      document.querySelector('main.main-surface') ||
+      document.querySelector('aside.app-shell-left-panel') ||
+      document.querySelector('.composer-surface-chrome') ||
+      document.querySelector('[role="main"]')
+    );
+    return {
+      url: location.href,
+      protocolOk: location.protocol === 'app:',
+      hasCodexShell,
+      title: document.title,
+      ready: location.protocol === 'app:' && hasCodexShell,
+    };
+  })()`);
+}
+
+async function waitForCodexSession(session, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastProbe;
+  while (Date.now() < deadline) {
+    lastProbe = await probeCodexSession(session);
+    if (lastProbe.ready) return lastProbe;
+    await new Promise((resolve) => setTimeout(resolve, 350));
+  }
+  throw new Error(`Target is not a ready Codex renderer: ${JSON.stringify(lastProbe)}`);
 }
 
 async function applyToSession(session, payload) {
@@ -144,6 +305,21 @@ async function removeFromSession(session) {
     if (state?.cleanup) return state.cleanup();
     document.documentElement?.classList.remove('codex-dream-skin');
     document.documentElement?.style.removeProperty('--dream-art');
+    for (const name of [
+      '--dream-ink',
+      '--dream-purple',
+      '--dream-violet',
+      '--dream-pink',
+      '--dream-blush',
+      '--dream-pearl',
+      '--dream-line',
+      '--dream-panel-alt',
+      '--dream-accent-alt',
+      '--dream-muted',
+      '--dream-tagline-content',
+      '--dream-project-prefix-content',
+      '--dream-project-label-content',
+    ]) document.documentElement?.style.removeProperty(name);
     document.getElementById('codex-dream-skin-style')?.remove();
     document.getElementById('codex-dream-skin-chrome')?.remove();
     return true;
@@ -160,9 +336,11 @@ async function verifySession(session) {
     const home = document.querySelector('.dream-home');
     const suggestions = home?.querySelector('.group\\\\/home-suggestions') ?? null;
     const cards = suggestions ? [...suggestions.querySelectorAll('button')].map(box) : [];
+    const state = window.__CODEX_DREAM_SKIN_STATE__ ?? {};
     const result = {
       installed: document.documentElement.classList.contains('codex-dream-skin'),
-      version: window.__CODEX_DREAM_SKIN_STATE__?.version ?? null,
+      version: state.version ?? null,
+      themeName: state.themeName ?? null,
       stylePresent: Boolean(document.getElementById('codex-dream-skin-style')),
       chromePresent: Boolean(document.getElementById('codex-dream-skin-chrome')),
       chromePointerEvents: getComputedStyle(document.getElementById('codex-dream-skin-chrome') || document.body).pointerEvents,
@@ -219,11 +397,12 @@ async function capture(session, outputPath) {
 
 async function runOneShot(options) {
   const targets = await waitForTargets(options.port, options.timeoutMs);
-  const payload = (options.mode === "once" || options.reload) ? await loadPayload() : null;
+  const payload = (options.mode === "once" || options.reload) ? await loadPayload(options.themeDir) : null;
   const results = [];
   for (const target of targets) {
-    const session = await connectTarget(target);
+    const session = await connectTarget(target, options.port);
     try {
+      await waitForCodexSession(session, Math.min(options.timeoutMs, 10000));
       if (options.mode === "remove") await removeFromSession(session);
       else if (options.mode === "once") await applyToSession(session, payload);
       if (options.mode === "once") {
@@ -250,7 +429,7 @@ async function runOneShot(options) {
 }
 
 async function runWatch(options) {
-  const payload = await loadPayload();
+  const payload = await loadPayload(options.themeDir);
   const sessions = new Map();
   let stopping = false;
   const stop = () => { stopping = true; };
@@ -278,7 +457,8 @@ async function runWatch(options) {
     for (const target of targets) {
       if (sessions.has(target.id)) continue;
       try {
-        const session = await connectTarget(target);
+        const session = await connectTarget(target, options.port);
+        await waitForCodexSession(session, 10000);
         session.on("Page.loadEventFired", () => {
           setTimeout(() => applyToSession(session, payload).catch((error) => {
             console.error(`[dream-skin] reinject failed: ${error.message}`);

--- a/windows/scripts/install-dream-skin.ps1
+++ b/windows/scripts/install-dream-skin.ps1
@@ -1,37 +1,40 @@
 [CmdletBinding()]
 param(
   [int]$Port = 9335,
-  [switch]$NoShortcuts
+  [switch]$NoShortcuts,
+  [switch]$SkipBaseTheme
 )
 
 $ErrorActionPreference = 'Stop'
 $SkillRoot = Split-Path -Parent $PSScriptRoot
 $StateRoot = Join-Path $env:LOCALAPPDATA 'CodexDreamSkin'
 New-Item -ItemType Directory -Force -Path $StateRoot | Out-Null
-$ConfigPath = Join-Path $HOME '.codex\config.toml'
-$BackupPath = Join-Path $StateRoot 'config.before-dream-skin.toml'
-if (-not (Test-Path -LiteralPath $ConfigPath)) { throw "Codex config not found: $ConfigPath" }
-if (-not (Test-Path -LiteralPath $BackupPath)) { Copy-Item -LiteralPath $ConfigPath -Destination $BackupPath }
+if (-not $SkipBaseTheme) {
+  $ConfigPath = Join-Path $HOME '.codex\config.toml'
+  $BackupPath = Join-Path $StateRoot 'config.before-dream-skin.toml'
+  if (-not (Test-Path -LiteralPath $ConfigPath)) { throw "Codex config not found: $ConfigPath" }
+  if (-not (Test-Path -LiteralPath $BackupPath)) { Copy-Item -LiteralPath $ConfigPath -Destination $BackupPath }
 
-$content = Get-Content -LiteralPath $ConfigPath -Raw
-$desktopMatch = [regex]::Match($content, '(?ms)^\[desktop\]\s*\r?\n(?<body>.*?)(?=^\[|\z)')
-if (-not $desktopMatch.Success) {
-  $content = $content.TrimEnd() + "`r`n`r`n[desktop]`r`n"
+  $content = Get-Content -LiteralPath $ConfigPath -Raw
   $desktopMatch = [regex]::Match($content, '(?ms)^\[desktop\]\s*\r?\n(?<body>.*?)(?=^\[|\z)')
+  if (-not $desktopMatch.Success) {
+    $content = $content.TrimEnd() + "`r`n`r`n[desktop]`r`n"
+    $desktopMatch = [regex]::Match($content, '(?ms)^\[desktop\]\s*\r?\n(?<body>.*?)(?=^\[|\z)')
+  }
+  $body = $desktopMatch.Groups['body'].Value
+  $settings = [ordered]@{
+    appearanceTheme = 'appearanceTheme = "light"'
+    appearanceLightCodeThemeId = 'appearanceLightCodeThemeId = "codex"'
+    appearanceLightChromeTheme = 'appearanceLightChromeTheme = { accent = "#B65CFF", contrast = 64, fonts = { code = "Cascadia Code", ui = "Microsoft YaHei UI" }, ink = "#4A235F", opaqueWindows = true, semanticColors = { diffAdded = "#BCE8CF", diffRemoved = "#F7B8CE", skill = "#C47BFF" }, surface = "#FFF4FA" }'
+  }
+  foreach ($key in $settings.Keys) {
+    $pattern = "(?m)^$([regex]::Escape($key))\s*=.*$"
+    if ([regex]::IsMatch($body, $pattern)) { $body = [regex]::Replace($body, $pattern, $settings[$key]) }
+    else { $body = $body.TrimEnd() + "`r`n" + $settings[$key] + "`r`n" }
+  }
+  $content = $content.Substring(0, $desktopMatch.Groups['body'].Index) + $body + $content.Substring($desktopMatch.Groups['body'].Index + $desktopMatch.Groups['body'].Length)
+  Set-Content -LiteralPath $ConfigPath -Value $content -Encoding utf8
 }
-$body = $desktopMatch.Groups['body'].Value
-$settings = [ordered]@{
-  appearanceTheme = 'appearanceTheme = "light"'
-  appearanceLightCodeThemeId = 'appearanceLightCodeThemeId = "codex"'
-  appearanceLightChromeTheme = 'appearanceLightChromeTheme = { accent = "#B65CFF", contrast = 64, fonts = { code = "Cascadia Code", ui = "Microsoft YaHei UI" }, ink = "#4A235F", opaqueWindows = true, semanticColors = { diffAdded = "#BCE8CF", diffRemoved = "#F7B8CE", skill = "#C47BFF" }, surface = "#FFF4FA" }'
-}
-foreach ($key in $settings.Keys) {
-  $pattern = "(?m)^$([regex]::Escape($key))\s*=.*$"
-  if ([regex]::IsMatch($body, $pattern)) { $body = [regex]::Replace($body, $pattern, $settings[$key]) }
-  else { $body = $body.TrimEnd() + "`r`n" + $settings[$key] + "`r`n" }
-}
-$content = $content.Substring(0, $desktopMatch.Groups['body'].Index) + $body + $content.Substring($desktopMatch.Groups['body'].Index + $desktopMatch.Groups['body'].Length)
-Set-Content -LiteralPath $ConfigPath -Value $content -Encoding utf8
 
 if (-not $NoShortcuts) {
   $shell = New-Object -ComObject WScript.Shell
@@ -40,20 +43,29 @@ if (-not $NoShortcuts) {
   $powershell = (Get-Command powershell.exe).Source
   $startScript = Join-Path $PSScriptRoot 'start-dream-skin.ps1'
   $restoreScript = Join-Path $PSScriptRoot 'restore-dream-skin.ps1'
+  $themeScript = Join-Path $PSScriptRoot 'set-dream-theme.ps1'
   foreach ($folder in @($desktop, $startMenu)) {
     $shortcut = $shell.CreateShortcut((Join-Path $folder 'Codex Dream Skin.lnk'))
     $shortcut.TargetPath = $powershell
-    $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$startScript`" -Port $Port -RestartExisting"
+    $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$startScript`" -Port $Port"
     $shortcut.WorkingDirectory = $SkillRoot
-    $shortcut.Description = 'Launch Codex with the Dream/Fiona full interface skin'
+    $shortcut.Description = 'Launch Codex with the Dream Skin interface theme'
     $shortcut.Save()
   }
   $restore = $shell.CreateShortcut((Join-Path $desktop 'Codex Dream Skin - Restore.lnk'))
   $restore.TargetPath = $powershell
-  $restore.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$restoreScript`" -Port $Port"
+  $restore.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$restoreScript`" -Port $Port -RestoreBaseTheme"
   $restore.WorkingDirectory = $SkillRoot
   $restore.Description = 'Remove the live Codex Dream Skin'
   $restore.Save()
+
+  $theme = $shell.CreateShortcut((Join-Path $desktop 'Codex Dream Skin - Theme.lnk'))
+  $theme.TargetPath = $powershell
+  $theme.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$themeScript`" -Interactive"
+  $theme.WorkingDirectory = $SkillRoot
+  $theme.Description = 'Open the guided Codex Dream Skin theme editor'
+  $theme.Save()
 }
 
 Write-Host 'Codex Dream Skin installed. Launch it with the created shortcut or start-dream-skin.ps1.'
+Write-Host 'Customize it with set-dream-theme.ps1 -ImagePath <file> -Name <name> -Accent #b65cff -Apply.'

--- a/windows/scripts/restore-dream-skin.ps1
+++ b/windows/scripts/restore-dream-skin.ps1
@@ -11,10 +11,27 @@ $injector = Join-Path $PSScriptRoot 'injector.mjs'
 $StateRoot = Join-Path $env:LOCALAPPDATA 'CodexDreamSkin'
 $StatePath = Join-Path $StateRoot 'state.json'
 
+function Stop-PreviousInjector([object]$State, [string]$ExpectedNode, [string]$ExpectedInjector) {
+  if (-not $State.injectorPid) { return }
+  $injectorPid = [int]$State.injectorPid
+  $process = Get-CimInstance Win32_Process -Filter "ProcessId = $injectorPid" -ErrorAction SilentlyContinue
+  if (-not $process) { return }
+
+  $commandLine = "$($process.CommandLine)"
+  $executable = "$($process.ExecutablePath)"
+  $nodeMatches = $executable -and ([System.IO.Path]::GetFullPath($executable) -ieq [System.IO.Path]::GetFullPath($ExpectedNode))
+  $injectorMatches = $commandLine.IndexOf($ExpectedInjector, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+  if (-not ($nodeMatches -and $injectorMatches)) {
+    Write-Warning "Skipping stale injector PID $injectorPid because it no longer matches this Dream Skin injector."
+    return
+  }
+  Stop-Process -Id $injectorPid -Force -ErrorAction SilentlyContinue
+}
+
 if (Test-Path -LiteralPath $StatePath) {
   try {
     $state = Get-Content -LiteralPath $StatePath -Raw | ConvertFrom-Json
-    if ($state.injectorPid) { Stop-Process -Id ([int]$state.injectorPid) -Force -ErrorAction SilentlyContinue }
+    Stop-PreviousInjector $state $node $injector
   } catch {}
   Remove-Item -LiteralPath $StatePath -Force -ErrorAction SilentlyContinue
 }
@@ -27,6 +44,7 @@ if ($Uninstall) {
   @(
     (Join-Path $desktop 'Codex Dream Skin.lnk'),
     (Join-Path $desktop 'Codex Dream Skin - Restore.lnk'),
+    (Join-Path $desktop 'Codex Dream Skin - Theme.lnk'),
     (Join-Path $startMenu 'Codex Dream Skin.lnk')
   ) | ForEach-Object { Remove-Item -LiteralPath $_ -Force -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/set-dream-theme.ps1
+++ b/windows/scripts/set-dream-theme.ps1
@@ -1,0 +1,203 @@
+[CmdletBinding()]
+param(
+  [string]$ImagePath,
+  [string]$Name,
+  [string]$BrandSubtitle,
+  [string]$Tagline,
+  [string]$ProjectPrefix,
+  [string]$ProjectLabel,
+  [string]$Quote,
+  [string]$Signature,
+  [AllowNull()][ValidateScript({ -not $_ -or $_ -match '^#[0-9A-Fa-f]{6}$' })][string]$Background,
+  [AllowNull()][ValidateScript({ -not $_ -or $_ -match '^#[0-9A-Fa-f]{6}$' })][string]$Panel,
+  [AllowNull()][ValidateScript({ -not $_ -or $_ -match '^#[0-9A-Fa-f]{6}$' })][string]$PanelAlt,
+  [AllowNull()][ValidateScript({ -not $_ -or $_ -match '^#[0-9A-Fa-f]{6}$' })][string]$Accent,
+  [AllowNull()][ValidateScript({ -not $_ -or $_ -match '^#[0-9A-Fa-f]{6}$' })][string]$AccentAlt,
+  [AllowNull()][ValidateScript({ -not $_ -or $_ -match '^#[0-9A-Fa-f]{6}$' })][string]$Secondary,
+  [AllowNull()][ValidateScript({ -not $_ -or $_ -match '^#[0-9A-Fa-f]{6}$' })][string]$Highlight,
+  [AllowNull()][ValidateScript({ -not $_ -or $_ -match '^#[0-9A-Fa-f]{6}$' })][string]$Text,
+  [AllowNull()][ValidateScript({ -not $_ -or $_ -match '^#[0-9A-Fa-f]{6}$' })][string]$Muted,
+  [int]$Port = 9335,
+  [switch]$Reset,
+  [switch]$Interactive,
+  [switch]$Apply,
+  [switch]$RestartExisting
+)
+
+$ErrorActionPreference = 'Stop'
+$SkillRoot = Split-Path -Parent $PSScriptRoot
+$AssetsRoot = Join-Path $SkillRoot 'assets'
+$DefaultThemePath = Join-Path $AssetsRoot 'theme.json'
+$DefaultImagePath = Join-Path $AssetsRoot 'dream-reference.png'
+$StateRoot = Join-Path $env:LOCALAPPDATA 'CodexDreamSkin'
+$ThemeDir = Join-Path $StateRoot 'theme'
+$ThemePath = Join-Path $ThemeDir 'theme.json'
+
+function Assert-ThemeDir {
+  $stateFull = [System.IO.Path]::GetFullPath($StateRoot)
+  $themeFull = [System.IO.Path]::GetFullPath($ThemeDir)
+  if (-not $themeFull.StartsWith($stateFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Theme directory is outside the expected state root: $ThemeDir"
+  }
+}
+
+function Read-JsonFile([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) { return $null }
+  return Get-Content -LiteralPath $Path -Raw -Encoding utf8 | ConvertFrom-Json
+}
+
+function Get-TextValue([object]$Provided, [object]$Current, [object]$Default, [int]$MaxLength) {
+  $value = $null
+  if ($null -ne $Provided -and "$Provided".Trim().Length -gt 0) { $value = "$Provided" }
+  elseif ($null -ne $Current -and "$Current".Trim().Length -gt 0) { $value = "$Current" }
+  else { $value = "$Default" }
+  if ($value.Length -gt $MaxLength) { return $value.Substring(0, $MaxLength) }
+  return $value
+}
+
+function Get-ColorValue([object]$Provided, [object]$CurrentColors, [object]$DefaultColors, [string]$Name) {
+  if ($null -ne $Provided -and "$Provided".Length -gt 0) { return "$Provided".ToLowerInvariant() }
+  $currentProperty = if ($CurrentColors) { $CurrentColors.PSObject.Properties[$Name] } else { $null }
+  if ($currentProperty -and "$($currentProperty.Value)".Length -gt 0) { return "$($currentProperty.Value)" }
+  $defaultProperty = $DefaultColors.PSObject.Properties[$Name]
+  return "$($defaultProperty.Value)"
+}
+
+function Convert-HexToRgba([string]$Hex, [double]$Alpha) {
+  $red = [Convert]::ToInt32($Hex.Substring(1, 2), 16)
+  $green = [Convert]::ToInt32($Hex.Substring(3, 2), 16)
+  $blue = [Convert]::ToInt32($Hex.Substring(5, 2), 16)
+  return "rgba($red, $green, $blue, $Alpha)"
+}
+
+function Read-OptionalValue([string]$Prompt, [string]$Current) {
+  $value = Read-Host "$Prompt [$Current]"
+  if ($value.Trim().Length -gt 0) { return $value.Trim() }
+  return $Current
+}
+
+function Read-OptionalColor([string]$Prompt, [string]$Current) {
+  while ($true) {
+    $value = Read-Host "$Prompt [$Current]"
+    if ($value.Trim().Length -eq 0) { return $Current }
+    if ($value -match '^#[0-9A-Fa-f]{6}$') { return $value.ToLowerInvariant() }
+    Write-Host 'Use a six-digit hex color, for example #b65cff.'
+  }
+}
+
+Assert-ThemeDir
+New-Item -ItemType Directory -Force -Path $StateRoot | Out-Null
+
+if ($Interactive -and -not $Reset) {
+  $defaultThemeForPrompt = Read-JsonFile $DefaultThemePath
+  $currentThemeForPrompt = Read-JsonFile $ThemePath
+  if (-not $currentThemeForPrompt) { $currentThemeForPrompt = $defaultThemeForPrompt }
+
+  Add-Type -AssemblyName System.Windows.Forms
+  $dialog = New-Object System.Windows.Forms.OpenFileDialog
+  $dialog.Title = 'Choose a Codex Dream Skin image'
+  $dialog.Filter = 'Images (*.png;*.jpg;*.jpeg;*.webp)|*.png;*.jpg;*.jpeg;*.webp|All files (*.*)|*.*'
+  if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
+    $ImagePath = $dialog.FileName
+  }
+
+  $Name = Read-OptionalValue 'Theme name' "$($currentThemeForPrompt.name)"
+  $Tagline = Read-OptionalValue 'Hero tagline' "$($currentThemeForPrompt.tagline)"
+  $Quote = Read-OptionalValue 'Ribbon quote' "$($currentThemeForPrompt.quote)"
+  $Signature = Read-OptionalValue 'Signature' "$($currentThemeForPrompt.signature)"
+  $Accent = Read-OptionalColor 'Accent color' "$($currentThemeForPrompt.colors.accent)"
+  $Secondary = Read-OptionalColor 'Secondary color' "$($currentThemeForPrompt.colors.secondary)"
+  $Highlight = Read-OptionalColor 'Highlight color' "$($currentThemeForPrompt.colors.highlight)"
+  $applyAnswer = Read-Host 'Apply now? [Y/n]'
+  if ($applyAnswer.Trim().Length -eq 0 -or $applyAnswer -match '^(y|yes)$') { $Apply = $true }
+}
+
+if ($Reset) {
+  if (Test-Path -LiteralPath $ThemeDir) {
+    Remove-Item -LiteralPath $ThemeDir -Recurse -Force
+  }
+  if ($Apply) {
+    $start = Join-Path $PSScriptRoot 'start-dream-skin.ps1'
+    $arguments = @('-Port', "$Port")
+    if ($RestartExisting) { $arguments += '-RestartExisting' }
+    & $start @arguments
+  }
+  Write-Host 'Codex Dream Skin theme reset to bundled defaults.'
+  exit 0
+}
+
+$defaultTheme = Read-JsonFile $DefaultThemePath
+if (-not $defaultTheme) { throw "Default theme not found: $DefaultThemePath" }
+$currentTheme = Read-JsonFile $ThemePath
+if (-not $currentTheme) { $currentTheme = $defaultTheme }
+
+New-Item -ItemType Directory -Force -Path $ThemeDir | Out-Null
+
+$imageName = $null
+if ($ImagePath) {
+  $resolvedImage = Resolve-Path -LiteralPath $ImagePath -ErrorAction Stop
+  $source = Get-Item -LiteralPath $resolvedImage.ProviderPath
+  if (-not $source.PSIsContainer) {
+    $extension = $source.Extension.ToLowerInvariant()
+    if ($extension -notin @('.png', '.jpg', '.jpeg', '.webp')) {
+      throw 'Theme image must be PNG, JPEG, or WebP.'
+    }
+    if ($source.Length -le 0 -or $source.Length -gt 16777216) {
+      throw 'Theme image must be non-empty and no larger than 16 MB.'
+    }
+    $imageName = "background-$((Get-Date).ToString('yyyyMMdd-HHmmss'))$extension"
+    Copy-Item -LiteralPath $source.FullName -Destination (Join-Path $ThemeDir $imageName) -Force
+  } else {
+    throw "Theme image is a directory: $($source.FullName)"
+  }
+} else {
+  $candidate = if ($currentTheme.image) { [System.IO.Path]::GetFileName("$($currentTheme.image)") } else { $null }
+  if ($candidate -and (Test-Path -LiteralPath (Join-Path $ThemeDir $candidate))) {
+    $imageName = $candidate
+  } else {
+    $imageName = 'dream-reference.png'
+    Copy-Item -LiteralPath $DefaultImagePath -Destination (Join-Path $ThemeDir $imageName) -Force
+  }
+}
+
+Get-ChildItem -LiteralPath $ThemeDir -File -Filter 'background-*' -ErrorAction SilentlyContinue |
+  Where-Object { $_.Name -ne $imageName } |
+  Remove-Item -Force
+
+$colors = [ordered]@{
+  background = Get-ColorValue $Background $currentTheme.colors $defaultTheme.colors 'background'
+  panel = Get-ColorValue $Panel $currentTheme.colors $defaultTheme.colors 'panel'
+  panelAlt = Get-ColorValue $PanelAlt $currentTheme.colors $defaultTheme.colors 'panelAlt'
+  accent = Get-ColorValue $Accent $currentTheme.colors $defaultTheme.colors 'accent'
+  accentAlt = Get-ColorValue $AccentAlt $currentTheme.colors $defaultTheme.colors 'accentAlt'
+  secondary = Get-ColorValue $Secondary $currentTheme.colors $defaultTheme.colors 'secondary'
+  highlight = Get-ColorValue $Highlight $currentTheme.colors $defaultTheme.colors 'highlight'
+  text = Get-ColorValue $Text $currentTheme.colors $defaultTheme.colors 'text'
+  muted = Get-ColorValue $Muted $currentTheme.colors $defaultTheme.colors 'muted'
+  line = Convert-HexToRgba (Get-ColorValue $Secondary $currentTheme.colors $defaultTheme.colors 'secondary') 0.42
+}
+
+$theme = [ordered]@{
+  schemaVersion = 1
+  name = Get-TextValue $Name $currentTheme.name $defaultTheme.name 80
+  brandSubtitle = Get-TextValue $BrandSubtitle $currentTheme.brandSubtitle $defaultTheme.brandSubtitle 80
+  tagline = Get-TextValue $Tagline $currentTheme.tagline $defaultTheme.tagline 160
+  projectPrefix = Get-TextValue $ProjectPrefix $currentTheme.projectPrefix $defaultTheme.projectPrefix 40
+  projectLabel = Get-TextValue $ProjectLabel $currentTheme.projectLabel $defaultTheme.projectLabel 40
+  statusText = Get-TextValue $null $currentTheme.statusText $defaultTheme.statusText 80
+  quote = Get-TextValue $Quote $currentTheme.quote $defaultTheme.quote 100
+  signature = Get-TextValue $Signature $currentTheme.signature $defaultTheme.signature 80
+  image = $imageName
+  colors = $colors
+}
+
+($theme | ConvertTo-Json -Depth 6) + "`n" | Set-Content -LiteralPath $ThemePath -Encoding utf8
+
+if ($Apply) {
+  $start = Join-Path $PSScriptRoot 'start-dream-skin.ps1'
+  $arguments = @('-Port', "$Port")
+  if ($RestartExisting) { $arguments += '-RestartExisting' }
+  & $start @arguments
+}
+
+Write-Host "Codex Dream Skin theme saved: $($theme.name)"

--- a/windows/scripts/start-dream-skin.ps1
+++ b/windows/scripts/start-dream-skin.ps1
@@ -15,13 +15,45 @@ $StdoutPath = Join-Path $StateRoot 'injector.log'
 $StderrPath = Join-Path $StateRoot 'injector-error.log'
 New-Item -ItemType Directory -Force -Path $StateRoot | Out-Null
 
-function Test-CodexDebugPort([int]$CandidatePort) {
+function Test-CdpWebSocketUrl([string]$Value, [int]$CandidatePort) {
   try {
-    $targets = Invoke-RestMethod "http://127.0.0.1:$CandidatePort/json/list" -TimeoutSec 1
-    return [bool]($targets | Where-Object { $_.type -eq 'page' -and $_.url -like 'app://*' })
+    $uri = [Uri]$Value
+    $host = $uri.Host.ToLowerInvariant()
+    return $uri.Scheme -eq 'ws' -and $uri.Port -eq $CandidatePort -and
+      $host -in @('127.0.0.1', 'localhost', '::1', '[::1]')
   } catch {
     return $false
   }
+}
+
+function Test-CodexDebugPort([int]$CandidatePort) {
+  try {
+    $targets = Invoke-RestMethod "http://127.0.0.1:$CandidatePort/json/list" -TimeoutSec 1
+    return [bool]($targets | Where-Object {
+      $_.type -eq 'page' -and
+      $_.url -like 'app://*' -and
+      (Test-CdpWebSocketUrl $_.webSocketDebuggerUrl $CandidatePort)
+    })
+  } catch {
+    return $false
+  }
+}
+
+function Stop-PreviousInjector([object]$State, [string]$ExpectedNode, [string]$ExpectedInjector) {
+  if (-not $State.injectorPid) { return }
+  $injectorPid = [int]$State.injectorPid
+  $process = Get-CimInstance Win32_Process -Filter "ProcessId = $injectorPid" -ErrorAction SilentlyContinue
+  if (-not $process) { return }
+
+  $commandLine = "$($process.CommandLine)"
+  $executable = "$($process.ExecutablePath)"
+  $nodeMatches = $executable -and ([System.IO.Path]::GetFullPath($executable) -ieq [System.IO.Path]::GetFullPath($ExpectedNode))
+  $injectorMatches = $commandLine.IndexOf($ExpectedInjector, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+  if (-not ($nodeMatches -and $injectorMatches)) {
+    Write-Warning "Skipping stale injector PID $injectorPid because it no longer matches this Dream Skin injector."
+    return
+  }
+  Stop-Process -Id $injectorPid -Force -ErrorAction SilentlyContinue
 }
 
 $node = (Get-Command node -ErrorAction Stop).Source
@@ -43,7 +75,7 @@ if (-not (Test-CodexDebugPort $Port)) {
   if (-not $package) { throw 'The OpenAI.Codex Store package is not installed.' }
   $exe = Join-Path $package.InstallLocation 'app\ChatGPT.exe'
   if (-not (Test-Path -LiteralPath $exe)) { throw "Codex executable not found: $exe" }
-  $arguments = @("--remote-debugging-port=$Port")
+  $arguments = @("--remote-debugging-address=127.0.0.1", "--remote-debugging-port=$Port")
   if ($ProfilePath) {
     New-Item -ItemType Directory -Force -Path $ProfilePath | Out-Null
     $arguments += "--user-data-dir=$ProfilePath"
@@ -60,7 +92,7 @@ while (-not (Test-CodexDebugPort $Port)) {
 if (Test-Path -LiteralPath $StatePath) {
   try {
     $old = Get-Content -LiteralPath $StatePath -Raw | ConvertFrom-Json
-    if ($old.injectorPid) { Stop-Process -Id ([int]$old.injectorPid) -Force -ErrorAction SilentlyContinue }
+    Stop-PreviousInjector $old $node $Injector
   } catch {}
 }
 
@@ -74,6 +106,8 @@ $daemon = Start-Process -FilePath $node -ArgumentList $injectorArgs -WindowStyle
 @{
   port = $Port
   injectorPid = $daemon.Id
+  injectorPath = $Injector
+  nodePath = $node
   startedAt = (Get-Date).ToString('o')
   skillRoot = $SkillRoot
   profilePath = $ProfilePath

--- a/windows/scripts/verify-dream-skin.ps1
+++ b/windows/scripts/verify-dream-skin.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
   [int]$Port = 9335,
+  [string]$ThemeDir,
   [string]$ScreenshotPath
 )
 
@@ -8,6 +9,7 @@ $ErrorActionPreference = 'Stop'
 $node = (Get-Command node -ErrorAction Stop).Source
 $injector = Join-Path $PSScriptRoot 'injector.mjs'
 $arguments = @($injector, '--verify', '--port', "$Port")
+if ($ThemeDir) { $arguments += @('--theme-dir', $ThemeDir) }
 if ($ScreenshotPath) { $arguments += @('--screenshot', $ScreenshotPath) }
 & $node @arguments
 exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

This PR upgrades the Windows Dream Skin implementation from a fixed demo skin into a configurable, safer Windows flow.

### What changed

- Added `windows/assets/theme.json` as the bundled fallback theme definition.
- Added `windows/scripts/set-dream-theme.ps1` so Windows users can customize the theme without editing source files.
- The Windows theme editor now supports custom image selection, theme name, hero tagline, ribbon quote, signature text, and accent/secondary/highlight colors.
- Added `-Interactive` mode for a guided local prompt.
- Updated the renderer injection template to consume theme JSON and set user-provided text with `textContent` instead of embedding custom text into HTML.
- Updated the injector to prefer `%LOCALAPPDATA%\CodexDreamSkin\theme\theme.json`, with fallback to bundled assets.
- Added validation for theme image type and size.
- Hardened CDP target selection by requiring loopback WebSocket URLs and the selected port.
- Added a renderer readiness probe before injection to reduce the chance of injecting into the wrong `app://` page.
- Changed Windows launch behavior so shortcuts no longer silently pass `-RestartExisting`.
- Bound Codex CDP startup explicitly to `127.0.0.1`.
- Added safer old-injector cleanup by checking the stored PID against the expected Node executable and injector command line before stopping it.
- Updated restore/uninstall handling to remove the new theme shortcut and support fuller base-theme restoration.
- Updated Windows docs, runtime notes, QA inventory, platform matrix, and added a Windows changelog.

## Why

The existing Windows implementation was mostly a fixed Fiona/Dream demo: the image, labels, and decorative copy were hard-coded in `dream-skin.css` and `renderer-inject.js`. It also created a launch shortcut that always used `-RestartExisting`, and the old injector cleanup stopped the stored PID without confirming that the PID still belonged to this injector.

That made Windows less controllable than macOS and made the install/restore behavior more surprising for users.

## User impact

Windows users can now create and apply their own Dream Skin theme with a command such as:

```powershell
.\windows\scripts\set-dream-theme.ps1 -ImagePath "D:\theme.png" -Name "My Codex Skin" -Tagline "Make something wonderful" -Accent "#123456" -Secondary "#abcdef" -Highlight "#654321" -Apply
```

Users who prefer a guided local prompt can run:

```powershell
.\windows\scripts\set-dream-theme.ps1 -Interactive
```

The saved theme lives under `%LOCALAPPDATA%\CodexDreamSkin\theme`, so source files no longer need to be modified to change the Windows skin.

## Safety notes

- The launcher now starts Codex with `--remote-debugging-address=127.0.0.1`.
- The injector refuses CDP WebSocket targets that are not loopback or do not match the chosen port.
- Existing Codex windows are not restarted by shortcuts unless the user explicitly opts into `-RestartExisting`.
- PID cleanup checks the process identity before stopping a previously recorded injector process.
- Theme images are constrained to PNG/JPEG/WebP and a maximum prepared size of 16 MB.

## Validation

Ran the following checks locally on Windows:

```powershell
node --check windows\scripts\injector.mjs
node --check windows\assets\renderer-inject.js
```

PowerShell parse validation for all Windows scripts:

```powershell
$errors = @()
foreach ($file in Get-ChildItem -LiteralPath 'windows\scripts' -Filter '*.ps1') {
  $tokens = $null
  $parseErrors = $null
  [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$tokens, [ref]$parseErrors) | Out-Null
  if ($parseErrors) { $errors += $parseErrors }
}
if ($errors.Count) { exit 1 }
```

Whitespace check:

```powershell
git diff --check HEAD~1..HEAD
```

Also verified `set-dream-theme.ps1` using a temporary `LOCALAPPDATA` root so the test did not touch the real user theme state. The script successfully wrote a custom `theme.json`, copied the selected image into the temporary theme directory, preserved the project prefix spacing, and applied the requested test colors.

## Not covered

I did not run the live install/start flow in this PR validation pass because that would restart or inject into the local Codex desktop app. The live verification path remains documented in `windows/references/qa-inventory.md`.
