### PR TITLE
fix(windows): prevent NativeCommandError on redirected stderr in PS 5.1

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `--verify`、`--once` 和 `--remove` 现在显式把预期 Browser ID 传入一次性目标发现，不再因引用越域的 CLI 变量而等待超时并导致启动验证回滚。
 - 记录中的 injector PID 若仍存活但身份不匹配，启动与恢复会保留 state 并中止，不再归档后继续操作未知进程。
 - Windows PowerShell 5.1 现在使用同目录临时备份调用 `File.Replace`，避免空备份参数被绑定为非法路径而导致现有 `config.toml` 无法更新。
+- 修复 Windows PowerShell 5.1 下注入器/Node 一旦向 stderr 输出（崩溃堆栈、超时报错、Node 警告）就把启动脚本炸成 `NativeCommandError` 的问题：现在原生命令统一经 `Invoke-DreamSkinNative` 执行，verify 失败时 `verify.log` 能真正写出本次输出与退出码，回滚清除注入的路径也不再被 stderr 干扰误判。
 - 安装与 `-RestoreBaseTheme` 现在严格按 UTF-8 读取，保留原换行风格，并以无 BOM、同目录原子替换方式写回 `config.toml`，避免中文项目名称乱码或导致 Codex 无法启动。
 - 遇到带 BOM/无 BOM 的 UTF-16、NUL 字符、无效 UTF-8 或写入期间被其他程序改动的配置时停止修改，不再静默转码或覆盖较新的内容。
 - 安装会在当前注册包或 state 记录的旧 Codex 仍运行时明确提示先关闭；配置临时文件写完后会在原子替换前再次核对原始字节，进一步缩小并发覆盖窗口。

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -75,16 +75,42 @@ function Get-DreamSkinProcessExecutablePath {
   }
 }
 
