### PR TITLE
fix(macos): initialize default theme before validation

### DIFF
--- a/macos/CHANGELOG.md
+++ b/macos/CHANGELOG.md
@@ -9,6 +9,7 @@
 - 恢复原本没有 `[desktop]` 配置段的用户设置时，不再额外写入空段
 - 热切换读取运行状态时复用 Codex 内置 Node.js，不再依赖系统 `python3` 或执行 `eval`
 - 显式传入的 `--theme-dir` 缺少 `theme.json` 时立即报错，不再静默回退到内置 demo 主题
+- 首次安装会在 payload 校验前初始化内置 demo 主题；重置 demo 时也会重新写入完整主题文件
 
 ---
 

--- a/macos/scripts/common-macos.sh
+++ b/macos/scripts/common-macos.sh
@@ -43,6 +43,30 @@ ensure_state_root() {
   /bin/chmod 700 "$STATE_ROOT"
 }
 
+ensure_default_theme() {
+  ensure_state_root
+  [ -f "$THEME_DIR/theme.json" ] && return 0
+
+  /bin/mkdir -p "$THEME_DIR"
+  /bin/chmod 700 "$THEME_DIR"
+
+  local image_name
+  image_name="$("$NODE" -e '
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const theme = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const image = String(theme.image || "");
+    if (!image || path.basename(image) !== image) process.exit(1);
+    process.stdout.write(image);
+  ' "$PROJECT_ROOT/assets/theme.json")" || fail "Bundled default theme is invalid."
+
+  [ -s "$PROJECT_ROOT/assets/theme.json" ] || fail "Bundled default theme config is missing."
+  [ -s "$PROJECT_ROOT/assets/$image_name" ] || fail "Bundled default theme image is missing: $image_name"
+  /bin/cp -f "$PROJECT_ROOT/assets/theme.json" "$THEME_DIR/theme.json"
+  /bin/cp -f "$PROJECT_ROOT/assets/$image_name" "$THEME_DIR/$image_name"
+  /bin/chmod 600 "$THEME_DIR/theme.json" "$THEME_DIR/$image_name" 2>/dev/null || true
+}
+
 discover_codex_app() {
   local candidate=""
   local identifier=""

--- a/macos/scripts/install-dream-skin-macos.sh
+++ b/macos/scripts/install-dream-skin-macos.sh
@@ -50,7 +50,7 @@ fi
 
 discover_codex_app
 require_macos_runtime
-ensure_state_root
+ensure_default_theme
 [ -f "$CONFIG_PATH" ] || fail "Codex config not found: $CONFIG_PATH. Launch Codex once, close it, and rerun the installer."
 "$NODE" "$INJECTOR" --check-payload --theme-dir "$THEME_DIR" >/dev/null
 "$NODE" "$SCRIPT_DIR/theme-config.mjs" install "$CONFIG_PATH" "$THEME_BACKUP_PATH"

--- a/macos/scripts/write-theme.mjs
+++ b/macos/scripts/write-theme.mjs
@@ -44,6 +44,15 @@ if (mode === "reset-demo") {
     throw new Error("Refusing to delete the bundled demo assets; pass a user --output-dir.");
   }
   await fs.rm(outputDir, { recursive: true, force: true });
+  const bundledThemePath = path.join(root, "assets", "theme.json");
+  const bundledTheme = JSON.parse(await fs.readFile(bundledThemePath, "utf8"));
+  const image = String(bundledTheme.image || "");
+  if (!image || path.basename(image) !== image) throw new Error("Bundled demo theme image is invalid.");
+  await fs.mkdir(outputDir, { recursive: true, mode: 0o700 });
+  await fs.copyFile(bundledThemePath, themePath);
+  await fs.copyFile(path.join(root, "assets", image), path.join(outputDir, image));
+  await fs.chmod(themePath, 0o600);
+  await fs.chmod(path.join(outputDir, image), 0o600);
   console.log("Restored the bundled abstract demo preset.");
   process.exit(0);
 }

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -79,8 +79,15 @@ if MISSING_THEME_OUTPUT="$(
 fi
 /usr/bin/printf '%s\n' "$MISSING_THEME_OUTPUT" | /usr/bin/grep -F -q \
   "Explicit theme directory is missing theme.json: $TMP/missing-theme/theme.json"
+DEFAULT_THEME_HOME="$TMP/default-theme-home"
+/usr/bin/env HOME="$DEFAULT_THEME_HOME" NODE="$NODE" /bin/bash -c '
+  . "$1/scripts/common-macos.sh"
+  ensure_default_theme
+  "$NODE" "$INJECTOR" --check-payload --theme-dir "$THEME_DIR" >/dev/null
+' _ "$ROOT"
 "$NODE" "$ROOT/scripts/write-theme.mjs" reset-demo --output-dir "$TMP/theme" >/dev/null
-[ ! -e "$TMP/theme" ]
+[ -s "$TMP/theme/theme.json" ]
+"$NODE" "$ROOT/scripts/injector.mjs" --check-payload --theme-dir "$TMP/theme" >/dev/null
 
 CONFIG="$TMP/config.toml"
 BACKUP="$TMP/theme-backup.json"


### PR DESCRIPTION
## Summary / 摘要

- Seed the bundled demo theme into the app-owned runtime theme directory before installer payload validation.
- Make `reset-demo` restore a complete usable theme instead of deleting the runtime theme directory.
- Add regression coverage for fresh theme initialization and reset payload validation.

## Root cause / 根因

PR #25 correctly made an explicit `--theme-dir` authoritative and rejected a missing `theme.json`. The macOS installer passed its runtime theme directory to that strict validation before a fresh installation had populated the directory, so first-time installation failed immediately.

This change preserves the strict explicit-directory behavior for start, verify, and doctor commands. Only the installer initializes the app-owned default theme before validation.

## Impact / 影响

Fresh macOS installs can complete with the bundled demo theme, while incomplete user-supplied or runtime theme directories continue to fail validation outside the installer initialization path.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [x] Scripts / install / restore / 脚本或安装恢复

## Platform / 平台

- [x] macOS

## Self-check / 自测

### macOS

- [x] `cd macos && npm test`
- [x] `./scripts/install-dream-skin-macos.sh --no-launch`
- [x] `./scripts/doctor-macos.sh` (`pass: true`, live session not requested)
- [ ] Restore / re-apply smoke — not run; restore behavior is unchanged.

### User-facing / 用户可见变更

- [x] Updated `macos/CHANGELOG.md`
- [x] Kept `macos/VERSION` at `1.1.2`; release bump can remain maintainer-controlled.

## Security / 安全

- [x] Does not modify the official Codex install, `app.asar`, or signatures.
- [x] Does not write API Base URLs or keys.
- [x] CDP remains loopback-only.
