### PR TITLE
fix(macos): 通过 argv 安全传递 AppleScript UI 文本

### DIFF
--- a/macos/CHANGELOG.md
+++ b/macos/CHANGELOG.md
@@ -9,6 +9,7 @@
 - 恢复原本没有 `[desktop]` 配置段的用户设置时，不再额外写入空段
 - 热切换读取运行状态时复用 Codex 内置 Node.js，不再依赖系统 `python3` 或执行 `eval`
 - 显式传入的 `--theme-dir` 缺少 `theme.json` 时立即报错，不再静默回退到内置 demo 主题
+- AppleScript 通知与弹窗改用 `argv` 传递动态文本，避免主题名或日志内容被解析为脚本
 
 ---
 

--- a/macos/scripts/apply-from-menubar-macos.sh
+++ b/macos/scripts/apply-from-menubar-macos.sh
@@ -6,6 +6,7 @@ set +e
 export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:${PATH:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+UI_SCRIPT="$SCRIPT_DIR/ui-macos.applescript"
 STATE_ROOT="${HOME}/Library/Application Support/CodexDreamSkinStudio"
 LOG_OUT="${STATE_ROOT}/menubar-apply.log"
 
@@ -16,19 +17,17 @@ LOG_OUT="${STATE_ROOT}/menubar-apply.log"
 
 progress() {
   printf '[progress] %s\n' "$*" >>"$LOG_OUT" 2>/dev/null
-  /usr/bin/osascript -e "display notification \"$*\" with title \"Codex Dream Skin\"" >/dev/null 2>&1 &
+  /usr/bin/osascript "$UI_SCRIPT" notify "$*" >/dev/null 2>&1 &
 }
 
 alert() {
-  /usr/bin/osascript -e "display alert \"Codex Dream Skin\" message \"$1\"" >/dev/null 2>&1 || true
+  /usr/bin/osascript "$UI_SCRIPT" alert "$1" >/dev/null 2>&1 || true
 }
 
 confirm() {
   local message="$1"
   local ok_label="${2:-继续}"
-  /usr/bin/osascript <<APPLESCRIPT >/dev/null 2>&1
-display dialog "$(printf '%s' "$message" | /usr/bin/sed 's/"/\\"/g')" buttons {"取消", "$ok_label"} default button "$ok_label" with title "Codex Dream Skin"
-APPLESCRIPT
+  /usr/bin/osascript "$UI_SCRIPT" confirm "$message" "$ok_label" >/dev/null 2>&1
 }
 
 progress "已收到点击…"

--- a/macos/scripts/install-menubar-macos.sh
+++ b/macos/scripts/install-menubar-macos.sh
@@ -47,6 +47,10 @@ if [ -d "$INSTALL_ROOT" ] && [ "$PROJECT_ROOT" != "$INSTALL_ROOT" ]; then
       /bin/chmod 755 "$INSTALL_ROOT/scripts/$name"
     fi
   done
+  [ -f "$PROJECT_ROOT/scripts/ui-macos.applescript" ] \
+    || fail "AppleScript UI helper missing: $PROJECT_ROOT/scripts/ui-macos.applescript"
+  /bin/cp -f "$PROJECT_ROOT/scripts/ui-macos.applescript" "$INSTALL_ROOT/scripts/ui-macos.applescript"
+  /bin/chmod 644 "$INSTALL_ROOT/scripts/ui-macos.applescript"
 fi
 
 /bin/chmod 755 \

--- a/macos/scripts/load-image-theme-macos.sh
+++ b/macos/scripts/load-image-theme-macos.sh
@@ -5,6 +5,7 @@
 
 set -euo pipefail
 . "$(cd "$(dirname "$0")" && pwd -P)/common-macos.sh"
+UI_SCRIPT="$SCRIPT_DIR/ui-macos.applescript"
 
 IMAGE=""
 THEME_NAME=""
@@ -52,7 +53,7 @@ theme_id="img-$(/bin/date '+%Y%m%d%H%M%S')-$$"
 
 progress() {
   printf '%s\n' "$*" >&2
-  /usr/bin/osascript -e "display notification \"$*\" with title \"Codex Dream Skin\"" >/dev/null 2>&1 || true
+  /usr/bin/osascript "$UI_SCRIPT" notify "$*" >/dev/null 2>&1 || true
 }
 
 progress "Loading image..."
@@ -125,5 +126,5 @@ if "$SCRIPT_DIR/start-dream-skin-macos.sh" --port "$PORT" --restart-existing; th
   exit 0
 fi
 
-/usr/bin/osascript -e 'display alert "Codex Dream Skin" message "Image saved but inject failed. Click Apply Skin."' >/dev/null 2>&1 || true
+/usr/bin/osascript "$UI_SCRIPT" alert "Image saved but inject failed. Click Apply Skin." >/dev/null 2>&1 || true
 exit 1

--- a/macos/scripts/switch-theme-macos.sh
+++ b/macos/scripts/switch-theme-macos.sh
@@ -4,6 +4,7 @@
 
 set -euo pipefail
 . "$(cd "$(dirname "$0")" && pwd -P)/common-macos.sh"
+UI_SCRIPT="$SCRIPT_DIR/ui-macos.applescript"
 
 THEME_ID=""
 APPLY_NOW="true"
@@ -25,7 +26,7 @@ SRC="$THEMES_ROOT/$THEME_ID"
 
 progress() {
   printf '%s\n' "$*" >&2
-  /usr/bin/osascript -e "display notification \"$*\" with title \"Codex Dream Skin\"" >/dev/null 2>&1 || true
+  /usr/bin/osascript "$UI_SCRIPT" notify "$*" >/dev/null 2>&1 || true
 }
 
 progress "Switching..."
@@ -63,5 +64,5 @@ if "$SCRIPT_DIR/start-dream-skin-macos.sh" --port "$PORT" --restart-existing; th
   exit 0
 fi
 
-/usr/bin/osascript -e 'display alert "Codex Dream Skin" message "Theme switched but inject failed. Click Apply Skin."' >/dev/null 2>&1 || true
+/usr/bin/osascript "$UI_SCRIPT" alert "Theme switched but inject failed. Click Apply Skin." >/dev/null 2>&1 || true
 exit 1

--- a/macos/scripts/ui-macos.applescript
+++ b/macos/scripts/ui-macos.applescript
@@ -1,0 +1,31 @@
+on requiredArgument(argumentList, argumentIndex, argumentName)
+  if (count of argumentList) < argumentIndex then
+    error "Missing " & argumentName number 64
+  end if
+  return item argumentIndex of argumentList as text
+end requiredArgument
+
+on run argv
+  set commandName to my requiredArgument(argv, 1, "command")
+
+  if commandName is "notify" then
+    set messageText to my requiredArgument(argv, 2, "message")
+    display notification messageText with title "Codex Dream Skin"
+    return ""
+  else if commandName is "alert" then
+    set messageText to my requiredArgument(argv, 2, "message")
+    display alert "Codex Dream Skin" message messageText
+    return ""
+  else if commandName is "confirm" then
+    set messageText to my requiredArgument(argv, 2, "message")
+    set okLabel to my requiredArgument(argv, 3, "confirmation label")
+    display dialog messageText buttons {"取消", okLabel} default button okLabel with title "Codex Dream Skin"
+    return ""
+  else if commandName is "echo-args" then
+    set firstValue to my requiredArgument(argv, 2, "first value")
+    set secondValue to my requiredArgument(argv, 3, "second value")
+    return firstValue & linefeed & secondValue
+  end if
+
+  error "Unknown command: " & commandName number 64
+end run

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -60,6 +60,31 @@ EXPECTED_TEAM_ID="TEAM'ID"
   exit 1
 }
 
