### PR TITLE
ci: add static and Windows regression checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-checks:
+    name: Static checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Check shell syntax
+        shell: bash
+        run: |
+          while IFS= read -r file; do
+            bash -n "$file"
+          done < <(
+            find macos -type f \( -name '*.sh' -o -name '*.command' \) \
+              ! -path '*/release/*' -print
+          )
+
+      - name: Check Node.js syntax
+        shell: bash
+        run: |
+          while IFS= read -r file; do
+            node --check "$file" >/dev/null
+          done < <(
+            find macos windows -type f \( -name '*.mjs' -o -name '*.js' \) -print
+          )
+
+      - name: Check Windows PowerShell source encoding
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          function visit(directory) {
+            for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+              const file = path.join(directory, entry.name);
+              if (entry.isDirectory()) visit(file);
+              if (!entry.isFile() || path.extname(file) !== ".ps1") continue;
+              const bytes = fs.readFileSync(file);
+              const hasBom = bytes.subarray(0, 3).equals(Buffer.from([0xef, 0xbb, 0xbf]));
+              const content = hasBom ? bytes.subarray(3) : bytes;
+              if (content.some((byte) => byte >= 0x80) && !hasBom) {
+                throw new Error(`${file}: non-ASCII PowerShell 5.1 source requires a UTF-8 BOM`);
+              }
+            }
+          }
+
+          visit("windows");
+          NODE
+
+      - name: Check runtime safety assertions
+        shell: bash
+        run: |
+          if grep -R -n -E 'dream-skin-skin|DREAM_SKIN_SKIN|1\.0\.0-rc2' \
+            macos/scripts macos/assets >/dev/null; then
+            printf 'Legacy release-candidate identifiers remain in runtime files.\n' >&2
+            exit 1
+          fi
+          if grep -R -n -E '(writeFile|rename|copyFile|rm).*app\.asar' \
+            macos/scripts >/dev/null; then
+            printf 'A runtime script appears to mutate app.asar.\n' >&2
+            exit 1
+          fi
+          if grep -n -E '/usr/bin/python3|(^|[[:space:]])eval([[:space:]]|$)' \
+            macos/scripts/common-macos.sh >/dev/null; then
+            printf 'The macOS runtime must parse state without python3 or eval.\n' >&2
+            exit 1
+          fi
+
+      - name: Check version consistency
+        shell: bash
+        run: |
+          expected="$(tr -d '\r\n' < macos/VERSION)"
+          common="$(sed -n 's/^SKIN_VERSION="\([^"]*\)"$/\1/p' macos/scripts/common-macos.sh)"
+          macos_injector="$(sed -n 's/^const SKIN_VERSION = "\([^"]*\)";$/\1/p' macos/scripts/injector.mjs)"
+          windows_injector="$(sed -n 's/^const SKIN_VERSION = "\([^"]*\)";$/\1/p' windows/scripts/injector.mjs)"
+          test -n "$expected"
+          test "$common" = "$expected"
+          test "$macos_injector" = "$expected"
+          test "$windows_injector" = "$expected"
+
+      - name: Run portable Node.js regressions
+        shell: bash
+        run: |
+          node --test macos/tests/*.test.mjs
+          node --test windows/tests/*.test.mjs
+          node macos/scripts/injector.mjs --check-payload >/dev/null
+          node windows/scripts/injector.mjs --check-payload >/dev/null
+
+  windows-tests:
+    name: Windows (${{ matrix.name }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows PowerShell 5.1
+            executable: powershell.exe
+          - name: PowerShell 7
+            executable: pwsh.exe
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run Windows regression suite
+        shell: cmd
+        run: ${{ matrix.executable }} -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\windows\tests\run-tests.ps1

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -95,11 +95,13 @@ function Invoke-DreamSkinNative {
   $ErrorActionPreference = 'Continue'
   try {
     if ($DiscardStderr) {
-      $output = @(& $FilePath @ArgumentList 2>$null | ForEach-Object { "$_" })
+      $nativeOutput = @(& $FilePath @ArgumentList 2>$null)
     } else {
-      $output = @(& $FilePath @ArgumentList 2>&1 | ForEach-Object { "$_" })
+      $nativeOutput = @(& $FilePath @ArgumentList 2>&1)
     }
-    return [pscustomobject]@{ Output = $output; ExitCode = $LASTEXITCODE }
+    $exitCode = $LASTEXITCODE
+    $output = @($nativeOutput | ForEach-Object { "$_" })
+    return [pscustomobject]@{ Output = $output; ExitCode = $exitCode }
   } finally {
     $ErrorActionPreference = $previousPreference
   }

--- a/windows/scripts/theme-windows.ps1
+++ b/windows/scripts/theme-windows.ps1
@@ -1,4 +1,4 @@
-if (-not (Get-Command Read-DreamSkinUtf8File -ErrorAction SilentlyContinue)) {
+﻿if (-not (Get-Command Read-DreamSkinUtf8File -ErrorAction SilentlyContinue)) {
   . (Join-Path $PSScriptRoot 'config-utf8.ps1')
 }
 

--- a/windows/scripts/tray-dream-skin.ps1
+++ b/windows/scripts/tray-dream-skin.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param([int]$Port = 9335)
 
 $ErrorActionPreference = 'Stop'

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param()
 
 $ErrorActionPreference = 'Stop'
@@ -650,7 +650,7 @@ try {
   $stderrProbe = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
     '-e', 'process.stderr.write("dream-skin-stderr-probe\n"); process.exit(7)')
   if ($stderrProbe.ExitCode -ne 7 -or ($stderrProbe.Output -join "`n") -notmatch 'dream-skin-stderr-probe') {
-    throw 'Native stderr was not captured with its real exit code under Stop preference.'
+    throw "Native stderr was not captured with its real exit code under Stop preference: exit=$($stderrProbe.ExitCode); output=$($stderrProbe.Output -join '<NL>')"
   }
   $discardedProbe = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
     '-e', 'process.stderr.write("ignored-warning\n"); process.stdout.write("kept-output")') -DiscardStderr

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -648,12 +648,12 @@ try {
 
   $node = Get-DreamSkinNodeRuntime
   $stderrProbe = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
-    '-e', 'process.stderr.write("dream-skin-stderr-probe\n"); process.exit(7)')
+    '-e', "process.stderr.write('dream-skin-stderr-probe\n'); process.exit(7)")
   if ($stderrProbe.ExitCode -ne 7 -or ($stderrProbe.Output -join "`n") -notmatch 'dream-skin-stderr-probe') {
     throw "Native stderr was not captured with its real exit code under Stop preference: exit=$($stderrProbe.ExitCode); output=$($stderrProbe.Output -join '<NL>')"
   }
   $discardedProbe = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
-    '-e', 'process.stderr.write("ignored-warning\n"); process.stdout.write("kept-output")') -DiscardStderr
+    '-e', "process.stderr.write('ignored-warning\n'); process.stdout.write('kept-output')") -DiscardStderr
   if ($discardedProbe.ExitCode -ne 0 -or ($discardedProbe.Output -join '') -cne 'kept-output') {
     throw 'Native stderr discard changed stdout or the real exit code.'
   }


### PR DESCRIPTION
Resolves #20.

Adds GitHub Actions coverage for checks that do not require Codex.app:

- Bash syntax, Node.js syntax, runtime safety, source-encoding, and cross-platform version checks.
- Portable macOS and Windows Node.js regressions plus payload validation on Ubuntu.
- The complete Windows regression suite on Windows PowerShell 5.1 and PowerShell 7 with Node.js 22.

The first real Windows run exposed that PowerShell 5.1 parsed non-ASCII UTF-8 source through the local ANSI code page. The three PowerShell files containing Chinese text are now explicitly UTF-8 with BOM, and CI prevents future non-ASCII PowerShell 5.1 sources from losing that marker.

Maintainer update: rebased onto current `main`, corrected stale repository paths, and retained the original contributor as commit author.