### PR TITLE
chore(repo): enforce portable line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.sh]
+end_of_line = lf
+
+[*.command]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+* text=auto
+.gitattributes text eol=lf
+.editorconfig text eol=lf
+
+# macOS launchers must stay executable after a Windows checkout or package build.
+*.sh text eol=lf
+*.command text eol=lf
+
+# Keep artwork out of text normalization and text diffs.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.icns binary


### PR DESCRIPTION
## 中文

### 摘要

- 增加 `.gitattributes`，让 macOS `*.sh` 和 `*.command` 在 Windows 检出后仍保持 LF。
- 将常见图片格式标记为 binary，避免文本换行符转换和无意义的文本 diff。
- 增加 `.editorconfig`，记录仓库现有的 UTF-8 与两空格缩进约定，并只对 macOS 启动文件指定 LF。
- 保持补丁为纯新增，不重新规范化任何现有源码或图片。

Closes #54

### 类型

- [x] 杂项

### 平台

- [x] 仅文档或仓库元数据

### 自测

- [x] 已检查链接和表述。
- [x] `git diff origin/main...HEAD --check` 通过，提交只包含 `.editorconfig` 与 `.gitattributes`。
- [x] 在 `core.autocrlf=true` 的隔离检出中检查 24 个受跟踪的 `*.sh` 和 `*.command` 文件，CRLF 数量为 0。
- [x] `git check-attr` 确认 macOS 启动文件使用 LF、PowerShell 保持默认文本处理、图片按 binary 处理。
- [x] 无用户可见的运行时变更。

### 安全

- [x] 不修改 Codex 官方安装目录、asar 或签名。
- [x] 不写入 API Base URL 或 Key。
- [x] 不改变 CDP 的回环绑定。

### 补充

- 推送前已更新到上游 `main` 的 `0437e18b9407cf2c6e50e34bfb84b83e325c2acf`。
- PR #47 修改的是运行时配置文件的编码和换行符；本 PR 只增加两个根目录元数据文件。

---

## English

### Summary

- Add `.gitattributes` so macOS `*.sh` and `*.command` launchers remain LF after a Windows checkout.
- Mark common artwork formats as binary to prevent text normalization and noisy text diffs.
- Add `.editorconfig` for the repository's existing UTF-8 and two-space conventions, with LF scoped to macOS launchers.
- Keep the patch additive without renormalizing tracked source or artwork.

Closes #54

### Type

- [x] Chore

### Platform

- [x] Docs or repository metadata only

### Self-check

- [x] Reviewed links and wording.
- [x] `git diff origin/main...HEAD --check` passed, and the commit contains only `.editorconfig` and `.gitattributes`.
- [x] An isolated checkout with `core.autocrlf=true` checked 24 tracked `*.sh` and `*.command` files with 0 CRLF violations.
- [x] `git check-attr` confirms LF for macOS launchers, default text handling for PowerShell, and binary handling for artwork.
- [x] No user-facing runtime behavior changes.

### Security

- [x] Does not modify the official Codex install, asar, or signatures.
- [x] Does not write an API Base URL or key.
- [x] Does not change the loopback CDP binding.

### Notes

- The branch was updated to upstream `main` at `0437e18b9407cf2c6e50e34bfb84b83e325c2acf` before push.
- PR #47 changes runtime configuration encoding and newlines. This PR adds only two root metadata files.
