### PR TITLE
fix(windows): avoid duplicate chrome theme TOML

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Windows Changelog
+
+## Unreleased
+
+### 修复
+
+- 安装基础主题时不再把 `appearanceLightChromeTheme` 同时写成内联值和分表，避免 Codex 因重复 TOML 键而忽略整份配置并重新提示 Windows 权限设置。
+- 重复安装现在保持配置结构稳定；一键恢复可以正确还原用户原有的内联或分表主题，同时保留其他后续配置改动。

--- a/windows/scripts/install-dream-skin.ps1
+++ b/windows/scripts/install-dream-skin.ps1
@@ -10,28 +10,8 @@ $StateRoot = Join-Path $env:LOCALAPPDATA 'CodexDreamSkin'
 New-Item -ItemType Directory -Force -Path $StateRoot | Out-Null
 $ConfigPath = Join-Path $HOME '.codex\config.toml'
 $BackupPath = Join-Path $StateRoot 'config.before-dream-skin.toml'
-if (-not (Test-Path -LiteralPath $ConfigPath)) { throw "Codex config not found: $ConfigPath" }
-if (-not (Test-Path -LiteralPath $BackupPath)) { Copy-Item -LiteralPath $ConfigPath -Destination $BackupPath }
-
-$content = Get-Content -LiteralPath $ConfigPath -Raw
-$desktopMatch = [regex]::Match($content, '(?ms)^\[desktop\]\s*\r?\n(?<body>.*?)(?=^\[|\z)')
-if (-not $desktopMatch.Success) {
-  $content = $content.TrimEnd() + "`r`n`r`n[desktop]`r`n"
-  $desktopMatch = [regex]::Match($content, '(?ms)^\[desktop\]\s*\r?\n(?<body>.*?)(?=^\[|\z)')
-}
-$body = $desktopMatch.Groups['body'].Value
-$settings = [ordered]@{
-  appearanceTheme = 'appearanceTheme = "light"'
-  appearanceLightCodeThemeId = 'appearanceLightCodeThemeId = "codex"'
-  appearanceLightChromeTheme = 'appearanceLightChromeTheme = { accent = "#B65CFF", contrast = 64, fonts = { code = "Cascadia Code", ui = "Microsoft YaHei UI" }, ink = "#4A235F", opaqueWindows = true, semanticColors = { diffAdded = "#BCE8CF", diffRemoved = "#F7B8CE", skill = "#C47BFF" }, surface = "#FFF4FA" }'
-}
-foreach ($key in $settings.Keys) {
-  $pattern = "(?m)^$([regex]::Escape($key))\s*=.*$"
-  if ([regex]::IsMatch($body, $pattern)) { $body = [regex]::Replace($body, $pattern, $settings[$key]) }
-  else { $body = $body.TrimEnd() + "`r`n" + $settings[$key] + "`r`n" }
-}
-$content = $content.Substring(0, $desktopMatch.Groups['body'].Index) + $body + $content.Substring($desktopMatch.Groups['body'].Index + $desktopMatch.Groups['body'].Length)
-Set-Content -LiteralPath $ConfigPath -Value $content -Encoding utf8
+$ThemeConfigScript = Join-Path $PSScriptRoot 'theme-config.ps1'
+& $ThemeConfigScript install $ConfigPath $BackupPath
 
 if (-not $NoShortcuts) {
   $shell = New-Object -ComObject WScript.Shell

--- a/windows/scripts/restore-dream-skin.ps1
+++ b/windows/scripts/restore-dream-skin.ps1
@@ -34,27 +34,8 @@ if ($Uninstall) {
 if ($RestoreBaseTheme) {
   $backup = Join-Path $StateRoot 'config.before-dream-skin.toml'
   $config = Join-Path $HOME '.codex\config.toml'
-  if (-not (Test-Path -LiteralPath $backup)) { throw 'No pre-install config backup is available.' }
-  $backupContent = Get-Content -LiteralPath $backup -Raw
-  $currentContent = Get-Content -LiteralPath $config -Raw
-  foreach ($key in @('appearanceTheme', 'appearanceLightCodeThemeId', 'appearanceLightChromeTheme')) {
-    $pattern = "(?m)^$([regex]::Escape($key))\s*=.*(?:\r?\n)?"
-    $saved = [regex]::Match($backupContent, $pattern)
-    if ([regex]::IsMatch($currentContent, $pattern)) {
-      $replacement = if ($saved.Success) { $saved.Value.TrimEnd("`r", "`n") + "`r`n" } else { '' }
-      $currentContent = [regex]::Replace($currentContent, $pattern, $replacement, 1)
-    } elseif ($saved.Success) {
-      $desktop = [regex]::Match($currentContent, '(?ms)^\[desktop\]\s*\r?\n(?<body>.*?)(?=^\[|\z)')
-      if (-not $desktop.Success) {
-        $currentContent = $currentContent.TrimEnd() + "`r`n`r`n[desktop]`r`n"
-        $desktop = [regex]::Match($currentContent, '(?ms)^\[desktop\]\s*\r?\n(?<body>.*?)(?=^\[|\z)')
-      }
-      $body = $desktop.Groups['body'].Value.TrimEnd() + "`r`n" + $saved.Value.TrimEnd("`r", "`n") + "`r`n"
-      $currentContent = $currentContent.Substring(0, $desktop.Groups['body'].Index) + $body +
-        $currentContent.Substring($desktop.Groups['body'].Index + $desktop.Groups['body'].Length)
-    }
-  }
-  Set-Content -LiteralPath $config -Value $currentContent -Encoding utf8
+  $themeConfigScript = Join-Path $PSScriptRoot 'theme-config.ps1'
+  & $themeConfigScript restore $config $backup
 }
 
 Write-Host 'The live Dream Skin was removed.'

--- a/windows/scripts/theme-config.ps1
+++ b/windows/scripts/theme-config.ps1
@@ -1,0 +1,154 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [ValidateSet('install', 'restore')]
+  [string]$Mode,
+  [Parameter(Mandatory = $true, Position = 1)]
+  [string]$ConfigPath,
+  [Parameter(Mandatory = $true, Position = 2)]
+  [string]$BackupPath
+)
+
+$ErrorActionPreference = 'Stop'
+$ThemeKey = 'appearanceLightChromeTheme'
+$ThemeTablePattern = '(?ms)^\[desktop\.appearanceLightChromeTheme(?:\.[^\]\r\n]+)?\][^\r\n]*(?:\r?\n|$).*?(?=^\[|\z)'
+
+function Get-NewLine([string]$Content) {
+  if ($Content.Contains("`r`n")) { return "`r`n" }
+  return "`n"
+}
+
+function Ensure-DesktopSection([string]$Content) {
+  if ([regex]::IsMatch($Content, '(?m)^\[desktop\]\s*$')) { return $Content }
+  $newline = Get-NewLine $Content
+  return $Content.TrimEnd() + $newline + $newline + '[desktop]' + $newline
+}
+
+function Get-DesktopMatch([string]$Content) {
+  return [regex]::Match($Content, '(?ms)^\[desktop\]\s*\r?\n(?<body>.*?)(?=^\[|\z)')
+}
+
+function Get-DesktopSetting([string]$Content, [string]$Key) {
+  $desktop = Get-DesktopMatch $Content
+  if (-not $desktop.Success) { return $null }
+  $pattern = "(?m)^$([regex]::Escape($Key))\s*=.*$"
+  $setting = [regex]::Match($desktop.Groups['body'].Value, $pattern)
+  if (-not $setting.Success) { return $null }
+  return $setting.Value.TrimEnd("`r", "`n")
+}
+
+function Set-DesktopSetting(
+  [string]$Content,
+  [string]$Key,
+  [AllowNull()][string]$Setting
+) {
+  $Content = Ensure-DesktopSection $Content
+  $desktop = Get-DesktopMatch $Content
+  if (-not $desktop.Success) { throw 'Could not locate the [desktop] table.' }
+
+  $newline = Get-NewLine $Content
+  $body = $desktop.Groups['body'].Value
+  $pattern = "(?m)^$([regex]::Escape($Key))\s*=.*(?:\r?\n)?"
+  if ([regex]::IsMatch($body, $pattern)) {
+    $replacement = if ($null -eq $Setting) { '' } else { $Setting + $newline }
+    $body = [regex]::Replace($body, $pattern, $replacement, 1)
+  } elseif ($null -ne $Setting) {
+    $body = $body.TrimEnd() + $newline + $Setting + $newline
+  }
+
+  return $Content.Substring(0, $desktop.Groups['body'].Index) + $body +
+    $Content.Substring($desktop.Groups['body'].Index + $desktop.Groups['body'].Length)
+}
+
+function Get-ThemeSnapshot([string]$Content) {
+  $inline = Get-DesktopSetting $Content $ThemeKey
+  $sections = [regex]::Matches($Content, $ThemeTablePattern)
+  if ($inline -and $sections.Count -gt 0) {
+    throw 'The saved config defines appearanceLightChromeTheme as both an inline value and tables.'
+  }
+  if ($inline) {
+    return [pscustomobject]@{ Mode = 'inline'; Text = $inline }
+  }
+  if ($sections.Count -gt 0) {
+    $newline = Get-NewLine $Content
+    $text = (($sections | ForEach-Object { $_.Value.Trim() }) -join ($newline + $newline))
+    return [pscustomobject]@{ Mode = 'sections'; Text = $text }
+  }
+  return [pscustomobject]@{ Mode = 'none'; Text = '' }
+}
+
+function Remove-ThemeConfig([string]$Content) {
+  $Content = Set-DesktopSetting $Content $ThemeKey $null
+  return [regex]::Replace($Content, $ThemeTablePattern, '')
+}
+
+function Add-ThemeSnapshot([string]$Content, [object]$Snapshot) {
+  if ($Snapshot.Mode -eq 'inline') {
+    return Set-DesktopSetting $Content $ThemeKey $Snapshot.Text
+  }
+  if ($Snapshot.Mode -eq 'sections') {
+    $newline = Get-NewLine $Content
+    return $Content.TrimEnd() + $newline + $newline + $Snapshot.Text.Trim() + $newline
+  }
+  return $Content
+}
+
+function Write-AtomicUtf8([string]$Path, [string]$Content) {
+  $temporary = "$Path.$PID.tmp"
+  try {
+    Set-Content -LiteralPath $temporary -Value $Content -Encoding utf8 -NoNewline
+    Move-Item -LiteralPath $temporary -Destination $Path -Force
+  } finally {
+    Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+  }
+}
+
+if (-not (Test-Path -LiteralPath $ConfigPath)) {
+  throw "Codex config not found: $ConfigPath"
+}
+
+$content = Get-Content -LiteralPath $ConfigPath -Raw
+if ($Mode -eq 'install') {
+  if (-not (Test-Path -LiteralPath $BackupPath)) {
+    Copy-Item -LiteralPath $ConfigPath -Destination $BackupPath
+  }
+
+  $content = Set-DesktopSetting $content 'appearanceTheme' 'appearanceTheme = "light"'
+  $content = Set-DesktopSetting $content 'appearanceLightCodeThemeId' 'appearanceLightCodeThemeId = "codex"'
+  $content = Remove-ThemeConfig $content
+  $newline = Get-NewLine $content
+  $theme = @(
+    '[desktop.appearanceLightChromeTheme]'
+    'accent = "#B65CFF"'
+    'contrast = 64'
+    'ink = "#4A235F"'
+    'opaqueWindows = true'
+    'surface = "#FFF4FA"'
+    ''
+    '[desktop.appearanceLightChromeTheme.fonts]'
+    'code = "Cascadia Code"'
+    'ui = "Microsoft YaHei UI"'
+    ''
+    '[desktop.appearanceLightChromeTheme.semanticColors]'
+    'diffAdded = "#BCE8CF"'
+    'diffRemoved = "#F7B8CE"'
+    'skill = "#C47BFF"'
+  ) -join $newline
+  $content = $content.TrimEnd() + $newline + $newline + $theme + $newline
+  Write-AtomicUtf8 $ConfigPath $content
+  Write-Host 'Saved the base-theme backup and applied the Dream Skin base theme.'
+  exit 0
+}
+
+if (-not (Test-Path -LiteralPath $BackupPath)) {
+  throw 'No pre-install config backup is available.'
+}
+
+$backup = Get-Content -LiteralPath $BackupPath -Raw
+$snapshot = Get-ThemeSnapshot $backup
+$content = Set-DesktopSetting $content 'appearanceTheme' (Get-DesktopSetting $backup 'appearanceTheme')
+$content = Set-DesktopSetting $content 'appearanceLightCodeThemeId' (Get-DesktopSetting $backup 'appearanceLightCodeThemeId')
+$content = Remove-ThemeConfig $content
+$content = Add-ThemeSnapshot $content $snapshot
+Write-AtomicUtf8 $ConfigPath $content
+Write-Host 'Restored the saved base-theme settings.'

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -1,0 +1,100 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$Root = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$ThemeConfig = Join-Path $Root 'windows\scripts\theme-config.ps1'
+$TemporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) "codex-dream-skin-tests-$PID"
+
+function Assert-True([bool]$Condition, [string]$Message) {
+  if (-not $Condition) { throw "Assertion failed: $Message" }
+}
+
+function Count-Matches([string]$Content, [string]$Pattern) {
+  return [regex]::Matches($Content, $Pattern).Count
+}
+
+try {
+  New-Item -ItemType Directory -Force -Path $TemporaryRoot | Out-Null
+  $config = Join-Path $TemporaryRoot 'config.toml'
+  $backup = Join-Path $TemporaryRoot 'backup.toml'
+  $original = @'
+model = "gpt-5.6"
+
+[desktop]
+appearanceTheme = "system"
+appearanceLightCodeThemeId = "one"
+localeOverride = "zh-CN"
+
+[desktop.appearanceLightChromeTheme]
+accent = "#526fff"
+contrast = 45
+ink = "#383a42"
+opaqueWindows = true
+surface = "#fafafa"
+
+[desktop.appearanceLightChromeTheme.fonts]
+code = "FiraCode Nerd Font"
+ui = "Noto Sans CJK SC"
+
+[desktop.appearanceLightChromeTheme.semanticColors]
+diffAdded = "#3bba54"
+diffRemoved = "#e45649"
+skill = "#526fff"
+
+[windows]
+sandbox = "unelevated"
+'@
+  Set-Content -LiteralPath $config -Value $original -Encoding utf8 -NoNewline
+
+  & $ThemeConfig install $config $backup
+  $installed = Get-Content -LiteralPath $config -Raw
+  Assert-True ((Count-Matches $installed '(?m)^appearanceLightChromeTheme\s*=') -eq 0) 'install removes the conflicting inline key'
+  Assert-True ((Count-Matches $installed '(?m)^\[desktop\.appearanceLightChromeTheme\]$') -eq 1) 'install writes one parent theme table'
+  Assert-True ((Count-Matches $installed '(?m)^\[desktop\.appearanceLightChromeTheme\.fonts\]$') -eq 1) 'install writes one fonts table'
+  Assert-True ((Count-Matches $installed '(?m)^\[desktop\.appearanceLightChromeTheme\.semanticColors\]$') -eq 1) 'install writes one semantic colors table'
+  Assert-True ($installed.Contains('sandbox = "unelevated"')) 'install preserves unrelated Windows settings'
+  Assert-True ($installed.Contains('localeOverride = "zh-CN"')) 'install preserves unrelated desktop settings'
+
+  & $ThemeConfig install $config $backup
+  $installedAgain = Get-Content -LiteralPath $config -Raw
+  Assert-True ($installedAgain -eq $installed) 'install is idempotent'
+
+  $installedAgain = $installedAgain.Replace('localeOverride = "zh-CN"', 'localeOverride = "zh-TW"')
+  Set-Content -LiteralPath $config -Value $installedAgain -Encoding utf8 -NoNewline
+  & $ThemeConfig restore $config $backup
+  $restored = Get-Content -LiteralPath $config -Raw
+  Assert-True ($restored.Contains('accent = "#526fff"')) 'restore recovers the original section-form theme'
+  Assert-True ($restored.Contains('code = "FiraCode Nerd Font"')) 'restore recovers nested theme tables'
+  Assert-True ($restored.Contains('appearanceTheme = "system"')) 'restore recovers the original appearance mode'
+  Assert-True ($restored.Contains('localeOverride = "zh-TW"')) 'restore preserves unrelated changes made after install'
+
+  $inlineRoot = Join-Path $TemporaryRoot 'inline'
+  New-Item -ItemType Directory -Force -Path $inlineRoot | Out-Null
+  $inlineConfig = Join-Path $inlineRoot 'config.toml'
+  $inlineBackup = Join-Path $inlineRoot 'backup.toml'
+  $inlineTheme = 'appearanceLightChromeTheme = { accent = "#112233", contrast = 50, fonts = { code = "Consolas", ui = "Segoe UI" }, ink = "#223344", opaqueWindows = true, semanticColors = { diffAdded = "#00aa00", diffRemoved = "#aa0000", skill = "#0000aa" }, surface = "#ffffff" }'
+  Set-Content -LiteralPath $inlineConfig -Encoding utf8 -NoNewline -Value "[desktop]`r`nappearanceTheme = `"system`"`r`n$inlineTheme`r`n`r`n[windows]`r`nsandbox = `"unelevated`"`r`n"
+  & $ThemeConfig install $inlineConfig $inlineBackup
+  & $ThemeConfig restore $inlineConfig $inlineBackup
+  $inlineRestored = Get-Content -LiteralPath $inlineConfig -Raw
+  Assert-True ($inlineRestored.Contains($inlineTheme)) 'restore preserves an original inline theme representation'
+  Assert-True ((Count-Matches $inlineRestored '(?m)^\[desktop\.appearanceLightChromeTheme(?:\.|\])') -eq 0) 'inline restore removes generated section tables'
+
+  $emptyRoot = Join-Path $TemporaryRoot 'empty-theme'
+  New-Item -ItemType Directory -Force -Path $emptyRoot | Out-Null
+  $emptyConfig = Join-Path $emptyRoot 'config.toml'
+  $emptyBackup = Join-Path $emptyRoot 'backup.toml'
+  Set-Content -LiteralPath $emptyConfig -Encoding utf8 -NoNewline -Value "[desktop]`r`nlocaleOverride = `"zh-CN`"`r`n`r`n[windows]`r`nsandbox = `"unelevated`"`r`n"
+  & $ThemeConfig install $emptyConfig $emptyBackup
+  & $ThemeConfig restore $emptyConfig $emptyBackup
+  $emptyRestored = Get-Content -LiteralPath $emptyConfig -Raw
+  Assert-True (-not $emptyRestored.Contains('appearanceTheme =')) 'restore removes an appearance mode that was absent before install'
+  Assert-True (-not $emptyRestored.Contains('appearanceLightCodeThemeId =')) 'restore removes a code theme that was absent before install'
+  Assert-True ((Count-Matches $emptyRestored '(?m)^\[desktop\.appearanceLightChromeTheme(?:\.|\])') -eq 0) 'restore removes a chrome theme that was absent before install'
+  Assert-True ($emptyRestored.Contains('localeOverride = "zh-CN"')) 'empty-theme restore preserves unrelated desktop settings'
+
+  Write-Host 'Windows theme config tests passed.'
+} finally {
+  Remove-Item -LiteralPath $TemporaryRoot -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

- replace the Windows installer's inline `appearanceLightChromeTheme` assignment with a shared table-aware config updater
- remove conflicting inline/table representations before writing one canonical theme table
- restore the user's original inline or section-based theme without overwriting unrelated config changes
- add idempotency and restore regression coverage plus Windows release notes

## Root cause

The installer wrote `appearanceLightChromeTheme = { ... }` inside `[desktop]` even when the user's config already contained `[desktop.appearanceLightChromeTheme]` and nested `fonts` / `semanticColors` tables. TOML treats the inline table as closed, so Codex rejected the whole config as a duplicate table/value. That could also prevent `[windows] sandbox = "unelevated"` from loading and send the app back through elevated Windows sandbox setup.

## Validation

```powershell
powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\tests\run-tests.ps1
```

The tests cover:

- an existing section-based chrome theme
- an existing inline chrome theme
- no pre-existing chrome theme
- repeated install idempotency
- selective restore while preserving unrelated post-install changes

Also completed:

- PowerShell parse validation for every script under `windows/scripts` and `windows/tests`
- `node --check` for the Windows injector and renderer payload
- `git diff --check`
- install twice + restore against a temporary copy of a real Codex config, parsed with Python `tomllib`, while preserving `windows.sandbox = "unelevated"`

No live Codex restart was required for these config transformation tests.