### PR TITLE
fix(windows): preserve config and activate the Store package

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -32,6 +32,8 @@
 | Codex 配置 | `%USERPROFILE%\.codex\config.toml` |
 | 默认 CDP 端口 | 首选 `9335`，冲突时自动选空闲口（Mac 包默认从 `9341` 起） |
 
+Windows 启动、失败回滚与恢复重开均从已注册的 `OpenAI.Codex` 包清单解析 AppUserModelId，并通过系统应用包激活接口传递 CDP 参数；不会直接执行受 WindowsApps ACL 限制的可执行文件路径。
+
 ## 能力矩阵
 
 | 功能 | macOS | Windows |

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -31,6 +31,7 @@
 - 记录中的 injector PID 若仍存活但身份不匹配，启动与恢复会保留 state 并中止，不再归档后继续操作未知进程。
 - Windows PowerShell 5.1 现在使用同目录临时备份调用 `File.Replace`，避免空备份参数被绑定为非法路径而导致现有 `config.toml` 无法更新。
 - 修复 Windows PowerShell 5.1 下注入器/Node 一旦向 stderr 输出（崩溃堆栈、超时报错、Node 警告）就把启动脚本炸成 `NativeCommandError` 的问题：现在原生命令统一经 `Invoke-DreamSkinNative` 执行，verify 失败时 `verify.log` 能真正写出本次输出与退出码，回滚清除注入的路径也不再被 stderr 干扰误判。
+- 带引号键名和 CRLF 的 `[desktop]` 配置现在可以逐字节往返恢复；新版 Codex 写入的非冲突 `[desktop.*]` 子表会原样保留，仅在子表与 Dream Skin 必须管理的标量键冲突时拒绝修改。
 - 安装与 `-RestoreBaseTheme` 现在严格按 UTF-8 读取，保留原换行风格，并以无 BOM、同目录原子替换方式写回 `config.toml`，避免中文项目名称乱码或导致 Codex 无法启动。
 - 遇到带 BOM/无 BOM 的 UTF-16、NUL 字符、无效 UTF-8 或写入期间被其他程序改动的配置时停止修改，不再静默转码或覆盖较新的内容。
 - 安装会在当前注册包或 state 记录的旧 Codex 仍运行时明确提示先关闭；配置临时文件写完后会在原子替换前再次核对原始字节，进一步缩小并发覆盖窗口。

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Windows PowerShell 5.1 现在使用同目录临时备份调用 `File.Replace`，避免空备份参数被绑定为非法路径而导致现有 `config.toml` 无法更新。
 - 修复 Windows PowerShell 5.1 下注入器/Node 一旦向 stderr 输出（崩溃堆栈、超时报错、Node 警告）就把启动脚本炸成 `NativeCommandError` 的问题：现在原生命令统一经 `Invoke-DreamSkinNative` 执行，verify 失败时 `verify.log` 能真正写出本次输出与退出码，回滚清除注入的路径也不再被 stderr 干扰误判。
 - 带引号键名和 CRLF 的 `[desktop]` 配置现在可以逐字节往返恢复；新版 Codex 写入的非冲突 `[desktop.*]` 子表会原样保留，仅在子表与 Dream Skin 必须管理的标量键冲突时拒绝修改。