+UI_SCRIPT="$ROOT/scripts/ui-macos.applescript"
+/usr/bin/osacompile -o "$TMP/ui-macos.scpt" "$UI_SCRIPT" >/dev/null
+INJECTION_MARKER="$TMP/applescript-injection-marker"
+INJECTION_TEXT="theme\" & (do shell script \"touch $INJECTION_MARKER\") & \""
+UI_ECHO="$(/usr/bin/osascript "$UI_SCRIPT" echo-args "$INJECTION_TEXT" "继续")"
+[ "$UI_ECHO" = "$INJECTION_TEXT"$'\n'"继续" ]
+[ ! -e "$INJECTION_MARKER" ]
+
+for file in \
+  "$ROOT/scripts/load-image-theme-macos.sh" \
+  "$ROOT/scripts/switch-theme-macos.sh" \
+  "$ROOT/scripts/apply-from-menubar-macos.sh"; do
+  /usr/bin/grep -q 'ui-macos\.applescript' "$file"
+  if /usr/bin/grep -n -E '/usr/bin/osascript[[:space:]]+(-e|<<)' "$file"; then
+    printf 'Dynamic AppleScript source remains in %s.\n' "$file" >&2
+    exit 1
+  fi
+done
+if ! /usr/bin/grep -Fq \
+  '/bin/cp -f "$PROJECT_ROOT/scripts/ui-macos.applescript" "$INSTALL_ROOT/scripts/ui-macos.applescript"' \
+  "$ROOT/scripts/install-menubar-macos.sh"; then
+  printf 'Menu-bar engine sync omits ui-macos.applescript.\n' >&2
+  exit 1
+fi
+
 /bin/mkdir -p "$TMP/theme"
 /bin/cp "$ROOT/assets/portal-hero.png" "$TMP/theme/background.png"
 "$NODE" "$ROOT/scripts/write-theme.mjs" custom --output-dir "$TMP/theme" \