+# Windows PowerShell 5.1 promotes redirected native-command stderr lines to
+# ErrorRecords; while $ErrorActionPreference is 'Stop' the first stderr line
+# becomes a terminating NativeCommandError before the exit code can be read.
+# Run the command with the preference relaxed and report output + exit code.
+function Invoke-DreamSkinNative {
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [string[]]$ArgumentList = @(),
+    [switch]$DiscardStderr
+  )
+  $previousPreference = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    if ($DiscardStderr) {
+      $output = @(& $FilePath @ArgumentList 2>$null | ForEach-Object { "$_" })
+    } else {
+      $output = @(& $FilePath @ArgumentList 2>&1 | ForEach-Object { "$_" })
+    }
+    return [pscustomobject]@{ Output = $output; ExitCode = $LASTEXITCODE }
+  } finally {
+    $ErrorActionPreference = $previousPreference
+  }
+}
+
 function Get-DreamSkinNodeRuntime {
   param([int]$MinimumMajor = 22)
 
   $command = Get-Command node.exe -ErrorAction SilentlyContinue
   if (-not $command) { $command = Get-Command node -ErrorAction SilentlyContinue }
   if (-not $command) { throw "Node.js $MinimumMajor or newer is required and was not found in PATH." }
-  $version = "$(& $command.Source -p 'process.versions.node' 2>$null)".Trim()
-  if ($LASTEXITCODE -ne 0 -or -not $version) { throw 'The Node.js runtime could not be validated.' }
-  $runtimePath = "$(& $command.Source -p 'process.execPath' 2>$null)".Trim()
-  if ($LASTEXITCODE -ne 0 -or -not $runtimePath -or -not (Test-Path -LiteralPath $runtimePath)) {
+  $versionProbe = Invoke-DreamSkinNative -FilePath $command.Source -ArgumentList @('-p', 'process.versions.node') -DiscardStderr
+  $version = ($versionProbe.Output -join '').Trim()
+  if ($versionProbe.ExitCode -ne 0 -or -not $version) { throw 'The Node.js runtime could not be validated.' }
+  $pathProbe = Invoke-DreamSkinNative -FilePath $command.Source -ArgumentList @('-p', 'process.execPath') -DiscardStderr
+  $runtimePath = ($pathProbe.Output -join '').Trim()
+  if ($pathProbe.ExitCode -ne 0 -or -not $runtimePath -or -not (Test-Path -LiteralPath $runtimePath)) {
     throw 'The Node.js executable path could not be validated.'
   }
   $major = 0

--- a/windows/scripts/start-dream-skin.ps1
+++ b/windows/scripts/start-dream-skin.ps1
@@ -225,11 +225,11 @@ try {
     }
     Write-DreamSkinState -Path $StatePath -State $state
 
-    $verifyOutput = @(& $node.Path $Injector --verify --port $Port --browser-id $cdpIdentity.BrowserId `
-      --timeout-ms 30000 2>&1)
-    $verifyExitCode = $LASTEXITCODE
-    Write-DreamSkinUtf8FileAtomically -Path $VerifyPath -Content (($verifyOutput -join "`r`n") + "`r`n")
-    if ($verifyExitCode -ne 0) { throw "Dream Skin verification failed. See $VerifyPath" }
+    $verify = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+      $Injector, '--verify', '--port', "$Port",
+      '--browser-id', $cdpIdentity.BrowserId, '--timeout-ms', '30000')
+    Write-DreamSkinUtf8FileAtomically -Path $VerifyPath -Content (($verify.Output -join "`r`n") + "`r`n")
+    if ($verify.ExitCode -ne 0) { throw "Dream Skin verification failed. See $VerifyPath" }
   } catch {
     $startupError = $_
     $injectorStopped = $true
@@ -254,9 +254,10 @@ try {
       try {
         $rollbackIdentity = Get-DreamSkinVerifiedCdpIdentity -Port $Port -Codex $codex
         if ($null -ne $rollbackIdentity -and $rollbackIdentity.BrowserId -ceq $cdpIdentity.BrowserId) {
-          & $node.Path $Injector --remove --port $Port --browser-id $cdpIdentity.BrowserId `
-            --timeout-ms 5000 *> $null
-          if ($LASTEXITCODE -ne 0) { throw 'Injector removal returned a failure status.' }
+          $removal = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+            $Injector, '--remove', '--port', "$Port",
+            '--browser-id', $cdpIdentity.BrowserId, '--timeout-ms', '5000') -DiscardStderr
+          if ($removal.ExitCode -ne 0) { throw 'Injector removal returned a failure status.' }
         }
       } catch {
         Write-Warning 'Startup rollback could not remove the partially applied live skin; reload or close Codex to clear it.'

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -575,22 +575,41 @@ try {
   }
 
   $node = Get-DreamSkinNodeRuntime
-  & $node.Path (Join-Path $Root 'scripts\injector.mjs') --self-test *> $null
-  if ($LASTEXITCODE -ne 0) { throw 'Injector CDP self-test failed.' }
-  & $node.Path (Join-Path $Root 'scripts\injector.mjs') --check-payload *> $null
-  if ($LASTEXITCODE -ne 0) { throw 'Injector self-test failed.' }
-  & $node.Path (Join-Path $Root 'scripts\injector.mjs') --check-payload --theme-dir $themePaths.Active *> $null
-  if ($LASTEXITCODE -ne 0) { throw 'Managed theme payload validation failed.' }
-  & $node.Path (Join-Path $Root 'scripts\injector.mjs') --check-payload --theme-dir $oversizedTheme *> $null
-  if ($LASTEXITCODE -eq 0) { throw 'Node injector accepted an image over the 16 MB limit.' }
-  & $node.Path (Join-Path $PSScriptRoot 'renderer-inject.test.mjs')
-  if ($LASTEXITCODE -ne 0) { throw 'Renderer auxiliary-window regression test failed.' }
-  & $node.Path (Join-Path $PSScriptRoot 'injector-bootstrap.test.mjs')
-  if ($LASTEXITCODE -ne 0) { throw 'Injector early-bootstrap regression test failed.' }
-  & $node.Path (Join-Path $PSScriptRoot 'injector-one-shot.test.mjs')
-  if ($LASTEXITCODE -ne 0) { throw 'Injector one-shot Browser ID regression test failed.' }
-  & $node.Path (Join-Path $PSScriptRoot 'image-metadata.test.mjs')
-  if ($LASTEXITCODE -ne 0) { throw 'Image metadata regression test failed.' }
+  $stderrProbe = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    '-e', 'process.stderr.write("dream-skin-stderr-probe\n"); process.exit(7)')
+  if ($stderrProbe.ExitCode -ne 7 -or ($stderrProbe.Output -join "`n") -notmatch 'dream-skin-stderr-probe') {
+    throw 'Native stderr was not captured with its real exit code under Stop preference.'
+  }
+  $discardedProbe = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    '-e', 'process.stderr.write("ignored-warning\n"); process.stdout.write("kept-output")') -DiscardStderr
+  if ($discardedProbe.ExitCode -ne 0 -or ($discardedProbe.Output -join '') -cne 'kept-output') {
+    throw 'Native stderr discard changed stdout or the real exit code.'
+  }
+
+  $selfTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    (Join-Path $Root 'scripts\injector.mjs'), '--self-test')
+  if ($selfTest.ExitCode -ne 0) { throw 'Injector CDP self-test failed.' }
+  $payloadTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    (Join-Path $Root 'scripts\injector.mjs'), '--check-payload')
+  if ($payloadTest.ExitCode -ne 0) { throw 'Injector self-test failed.' }
+  $managedPayloadTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    (Join-Path $Root 'scripts\injector.mjs'), '--check-payload', '--theme-dir', $themePaths.Active)
+  if ($managedPayloadTest.ExitCode -ne 0) { throw 'Managed theme payload validation failed.' }
+  $oversizedPayloadTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    (Join-Path $Root 'scripts\injector.mjs'), '--check-payload', '--theme-dir', $oversizedTheme)
+  if ($oversizedPayloadTest.ExitCode -eq 0) { throw 'Node injector accepted an image over the 16 MB limit.' }
+  $rendererTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    (Join-Path $PSScriptRoot 'renderer-inject.test.mjs'))
+  if ($rendererTest.ExitCode -ne 0) { throw 'Renderer auxiliary-window regression test failed.' }
+  $bootstrapTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    (Join-Path $PSScriptRoot 'injector-bootstrap.test.mjs'))
+  if ($bootstrapTest.ExitCode -ne 0) { throw 'Injector early-bootstrap regression test failed.' }
+  $oneShotTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    (Join-Path $PSScriptRoot 'injector-one-shot.test.mjs'))
+  if ($oneShotTest.ExitCode -ne 0) { throw 'Injector one-shot Browser ID regression test failed.' }
+  $imageMetadataTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    (Join-Path $PSScriptRoot 'image-metadata.test.mjs'))
+  if ($imageMetadataTest.ExitCode -ne 0) { throw 'Image metadata regression test failed.' }
 
   Write-Host 'PASS: config transactions, restore scoping, state safety, argument quoting, and loopback CDP validation.'
 } finally {


### PR DESCRIPTION
…top preference

Windows PowerShell 5.1 promotes redirected native-command stderr lines to ErrorRecords, and with $ErrorActionPreference = 'Stop' the first line becomes a terminating NativeCommandError. Every affected call site sat on a failure path: when the injector crashed or timed out (stack trace on stderr), start-dream-skin.ps1 died at the assignment before writing verify.log or reading the exit code, so users got a random stderr fragment as the error and a stale verify.log; the rollback --remove and the Node runtime probes could be aborted by any stderr noise (e.g. NODE_OPTIONS warnings).

Route the five native invocations through Invoke-DreamSkinNative, which relaxes the preference locally and returns output plus exit code.

<!--
Thanks for contributing! Please complete this template.
感谢贡献！请填完本模板后再提交。

Docs: README.md · macos/README.md · windows/SKILL.md · docs/platforms.md
Security: loopback CDP only — do not patch official .app / asar / WindowsApps; do not rewrite API keys.
安全：仅本机 CDP；勿改官方安装包；勿静默改写 API。
-->

## Summary / 摘要

- Windows PowerShell 5.1 会把重定向后的原生命令 stderr 行升级为 ErrorRecord；在 `$ErrorActionPreference = 'Stop'` 下，第一行 stderr 就成为终止性 `NativeCommandError`
- 受影响的调用点全部位于失败路径：注入器崩溃/超时（堆栈打到 stderr）时，`start-dream-skin.ps1` 在 `$verifyOutput = @(... 2>&1)` 赋值处直接中断——`verify.log` 没写、退出码没读，用户拿到一段随机 stderr 片段当错误消息，`verify.log` 里还是上一次的旧内容，误导排障
- 同类隐患共 5 处：启动回滚的 `--remove *> $null`（任何 stderr 噪音都会误判"移除失败"）、`Get-DreamSkinNodeRuntime` 的两次 Node 探测（如 NODE_OPTIONS 警告即可中断）、`run-tests.ps1` 自检两处
- 修复：新增 `Invoke-DreamSkinNative`，在函数内局部放宽 preference 并返回输出 + 退出码，5 处原生调用统一改经它执行
- 一行复现（PS 5.1）：`$ErrorActionPreference='Stop'; $o=@(node -e "console.error('x')" 2>&1)` → 抛 NativeCommandError

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional)
- [ ] Live verify
- [ ] Restore / re-apply smoke

### Windows (when code under `windows/` changes)

- [x] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [x] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [x] Updated changelog / 已更新 changelog（本 PR 更新 `windows/CHANGELOG.md`）

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充
环境：Windows 11 家庭中文版 25H2（OS Build 26200.7840，x64）/ Windows PowerShell 5.1.26100.7705（Desktop）/ Node.js v22.14.0 / Codex 26.707.9981.0（Microsoft Store）
-
