### PR TITLE
docs(macos): correct the Codex launch model

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -58,11 +58,11 @@ That ZIP contains a visible installer plus a hidden `.codex-dream-skin-studio` e
 ## How it works (security boundary)
 
 1. Discover `com.openai.codex` and validate signature / Team ID / arch / bundled Node.
-2. Start Codex via user `launchd` with CDP bound to `127.0.0.1` only.
+2. Start Codex as a normal user process with CDP bound to `127.0.0.1` only; stale launchd jobs from older releases are removed first.
 3. Accept the debug port only when it belongs to Codex (or a legitimate child).
 4. Inject only into expected `app://` renderer targets.
 5. Keep a small injector alive across reloads and route changes.
-6. Restore stops the injector only when PID, path, and start time match the recorded job.
+6. Restore stops the injector only when PID, path, and start time match the recorded process.
 
 CDP is powerful and unauthenticated on loopback. Prefer Restore when you are done theming.
 


### PR DESCRIPTION
## Summary / 摘要

- Correct the macOS security-boundary documentation to match the current normal-process launch flow.
- Explain that stale launchd jobs are removed only for compatibility with older releases.
- Refer to the recorded injector as a process rather than a launchd job.

## Type / 类型

- [x] Docs / 文档

## Platform / 平台

- [x] macOS
- [x] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

- [x] Wording reviewed against `launch_codex_with_cdp` and the 1.1.1 changelog.
- [x] `git diff --check`
- [x] N/A — no user-visible runtime change / 无用户可见运行时变更

## Security / 安全

- [x] Does not modify the official Codex install, app.asar, or signatures.
- [x] Does not write API settings or credentials.
- [x] CDP remains loopback-only.

## Notes / 补充

The old wording described the pre-1.1.1 behavior and could send troubleshooting in the wrong direction. This PR is documentation-only.