### PR TITLE
fix(windows): 修复 Microsoft Store 版 Codex 启动时拒绝访问

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Windows Changelog
+
+## Unreleased
+
+### 修复
+
+- 修复部分 Microsoft Store 版 Codex 因 WindowsApps 权限拒绝直接启动的问题；改用 Windows 官方包应用激活接口，并继续仅通过本机回环 CDP 应用主题。

--- a/windows/scripts/start-dream-skin.ps1
+++ b/windows/scripts/start-dream-skin.ps1
@@ -24,6 +24,57 @@ function Test-CodexDebugPort([int]$CandidatePort) {
   }
 }
 
+function Start-PackagedCodex([string]$PackageFamilyName, [string[]]$Arguments) {
+  if (-not ('CodexDreamSkin.PackageLauncher' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+namespace CodexDreamSkin {
+  [Flags]
+  internal enum ActivateOptions : uint {
+    None = 0
+  }
+
+  [ComImport]
+  [Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
+  [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  internal interface IApplicationActivationManager {
+    [PreserveSig]
+    int ActivateApplication(
+      [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+      [MarshalAs(UnmanagedType.LPWStr)] string arguments,
+      ActivateOptions options,
+      out uint processId);
+  }
+
+  [ComImport]
+  [Guid("45ba127d-10a8-46ea-8ab7-56ea9078943c")]
+  internal class ApplicationActivationManager {}
+
+  public static class PackageLauncher {
+    public static uint Launch(string appUserModelId, string arguments) {
+      var manager = (IApplicationActivationManager)new ApplicationActivationManager();
+      uint processId;
+      int result = manager.ActivateApplication(appUserModelId, arguments, ActivateOptions.None, out processId);
+      Marshal.ThrowExceptionForHR(result);
+      return processId;
+    }
+  }
+}
+'@
+  }
+
+  foreach ($argument in $Arguments) {
+    if ($argument.Contains('"')) { throw 'Codex launch arguments cannot contain double quotes.' }
+  }
+  $argumentLine = ($Arguments | ForEach-Object {
+    if ($_ -match '\s') { '"' + $_ + '"' } else { $_ }
+  }) -join ' '
+  $appUserModelId = "$PackageFamilyName!App"
+  [void][CodexDreamSkin.PackageLauncher]::Launch($appUserModelId, $argumentLine)
+}
+
 $node = (Get-Command node -ErrorAction Stop).Source
 $debugReady = Test-CodexDebugPort $Port
 $mainProcesses = @(Get-Process ChatGPT -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowHandle -ne 0 })
@@ -48,7 +99,9 @@ if (-not (Test-CodexDebugPort $Port)) {
     New-Item -ItemType Directory -Force -Path $ProfilePath | Out-Null
     $arguments += "--user-data-dir=$ProfilePath"
   }
-  Start-Process -FilePath $exe -ArgumentList $arguments
+  # Store package executables can reject direct Start-Process calls even when
+  # their files are readable. Activate the registered full-trust app instead.
+  Start-PackagedCodex $package.PackageFamilyName $arguments
 }
 
 $deadline = (Get-Date).AddSeconds(30)


### PR DESCRIPTION
## 问题说明

Windows 端原启动脚本会通过 `Start-Process`，直接运行 Microsoft Store
安装目录中的 `ChatGPT.exe`：

`C:\Program Files\WindowsApps\OpenAI.Codex_*\app\ChatGPT.exe`

在部分 Windows 环境中，该目录受到应用包权限保护，直接运行会出现：

`Start-Process：拒绝访问`

最终导致 Codex 无法启动，主题也无法通过 CDP 完成注入。

## 问题原因

Microsoft Store 应用应通过系统注册的应用包入口启动。

即使脚本可以找到 `WindowsApps` 中的可执行文件，Windows 仍可能禁止外部
PowerShell 脚本直接运行该文件。

## 修复内容

- 新增基于 Windows 应用包激活接口的启动逻辑。
- 使用 Codex 的应用包标识启动官方 Codex。
- 保留 `--remote-debugging-port` 调试端口参数。
- 保留 `--user-data-dir` 独立用户目录参数。
- 不修改 `WindowsApps` 的目录权限。
- 不修改官方 Codex 文件、安装包和数字签名。
- 增加 Windows 更新日志。

## 验证结果

测试环境：

- Microsoft Store 版 Codex：`26.707.9981.0`
- Node.js：`22.22.0`
- 本机 CDP 地址：`127.0.0.1:9335`

验证结果：

- Codex 可以正常启动。
- 本机 CDP 端口正常开放。
- Dream Skin 主题成功注入。
- `verify-dream-skin.ps1` 验证结果为 `pass: true`。

## 影响范围

本次修改只调整 Windows 商店版 Codex 的启动方式。

不会影响：

- Codex 用户配置
- 登录状态和历史任务
- 主题样式和主题素材
- 官方安装目录及文件权限
- 官方应用包和数字签名