### PR TITLE
test(macos): isolate doctor from user theme state

### DIFF
--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -111,6 +111,12 @@ NO_DESKTOP_BACKUP="$TMP/theme-backup-without-desktop.json"
 /usr/bin/cmp -s "$NO_DESKTOP_CONFIG" "$TMP/original-without-desktop.toml"
 
 /usr/bin/env -u HOME /bin/bash -c '. "$1/scripts/common-macos.sh"; [ -n "$HOME" ] && [ "$SKIN_VERSION" = "1.1.2" ]' _ "$ROOT"
-"$ROOT/scripts/doctor-macos.sh" >/dev/null
+
+DOCTOR_HOME="$TMP/doctor-home"
+DOCTOR_THEME="$DOCTOR_HOME/Library/Application Support/CodexDreamSkinStudio/theme"
+/bin/mkdir -p "$DOCTOR_HOME/.codex" "$DOCTOR_THEME"
+/usr/bin/printf '%s\n' 'model = "gpt-5"' > "$DOCTOR_HOME/.codex/config.toml"
+/bin/cp "$ROOT/assets/theme.json" "$ROOT/assets/portal-hero.png" "$DOCTOR_THEME/"
+HOME="$DOCTOR_HOME" "$ROOT/scripts/doctor-macos.sh" >/dev/null
 
 printf 'PASS: syntax, payload, runtime-state safety, custom-theme, config round-trips, HOME recovery, signature, and doctor checks.\n'


### PR DESCRIPTION
## Summary / 摘要

- Run the doctor check with a temporary HOME, config, and complete theme fixture.
- Stop the test suite from depending on a contributor’s real Application Support theme directory.
- Keep the signed Codex runtime and doctor validation in coverage.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [x] Chore / 杂项

## Platform / 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

- [x] `cd macos && npm test`
- [x] `git diff --check`
- [x] N/A — no user-visible change / 无用户可见变更

## Security / 安全

- [x] Does not modify the official Codex install, app.asar, or signatures.
- [x] Does not write API settings or credentials.
- [x] CDP behavior is unchanged.

## Notes / 补充

Before this change, the suite failed when `~/Library/Application Support/CodexDreamSkinStudio/theme` was absent or incomplete. The doctor fixture is now created under the suite’s existing temporary directory and removed by its existing cleanup trap.