+- Codex 的启动、失败回滚和恢复重开统一通过已注册 Store 包清单中的 AppUserModelId 激活，不再直接执行可能被 WindowsApps 权限拒绝的 `ChatGPT.exe`；CDP 和自定义 profile 参数仍通过系统包激活接口传递。
 - 安装与 `-RestoreBaseTheme` 现在严格按 UTF-8 读取，保留原换行风格，并以无 BOM、同目录原子替换方式写回 `config.toml`，避免中文项目名称乱码或导致 Codex 无法启动。
 - 遇到带 BOM/无 BOM 的 UTF-16、NUL 字符、无效 UTF-8 或写入期间被其他程序改动的配置时停止修改，不再静默转码或覆盖较新的内容。
 - 安装会在当前注册包或 state 记录的旧 Codex 仍运行时明确提示先关闭；配置临时文件写完后会在原子替换前再次核对原始字节，进一步缩小并发覆盖窗口。

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -58,9 +58,15 @@ function Test-DreamSkinCommandLineToken {
 function ConvertTo-DreamSkinProcessArgument {
   param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
   if ($Value.Contains('"')) { throw 'Process arguments containing a double quote are not supported.' }
+  if ($Value.Length -eq 0) { return '""' }
   if ($Value -notmatch '\s') { return $Value }
   $escaped = [regex]::Replace($Value, '(\\+)$', '$1$1')
   return '"' + $escaped + '"'
+}
+
+function ConvertTo-DreamSkinArgumentLine {
+  param([AllowEmptyCollection()][string[]]$Arguments = @())
+  return (($Arguments | ForEach-Object { ConvertTo-DreamSkinProcessArgument -Value $_ }) -join ' ')
 }
 
 function Get-DreamSkinProcessExecutablePath {
@@ -121,7 +127,10 @@ function Get-DreamSkinNodeRuntime {
 }
 
 function ConvertTo-DreamSkinCodexInstall {
-  param([Parameter(Mandatory = $true)][object]$Package)
+  param(
+    [Parameter(Mandatory = $true)][object]$Package,
+    [AllowNull()][object]$Manifest
+  )
   if ("$($Package.Name)" -ine 'OpenAI.Codex' -or -not $Package.InstallLocation -or
     -not $Package.PackageFullName -or -not $Package.PackageFamilyName -or
     "$($Package.SignatureKind)" -ine 'Store' -or [bool]$Package.IsDevelopmentMode) {
@@ -130,12 +139,31 @@ function ConvertTo-DreamSkinCodexInstall {
   $packageRoot = "$($Package.InstallLocation)"
   $executable = Join-Path $packageRoot 'app\ChatGPT.exe'
   if (-not (Test-Path -LiteralPath $executable)) { return $null }
+  try {
+    if (-not $PSBoundParameters.ContainsKey('Manifest')) {
+      $Manifest = Get-AppxPackageManifest -Package $Package -ErrorAction Stop
+    }
+    $applications = @($Manifest.Package.Applications.Application | Where-Object {
+      "$($_.Executable)".Replace('/', '\') -ieq 'app\ChatGPT.exe'
+    })
+    if ($applications.Count -ne 1) { return $null }
+    $applicationId = "$($applications[0].Id)"
+  } catch {
+    return $null
+  }
+  $packageFamilyName = "$($Package.PackageFamilyName)"
+  if ($packageFamilyName -cnotmatch '^[A-Za-z0-9._-]{1,128}$' -or
+    $applicationId -cnotmatch '^[A-Za-z0-9._-]{1,64}$') {
+    return $null
+  }
   return [pscustomobject]@{
     PackageRoot = $packageRoot
     Executable = $executable
     Version = "$($Package.Version)"
     PackageFullName = "$($Package.PackageFullName)"
-    PackageFamilyName = "$($Package.PackageFamilyName)"
+    PackageFamilyName = $packageFamilyName
+    ApplicationId = $applicationId
+    AppUserModelId = "$packageFamilyName!$applicationId"
     SignatureKind = "$($Package.SignatureKind)"
   }
 }
@@ -154,6 +182,71 @@ function Get-DreamSkinCodexInstall {
   $installs = @(Get-DreamSkinRegisteredCodexInstalls)
   if ($installs.Count -eq 0) { throw 'The official OpenAI.Codex Store package is not installed or its identity cannot be validated.' }
   return $installs[0]
+}
+
+function Initialize-DreamSkinPackageLauncher {
+  if ('CodexDreamSkin.PackageLauncher' -as [type]) { return }
+  Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+namespace CodexDreamSkin {
+  [Flags]
+  internal enum ActivateOptions : uint {
+    None = 0
+  }
+
+  [ComImport]
+  [Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
+  [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  internal interface IApplicationActivationManager {
+    [PreserveSig]
+    int ActivateApplication(
+      [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+      [MarshalAs(UnmanagedType.LPWStr)] string arguments,
+      ActivateOptions options,
+      out uint processId);
+  }
+
+  [ComImport]
+  [Guid("45ba127d-10a8-46ea-8ab7-56ea9078943c")]
+  internal class ApplicationActivationManager {}
+
+  public static class PackageLauncher {
+    public static uint Launch(string appUserModelId, string arguments) {
+      var manager = (IApplicationActivationManager)new ApplicationActivationManager();
+      try {
+        uint processId;
+        int result = manager.ActivateApplication(
+          appUserModelId,
+          arguments ?? string.Empty,
+          ActivateOptions.None,
+          out processId);
+        Marshal.ThrowExceptionForHR(result);
+        return processId;
+      } finally {
+        if (Marshal.IsComObject(manager)) Marshal.FinalReleaseComObject(manager);
+      }
+    }
+  }
+}
+'@
+}
+
+function Start-DreamSkinCodex {
+  param(
+    [Parameter(Mandatory = $true)][object]$Codex,
+    [AllowEmptyCollection()][string[]]$Arguments = @()
+  )
+  $appUserModelId = "$($Codex.AppUserModelId)"
+  if ($appUserModelId -cnotmatch '^[A-Za-z0-9._-]{1,128}![A-Za-z0-9._-]{1,64}$') {
+    throw 'The registered Codex AppUserModelId is unavailable or invalid.'
+  }
+  Initialize-DreamSkinPackageLauncher
+  $argumentLine = ConvertTo-DreamSkinArgumentLine -Arguments $Arguments
+  $processId = [CodexDreamSkin.PackageLauncher]::Launch($appUserModelId, $argumentLine)
+  if ($processId -le 0) { throw 'Windows did not return a Codex process ID after package activation.' }
+  return $processId
 }
 
 function Get-DreamSkinCodexStatePathCandidate {
@@ -197,6 +290,8 @@ function Resolve-DreamSkinCodexInstallFromState {
       Version = $install.Version
       PackageFullName = $install.PackageFullName
       PackageFamilyName = $install.PackageFamilyName
+      ApplicationId = $install.ApplicationId
+      AppUserModelId = $install.AppUserModelId
       SignatureKind = $install.SignatureKind
       FromState = $true
       RegisteredPackageVerified = $true

--- a/windows/scripts/config-utf8.ps1
+++ b/windows/scripts/config-utf8.ps1
@@ -194,7 +194,7 @@ function Assert-DreamSkinTomlLineEditingSafe {
   if ($Content.Contains('"""') -or $Content.Contains("'''")) {
     throw 'Refusing to rewrite TOML containing multiline strings; use single-line values before installing Dream Skin.'
   }
-  foreach ($match in [regex]::Matches($Content, '(?m)^[^\r\n]*=[\t ]*\[[^\r\n]*$')) {
+  foreach ($match in [regex]::Matches($Content, '(?m)^[^\r\n]*=[\t ]*\[[^\r\n]*\r?$')) {
     if ((Get-DreamSkinTomlArrayBracketBalance -Line $match.Value) -ne 0) {
       throw 'Refusing to rewrite TOML containing multiline arrays; use single-line arrays before installing Dream Skin.'
     }
@@ -217,6 +217,20 @@ function Get-DreamSkinDesktopSectionPattern {
   return "(?ms)^[\t ]*\[[\t ]*$desktopToken[\t ]*\][\t ]*(?:#[^\r\n]*)?(?:\r?\n|(?=\z))(?<body>.*?)(?=^[\t ]*\[\[?|\z)"
 }
 
+function Test-DreamSkinDesktopNestedTable {
+  param(
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content,
+    [Parameter(Mandatory = $true)][string]$Key
+  )
+
+  $desktopToken = Get-DreamSkinTomlKeyTokenPattern -Key 'desktop'
+  $keyToken = Get-DreamSkinTomlKeyTokenPattern -Key $Key
+  return [regex]::IsMatch(
+    $Content,
+    "(?m)^[\t ]*\[[\t ]*$desktopToken[\t ]*\.[\t ]*$keyToken[\t ]*(?:\]|\.)"
+  )
+}
+
 function Assert-DreamSkinDesktopShapeSupported {
   param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content)
 
@@ -227,11 +241,13 @@ function Assert-DreamSkinDesktopShapeSupported {
   }
 
   $desktopToken = Get-DreamSkinTomlKeyTokenPattern -Key 'desktop'
-  if ([regex]::IsMatch($Content, "(?m)^[\t ]*\[\[[\t ]*$desktopToken[\t ]*\]\]")) {
+  if ([regex]::IsMatch($Content, "(?m)^[\t ]*\[\[[\t ]*$desktopToken[\t ]*(?:\]\]|\.)")) {
     throw 'Refusing to rewrite a config that represents desktop as an array of tables.'
   }
-  if ([regex]::IsMatch($Content, "(?m)^[\t ]*\[\[?[\t ]*$desktopToken[\t ]*\.")) {
-    throw 'Refusing to rewrite nested desktop tables; normalize them to a single [desktop] table first.'
+  foreach ($key in @('appearanceTheme', 'appearanceLightCodeThemeId')) {
+    if (Test-DreamSkinDesktopNestedTable -Content $Content -Key $key) {
+      throw "Refusing to replace '$key' because it is represented as a nested desktop table."
+    }
   }
 
   $firstTable = [regex]::Match($Content, '(?m)^[\t ]*\[\[?')
@@ -246,6 +262,11 @@ function Assert-DreamSkinDesktopShapeSupported {
     foreach ($key in @('appearanceTheme', 'appearanceLightCodeThemeId', 'appearanceLightChromeTheme')) {
       $keyToken = Get-DreamSkinTomlKeyTokenPattern -Key $key
       $settingShape = "(?m)^[\t ]*$keyToken[\t ]*(?:\.|=)"
+      if ($key -eq 'appearanceLightChromeTheme' -and
+        (Test-DreamSkinDesktopNestedTable -Content $Content -Key $key) -and
+        [regex]::IsMatch($desktop.Body, $settingShape)) {
+        throw "Refusing to rewrite '$key' because both a scalar and nested table are present."
+      }
       if ([regex]::Matches($bodyProbe, $settingShape).Count -gt
         [regex]::Matches($desktop.Body, $settingShape).Count) {
         throw "Refusing to rewrite an escaped TOML key equivalent to '$key'."
@@ -286,12 +307,12 @@ function Set-DreamSkinSectionSetting {
   param(
     [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Body,
     [Parameter(Mandatory = $true)][string]$Key,
-    [AllowNull()][string]$Line,
+    [AllowNull()][object]$Line,
     [Parameter(Mandatory = $true)][string]$NewLine
   )
 
   $keyToken = Get-DreamSkinTomlKeyTokenPattern -Key $Key
-  $pattern = "(?m)^[\t ]*$keyToken[\t ]*=.*(?:\r?\n)?"
+  $pattern = "(?m)^[\t ]*$keyToken[\t ]*=[^\r\n]*(?:\r?\n|(?=\z))"
   $matcher = [regex]::new($pattern)
   if ($matcher.Matches($Body).Count -gt 1) {
     throw "Refusing to rewrite duplicate '$Key' entries in the [desktop] section."
@@ -418,7 +439,10 @@ function Install-DreamSkinBaseTheme {
       appearanceLightCodeThemeId = $script:DreamSkinManagedLightCodeTheme
       appearanceLightChromeTheme = $script:DreamSkinManagedLightChromeTheme
     }
+    $hasNestedLightChromeTheme = Test-DreamSkinDesktopNestedTable `
+      -Content $content -Key 'appearanceLightChromeTheme'
     foreach ($key in $settings.Keys) {
+      if ($key -eq 'appearanceLightChromeTheme' -and $hasNestedLightChromeTheme) { continue }
       $body = Set-DreamSkinSectionSetting -Body $body -Key $key -Line $settings[$key] -NewLine $newLine
     }
 
@@ -470,9 +494,12 @@ function Restore-DreamSkinBaseTheme {
     (Test-DreamSkinLegacyManagedLightTrio -Content $currentContent)
   $restoreKeys = @('appearanceLightCodeThemeId', 'appearanceLightChromeTheme')
   if ($restoreLegacyAppearance) { $restoreKeys = @('appearanceTheme') + $restoreKeys }
+  $hasNestedLightChromeTheme = Test-DreamSkinDesktopNestedTable `
+    -Content $currentContent -Key 'appearanceLightChromeTheme'
   foreach ($key in $restoreKeys) {
+    if ($key -eq 'appearanceLightChromeTheme' -and $hasNestedLightChromeTheme) { continue }
     $keyToken = Get-DreamSkinTomlKeyTokenPattern -Key $key
-    $pattern = "(?m)^[\t ]*$keyToken[\t ]*=.*(?:\r?\n)?"
+    $pattern = "(?m)^[\t ]*$keyToken[\t ]*=[^\r\n]*(?:\r?\n|(?=\z))"
     $saved = if ($null -ne $backupDesktop) { [regex]::Match($backupDesktop.Body, $pattern) } else { $null }
     $line = if ($null -ne $saved -and $saved.Success) { $saved.Value } else { $null }
     $body = Set-DreamSkinSectionSetting -Body $body -Key $key -Line $line -NewLine $newLine

--- a/windows/scripts/restore-dream-skin.ps1
+++ b/windows/scripts/restore-dream-skin.ps1
@@ -164,13 +164,13 @@ try {
       if ($null -eq $relaunchCodex -or -not (Test-Path -LiteralPath $relaunchCodex.Executable)) {
         throw 'Codex cannot be reopened because its current executable is unavailable.'
       }
-      Start-Process -FilePath $relaunchCodex.Executable | Out-Null
+      $null = Start-DreamSkinCodex -Codex $relaunchCodex
     }
   } catch {
     $restoreError = $_
     if ($shouldCloseCodex -and -not $NoRelaunch -and $null -ne $relaunchCodex -and
       (Get-DreamSkinCodexProcesses -Codex $codex).Count -eq 0 -and (Test-Path -LiteralPath $relaunchCodex.Executable)) {
-      try { Start-Process -FilePath $relaunchCodex.Executable | Out-Null } catch {
+      try { $null = Start-DreamSkinCodex -Codex $relaunchCodex } catch {
         Write-Warning 'Restore failed and Codex could not be reopened automatically.'
       }
     }

--- a/windows/scripts/start-dream-skin.ps1
+++ b/windows/scripts/start-dream-skin.ps1
@@ -110,9 +110,9 @@ try {
       $arguments = @('--remote-debugging-address=127.0.0.1', "--remote-debugging-port=$Port")
       if ($ProfilePath) {
         New-Item -ItemType Directory -Force -Path $ProfilePath | Out-Null
-        $arguments += ConvertTo-DreamSkinProcessArgument -Value "--user-data-dir=$ProfilePath"
+        $arguments += "--user-data-dir=$ProfilePath"
       }
-      Start-Process -FilePath $codex.Executable -ArgumentList $arguments | Out-Null
+      $null = Start-DreamSkinCodex -Codex $codex -Arguments $arguments
       $launchedWithCdp = $true
     }
 
@@ -137,7 +137,7 @@ try {
       if ($launchedWithCdp) {
         Write-Warning 'Dream Skin launch failed; reopening Codex without a debugging port.'
       }
-      try { Start-Process -FilePath $codex.Executable | Out-Null } catch {
+      try { $null = Start-DreamSkinCodex -Codex $codex } catch {
         Write-Warning 'Launch rollback could not reopen Codex automatically.'
       }
     }
@@ -154,7 +154,7 @@ try {
     if ($launchedWithCdp) {
       try {
         Stop-DreamSkinCodex -Codex $codex -AllowForce
-        Start-Process -FilePath $codex.Executable | Out-Null
+        $null = Start-DreamSkinCodex -Codex $codex
       } catch {
         Write-Warning 'State validation rollback could not fully restart Codex; close Codex to ensure its CDP port is closed.'
       }
@@ -267,7 +267,7 @@ try {
     if ($launchedWithCdp) {
       try {
         Stop-DreamSkinCodex -Codex $codex -AllowForce
-        Start-Process -FilePath $codex.Executable | Out-Null
+        $null = Start-DreamSkinCodex -Codex $codex
       } catch {
         Write-Warning 'Startup rollback could not fully restart Codex; close Codex to ensure its CDP port is closed.'
       }

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -329,6 +329,23 @@ try {
   if ($quotedProfile -cne '"--user-data-dir=C:\Dream Skin\Profile\\"') {
     throw 'Process argument quoting did not protect spaces and a trailing backslash.'
   }
+  $argumentLine = ConvertTo-DreamSkinArgumentLine -Arguments @(
+    '--remote-debugging-address=127.0.0.1',
+    '--user-data-dir=C:\Dream Skin\Profile\',
+    ''
+  )
+  if ($argumentLine -cne '--remote-debugging-address=127.0.0.1 "--user-data-dir=C:\Dream Skin\Profile\\" ""') {
+    throw 'Packaged-app argument line quoting failed.'
+  }
+  Initialize-DreamSkinPackageLauncher
+  if (-not ('CodexDreamSkin.PackageLauncher' -as [type])) {
+    throw 'Packaged-app activation helper did not compile.'
+  }
+  $invalidActivationRejected = $false
+  try { $null = Start-DreamSkinCodex -Codex ([pscustomobject]@{ AppUserModelId = 'invalid app' }) } catch {
+    $invalidActivationRejected = $true
+  }
+  if (-not $invalidActivationRejected) { throw 'An invalid AppUserModelId reached package activation.' }
 
   $statePath = Join-Path $temporaryRoot 'state.json'
   $state = [pscustomobject]@{
@@ -373,13 +390,34 @@ try {
     IsDevelopmentMode = $false
     Version = [version]'1.2.3.4'
   }
-  $fakeInstall = ConvertTo-DreamSkinCodexInstall -Package $fakePackage
+  $fakeManifest = [pscustomobject]@{
+    Package = [pscustomobject]@{
+      Applications = [pscustomobject]@{
+        Application = @(
+          [pscustomobject]@{ Id = 'Other'; Executable = 'other\Other.exe' },
+          [pscustomobject]@{ Id = 'App'; Executable = 'app/ChatGPT.exe' }
+        )
+      }
+    }
+  }
+  $fakeInstall = ConvertTo-DreamSkinCodexInstall -Package $fakePackage -Manifest $fakeManifest
   if ($null -eq $fakeInstall -or $fakeInstall.PackageFullName -cne $fakePackage.PackageFullName -or
+    $fakeInstall.AppUserModelId -cne 'OpenAI.Codex_test!App' -or
     -not (Test-DreamSkinPathEqual -Left $fakeInstall.Executable -Right $fakeExecutable)) {
     throw 'Registered Appx package identity conversion failed.'
   }
+  $fakeManifest.Package.Applications.Application[1].Id = 'Invalid App'
+  if ($null -ne (ConvertTo-DreamSkinCodexInstall -Package $fakePackage -Manifest $fakeManifest)) {
+    throw 'An invalid packaged-app application ID was accepted.'
+  }
+  $fakeManifest.Package.Applications.Application[1].Id = 'App'
+  $fakeManifest.Package.Applications.Application += [pscustomobject]@{ Id = 'Duplicate'; Executable = 'app\ChatGPT.exe' }
+  if ($null -ne (ConvertTo-DreamSkinCodexInstall -Package $fakePackage -Manifest $fakeManifest)) {
+    throw 'An ambiguous packaged-app manifest was accepted.'
+  }
+  $fakeManifest.Package.Applications.Application = @($fakeManifest.Package.Applications.Application[0..1])
   $fakePackage.SignatureKind = 'Developer'
-  if ($null -ne (ConvertTo-DreamSkinCodexInstall -Package $fakePackage)) {
+  if ($null -ne (ConvertTo-DreamSkinCodexInstall -Package $fakePackage -Manifest $fakeManifest)) {
     throw 'A non-Store Appx package was accepted as official Codex.'
   }
   $fakePackage.SignatureKind = 'Store'
@@ -404,7 +442,8 @@ try {
   }
   $resolvedInstall = Resolve-DreamSkinCodexInstallFromState -State $verifiedPackageState `
     -RegisteredInstalls @($fakeInstall)
-  if ($null -eq $resolvedInstall -or -not $resolvedInstall.RegisteredPackageVerified) {
+  if ($null -eq $resolvedInstall -or -not $resolvedInstall.RegisteredPackageVerified -or
+    $resolvedInstall.AppUserModelId -cne $fakeInstall.AppUserModelId) {
     throw 'State package identity did not resolve against the registered Appx package.'
   }
   $verifiedPackageState.codexPackageFamilyName = 'OpenAI.Codex_wrong'
@@ -548,7 +587,15 @@ try {
   if (-not $restoreSource.Contains('Stop-DreamSkinTrayProcess')) {
     throw 'Complete restore does not stop a separately launched tray process.'
   }
+  if ($restoreSource.Contains('Start-Process -FilePath $relaunchCodex.Executable') -or
+    -not $restoreSource.Contains('Start-DreamSkinCodex -Codex $relaunchCodex')) {
+    throw 'Restore still executes the WindowsApps path instead of activating the registered package.'
+  }
   $startSource = Read-DreamSkinUtf8File -Path (Join-Path $Root 'scripts\start-dream-skin.ps1')
+  if ($startSource.Contains('Start-Process -FilePath $codex.Executable') -or
+    -not $startSource.Contains('Start-DreamSkinCodex -Codex $codex')) {
+    throw 'Start still executes the WindowsApps path instead of activating the registered package.'
+  }
   $stateReadIndex = $startSource.IndexOf('$previousState = Read-DreamSkinState', [System.StringComparison]::Ordinal)
   $restartPromptIndex = $startSource.IndexOf('$restartAuthorized = Confirm-DreamSkinRestart', [System.StringComparison]::Ordinal)
   $recordedStopIndex = $startSource.IndexOf('$recordedInjectorStopped = Stop-DreamSkinRecordedInjector', [System.StringComparison]::Ordinal)

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -163,6 +163,29 @@ try {
     throw 'Quoted desktop keys or a table-header comment were not restored exactly.'
   }
 
+  $nestedConfigPath = Join-Path $temporaryRoot 'config-nested-themes.toml'
+  $nestedBackupPath = Join-Path $temporaryRoot 'config-nested-themes.before.toml'
+  $nestedTables = "[desktop.appearanceDarkChromeTheme]`r`naccent = `"#112233`"`r`n`r`n[desktop.appearanceDarkChromeTheme.fonts]`r`ncode = `"Cascadia Code`"`r`n`r`n[desktop.appearanceDarkChromeTheme.semanticColors]`r`ndiffAdded = `"#234567`"`r`n`r`n[desktop.appearanceLightChromeTheme]`r`naccent = `"#abcdef`"`r`n`r`n[desktop.appearanceLightChromeTheme.fonts]`r`nui = `"Microsoft YaHei UI`"`r`n`r`n[desktop.appearanceLightChromeTheme.semanticColors]`r`ndiffRemoved = `"#fedcba`"`r`n`r`n[`"desktop`".layout]`r`ndensity = `"compact`"`r`n"
+  $nestedOriginal = "[desktop]`r`nappearanceTheme = `"system`"`r`nappearanceLightCodeThemeId = `"github-light`"`r`n`r`n$nestedTables"
+  [System.IO.File]::WriteAllText($nestedConfigPath, $nestedOriginal, $utf8NoBom)
+  Install-DreamSkinBaseTheme -ConfigPath $nestedConfigPath -BackupPath $nestedBackupPath
+  $nestedInstalled = Read-DreamSkinUtf8File -Path $nestedConfigPath
+  $nestedDesktop = Get-DreamSkinDesktopSection -Content $nestedInstalled
+  if (-not $nestedDesktop.Body.Contains('appearanceTheme = "system"') -or
+    -not $nestedDesktop.Body.Contains('appearanceLightCodeThemeId = "codex"')) {
+    throw 'Install did not update scalar appearance settings beside nested desktop theme tables.'
+  }
+  if ([regex]::IsMatch($nestedDesktop.Body, '(?m)^[\t ]*appearanceLightChromeTheme[\t ]*=')) {
+    throw 'Install wrote an inline light chrome theme beside the equivalent nested table.'
+  }
+  if (-not $nestedInstalled.Contains($nestedTables)) {
+    throw 'Install changed native Codex chrome theme or unrelated nested desktop tables.'
+  }
+  Restore-DreamSkinBaseTheme -ConfigPath $nestedConfigPath -BackupPath $nestedBackupPath
+  if ((Read-DreamSkinUtf8File -Path $nestedConfigPath) -cne $nestedOriginal) {
+    throw 'Nested desktop theme tables were not preserved through install and restore.'
+  }
+
   $singleLineArrayPath = Join-Path $temporaryRoot 'config-single-line-array.toml'
   $singleLineArrayBackup = Join-Path $temporaryRoot 'config-single-line-array.before.toml'
   $singleLineArray = "labels = [`"name[1]`", `"#tag]`"]`r`n"
@@ -176,8 +199,10 @@ try {
     'desktop.appearanceTheme = "system"',
     'desktop = { appearanceTheme = "system" }',
     '[[desktop]]',
+    '[[desktop.layout]]',
     '[desktop.appearanceTheme]',
-    '["desktop".layout]',
+    '[desktop.appearanceLightCodeThemeId]',
+    "[desktop]`r`nappearanceLightChromeTheme = { accent = `"#ffffff`" }`r`n`r`n[desktop.appearanceLightChromeTheme]`r`naccent = `"#000000`"",
     '["desk\u0074op".layout]',
     '["desk\u0074op"]',
     "note = `"`"`"fake`r`n[desktop]`r`nappearanceTheme = `"dark`"`r`n`"`"`"",


### PR DESCRIPTION
## Summary

- Restore quoted desktop keys and CRLF configuration byte-for-byte.
- Preserve non-conflicting native desktop sub-tables written by current Codex releases while rejecting scalar/sub-table conflicts.
- Resolve the official Codex AppUserModelId from the registered Appx manifest.
- Launch, rollback, and restore through IApplicationActivationManager instead of directly executing the WindowsApps ChatGPT.exe path.
- Preserve loopback CDP and custom profile arguments through a validated argument-line encoder.

## Maintainer narrowing

This PR has been rebased onto current main and narrowed to the two still-needed Windows fixes from the original contribution. The superseded atomic cleanup and unrelated macOS changes were removed. Both commits preserve @Su-cyber-art as Author; Fei-Away is only the Committer.

## Validation

- git diff --check: PASS.
- Parsed every Windows PowerShell file with PowerShell 7.6.3: PASS.
- Quoted-key, CRLF, multiline-array, nested-table, conflict-rejection, install, restore, recovery, AUMID manifest matching, argument quoting, state revalidation, and COM helper compilation tests: PASS.
- The full suite proceeds through all changed configuration and package-activation tests, then stops in this macOS-hosted run at the expected Windows path-separator guard in theme-windows.ps1.
- The original PR records @Su-cyber-art's Windows full-suite and real Microsoft Store Codex start/restore smoke validation.

## Safety

- CDP remains bound to 127.0.0.1.
- The official WindowsApps installation, app.asar, signatures, API keys, and Base URLs are not modified.
- AppUserModelId is derived from exactly one manifest application matching app\\ChatGPT.exe and is revalidated from the registered package rather than trusted from saved state.

Supersedes the weaker direct-launch approaches in #7 and #10.