@@ -113,4 +138,4 @@ NO_DESKTOP_BACKUP="$TMP/theme-backup-without-desktop.json"
 /usr/bin/env -u HOME /bin/bash -c '. "$1/scripts/common-macos.sh"; [ -n "$HOME" ] && [ "$SKIN_VERSION" = "1.1.2" ]' _ "$ROOT"
 "$ROOT/scripts/doctor-macos.sh" >/dev/null
 
-printf 'PASS: syntax, payload, runtime-state safety, custom-theme, config round-trips, HOME recovery, signature, and doctor checks.\n'
+printf 'PASS: syntax, AppleScript argv safety, payload, runtime-state safety, custom-theme, config round-trips, HOME recovery, signature, and doctor checks.\n'


### PR DESCRIPTION
## 摘要

- 将动态拼接的 AppleScript 通知与弹窗替换为固定脚本入口。
- 主题名、日志摘要、消息和按钮文字均通过 `osascript` 的 `argv` 传递，不再进入 AppleScript 源代码。
- 更新已有菜单栏安装时同步新的 AppleScript UI 辅助文件。
- 增加注入形状输入、AppleScript 编译及动态源码残留检查的回归测试。

## 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS

- [x] `macos/tests/run-tests.sh` passed / 已通过
- [x] Doctor：`macos/scripts/doctor-macos.sh`
- [ ] Live verify：`verify-dream-skin-macos.sh` 或桌面 **Verify**
- [ ] Restore / re-apply smoke / 恢复与重新应用冒烟测试

### Windows

- [ ] Relevant scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below / 下方注明环境

### 用户可见变更

- [x] Updated `macos/CHANGELOG.md` / 已更新 changelog
- [ ] N/A — no user-visible change / 无用户可见变更

## 安全

- [x] 未修改官方 Codex 安装、`app.asar` 或签名
- [x] 未静默写入 API Base URL 或 Key
- [x] CDP 行为未改变，仍仅面向本机回环地址

## 补充

- 在隔离 HOME 环境运行完整 macOS 测试并通过：

  ```text
  PASS: syntax, AppleScript argv safety, payload, runtime-state safety,
  custom-theme, config round-trips, HOME recovery, signature, and doctor checks.
  ```

- 单独运行 Doctor 通过，环境为 macOS arm64、官方签名 Codex 应用及其内置 Node.js。
- 未运行 Live verify，因为本次没有修改 renderer 注入、CSS、CDP 或 Codex 启动行为。
- 未运行 restore / re-apply smoke，避免改动当前用户正在使用的 Codex / SwiftBar 环境。
- 此修复未调整版本号，可由维护者纳入下一次发布。
