### PR TITLE
fix(windows): launch Codex via shell:AppsFolder activation

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### 修复
+
+- `scripts/start-dream-skin.ps1` 改用 `shell:AppsFolder\<AUMID>` 激活 Codex，而不是直接运行 `app\ChatGPT.exe`：当前 Win11 + Store 版的 `ChatGPT.exe` 需要包身份，外部进程一律"拒绝访问"；走 AppsFolder 激活能正常启动，并把 `--remote-debugging-port`（及 `--user-data-dir`）透传给进程

--- a/windows/scripts/start-dream-skin.ps1
+++ b/windows/scripts/start-dream-skin.ps1
@@ -41,14 +41,21 @@ if (-not $debugReady -and -not $ProfilePath -and $mainProcesses.Count -gt 0) {
 if (-not (Test-CodexDebugPort $Port)) {
   $package = Get-AppxPackage OpenAI.Codex | Sort-Object Version -Descending | Select-Object -First 1
   if (-not $package) { throw 'The OpenAI.Codex Store package is not installed.' }
-  $exe = Join-Path $package.InstallLocation 'app\ChatGPT.exe'
-  if (-not (Test-Path -LiteralPath $exe)) { throw "Codex executable not found: $exe" }
+  # Launch via the shell AppX activator (shell:AppsFolder\<AUMID>) instead of
+  # running ChatGPT.exe directly. On current Windows builds the packaged binary
+  # requires package identity, so Start-Process on the exe fails with Access
+  # Denied for every caller (admin, standard, even ShellExecute). Activating by
+  # AppUserModelId uses the same path as the Start Menu and forwards
+  # --remote-debugging-port (and --user-data-dir) through to the process.
+  $manifest = Get-AppxPackageManifest $package
+  $appId = $manifest.Package.Applications.Application.Id
+  $aumid = "$($package.PackageFamilyName)!$appId"
   $arguments = @("--remote-debugging-port=$Port")
   if ($ProfilePath) {
     New-Item -ItemType Directory -Force -Path $ProfilePath | Out-Null
     $arguments += "--user-data-dir=$ProfilePath"
   }
-  Start-Process -FilePath $exe -ArgumentList $arguments
+  Start-Process -FilePath "shell:AppsFolder\$aumid" -ArgumentList $arguments
 }
 
 $deadline = (Get-Date).AddSeconds(30)


### PR DESCRIPTION
On current Windows 11 builds the Store-packaged ChatGPT.exe requires package identity, so Start-Process on the exe (and Start-Process /Invoke-Item on a .lnk to it) returns Access Denied for every caller. Invoke-CommandInDesktopPackage was also tried but the activation broker cancels the main app binary.

Activate by AppUserModelId through Start-Process shell:AppsFolder\<AUMID> with -ArgumentList so --remote-debugging-port and --user-data-dir reach the launched process. The AUMID is resolved from Get-AppxPackage + Get-AppxPackageManifest so Store updates keep working.

<!--
Thanks for contributing! Please complete this template.
感谢贡献！请填完本模板后再提交。

Docs: README.md · macos/README.md · windows/SKILL.md · docs/platforms.md
Security: loopback CDP only — do not patch official .app / asar / WindowsApps; do not rewrite API keys.
安全：仅本机 CDP；勿改官方安装包；勿静默改写 API。
-->

## Summary / 摘要

<!-- What changed and why? 1–5 bullets. 改了什么、为什么？ -->

-

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

Check what you actually ran. Skip items that do not apply and say so under Notes.
请勾选**实际跑过**的项；不适用的在 Notes 说明。

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [x] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [ ] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [ ] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [ ] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

<!-- Test output summary, screenshots (no private chat), follow-ups. 测试摘要、截图（勿含隐私对话）、后续事项。 -->

-
