### PR TITLE
docs(windows): add user setup guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,8 +11,8 @@ contact_links:
   - name: macOS 使用说明 / macOS README
     url: https://github.com/Fei-Away/Codex-Dream-Skin/blob/main/macos/README.md
     about: 安装路径、定制、Verify / Restore · Install paths, customize, verify & restore
-  - name: Windows 说明 / Windows SKILL
-    url: https://github.com/Fei-Away/Codex-Dream-Skin/blob/main/windows/SKILL.md
+  - name: Windows 使用说明 / Windows README
+    url: https://github.com/Fei-Away/Codex-Dream-Skin/blob/main/windows/README.md
     about: Windows 安装、启动、校验、恢复 · Install, start, verify, restore on Windows
   - name: 平台路径对照 / Platform paths
     url: https://github.com/Fei-Away/Codex-Dream-Skin/blob/main/docs/platforms.md

--- a/windows/README.en.md
+++ b/windows/README.en.md
@@ -1,0 +1,150 @@
+# Codex Dream Skin for Windows
+
+<p align="center">
+  <a href="./README.md">中文</a> · <strong>English</strong>
+</p>
+
+Codex Dream Skin loads an external theme into the official Codex Windows desktop app through loopback CDP. The native sidebar, project picker, task content, and composer remain interactive. The tool does not modify WindowsApps, `app.asar`, or the app signature.
+
+## Requirements
+
+- The official `OpenAI.Codex` app installed from Microsoft Store and registered for the current user.
+- Node.js 22 or newer, with `node.exe` available on `PATH`.
+- Windows PowerShell 5.1 or newer.
+
+Run the installer after Codex has fully exited. Normal use does not require administrator access or ownership changes under WindowsApps.
+
+## Install
+
+Open PowerShell in the repository's `windows` directory and run:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-dream-skin.ps1
+```
+
+The installer validates the official Codex Store package and Node.js, saves a recoverable appearance baseline, and initializes the local theme store. By default it also creates these shortcuts:
+
+- `Codex Dream Skin`: launch or reapply the skin.
+- `Codex Dream Skin - Tray`: open the system tray theme controls.
+- `Codex Dream Skin - Restore`: restore the stock appearance and close the saved CDP session.
+
+Pass `-Port` during installation to use a fixed custom port. Valid ports range from `1024` through `65535`.
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-dream-skin.ps1 -Port 9444
+```
+
+## Launch and verify
+
+The `Codex Dream Skin` shortcut is the recommended launcher. It asks for confirmation before restarting an open Codex window.
+
+Command-line launch:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\start-dream-skin.ps1 -PromptRestart
+```
+
+Run verification after launch:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify-dream-skin.ps1 `
+  -ScreenshotPath "$env:TEMP\codex-dream-skin.png"
+```
+
+The verification script confirms:
+
+- The CDP endpoint is bound to loopback and belongs to the current official Codex package.
+- The current renderer has loaded the expected skin version.
+- The native sidebar and composer remain present.
+- The decorative skin layer does not intercept pointer events.
+- When the current route is home, the themed home structure has loaded.
+
+Next, use the generated screenshot to check horizontal overflow and text contrast. On both the home and normal task routes, manually check the project menu and composer interaction. See [`references/qa-inventory.md`](./references/qa-inventory.md) for the complete visual checklist.
+
+## Change and save themes
+
+Open `Codex Dream Skin - Tray` to:
+
+- Import a PNG, JPEG, or WebP background.
+- Save the active theme and switch through saved themes.
+- Pause or resume the skin.
+- Reapply the theme or fully restore Codex.
+
+Import a UI-free wallpaper rather than a preview containing a window, sidebar, composer, text, or buttons. Images may be at most 16 MB, 16384 pixels on either side, and 50 million total pixels.
+
+## Restore and remove shortcuts
+
+Restore the stock appearance. If Codex is running, confirm its closure and relaunch:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\restore-dream-skin.ps1 `
+  -RestoreBaseTheme -PromptRestart
+```
+
+Add `-Uninstall` to also remove the shortcuts created by Dream Skin:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\restore-dream-skin.ps1 `
+  -RestoreBaseTheme -PromptRestart -Uninstall
+```
+
+`-RecoverConfigBackup` restores the complete pre-install `config.toml` backup and saves the current configuration first. Reserve it for a damaged configuration that normal `-RestoreBaseTheme` recovery cannot resolve.
+
+## Files and logs
+
+| Purpose | Path |
+|---------|------|
+| Dream Skin state root | `%LOCALAPPDATA%\CodexDreamSkin` |
+| Active theme | `%LOCALAPPDATA%\CodexDreamSkin\active-theme` |
+| Saved themes | `%LOCALAPPDATA%\CodexDreamSkin\themes` |
+| Imported image archive | `%LOCALAPPDATA%\CodexDreamSkin\images` |
+| Session state | `%LOCALAPPDATA%\CodexDreamSkin\state.json` |
+| Injector log | `%LOCALAPPDATA%\CodexDreamSkin\injector.log` |
+| Injector error log | `%LOCALAPPDATA%\CodexDreamSkin\injector-error.log` |
+| Verification log | `%LOCALAPPDATA%\CodexDreamSkin\verify.log` |
+| Codex configuration | `%USERPROFILE%\.codex\config.toml` |
+
+See [`../docs/platforms.md`](../docs/platforms.md) for the complete platform path reference.
+
+## Troubleshooting
+
+### Node.js is missing
+
+Run `node --version`, confirm that it reports version 22 or newer, and reopen PowerShell so an updated `PATH` takes effect.
+
+### The official Codex package is missing
+
+Run:
+
+```powershell
+Get-AppxPackage -Name OpenAI.Codex
+```
+
+The scripts accept only a registered official Store package. They do not launch Codex from an arbitrary executable path.
+
+### The installer asks you to close Codex
+
+Close every Codex window and run the installer again. Installation requires stable app and configuration state.
+
+### The port is occupied
+
+When `-Port` is omitted, the launcher searches for a free port beginning at `9335`. If another process owns an explicitly requested port, choose a different port rather than stopping an unknown listener.
+
+### Verification cannot find a CDP endpoint
+
+Launch Codex through the `Codex Dream Skin` shortcut, then run verification. A normal Codex launch does not open the debug session used by Dream Skin.
+
+### The skin stops working after a Codex update
+
+Run the installer and launch shortcut again. The scripts rediscover the currently registered Store package instead of trusting an executable path from an older app version.
+
+Open the repository's [new issue page](https://github.com/Fei-Away/Codex-Dream-Skin/issues/new/choose) and choose the bug form when reporting a problem. Include the Windows version, Codex source, reproduction steps, and relevant log lines. Remove secrets, `auth.json`, relay tokens, and private conversation content.
+
+## Security boundaries
+
+- CDP binds only to `127.0.0.1`. Avoid untrusted local software while the skin is active.
+- The tool does not modify the official Codex installation, WindowsApps, `app.asar`, or signatures.
+- It does not write API keys, Base URLs, or model provider settings.
+- Restore controls only Codex processes that pass package identity, executable path, and recorded session checks.
+
+Maintainer and agent constraints live in [`SKILL.md`](./SKILL.md). See [`references/runtime-notes.md`](./references/runtime-notes.md) for deeper runtime troubleshooting.

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,150 @@
+# Codex Dream Skin for Windows
+
+<p align="center">
+  <strong>中文</strong> · <a href="./README.en.md">English</a>
+</p>
+
+Codex Dream Skin 通过本机回环 CDP 给官方 Codex Windows 桌面应用加载外部主题。它保留原生侧栏、项目选择、任务内容和输入框，不修改 WindowsApps、`app.asar` 或应用签名。
+
+## 运行要求
+
+- 从 Microsoft Store 安装且已注册到当前用户的官方 `OpenAI.Codex` 应用。
+- Node.js 22 或更高版本，`node.exe` 可从 `PATH` 找到。
+- Windows PowerShell 5.1 或更高版本。
+
+安装脚本需要在 Codex 完全退出后运行。普通使用不需要管理员权限，也不需要接管 WindowsApps 目录。
+
+## 安装
+
+在 PowerShell 中进入仓库的 `windows` 目录，然后运行：
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-dream-skin.ps1
+```
+
+安装器会校验官方 Codex Store 包和 Node.js，保存可恢复的外观配置，并初始化本地主题仓库。默认还会创建这些快捷方式：
+
+- `Codex Dream Skin`：启动或重新应用皮肤。
+- `Codex Dream Skin - Tray`：打开系统托盘主题控制。
+- `Codex Dream Skin - Restore`：恢复官方外观并关闭已保存的 CDP 会话。
+
+如需使用自定义端口，可以在安装时传入 `-Port`。端口范围必须是 `1024` 到 `65535`。
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-dream-skin.ps1 -Port 9444
+```
+
+## 启动与验证
+
+推荐从 `Codex Dream Skin` 快捷方式启动。它发现 Codex 已经运行时会先询问是否重启。
+
+命令行启动：
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\start-dream-skin.ps1 -PromptRestart
+```
+
+启动后运行验证脚本：
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify-dream-skin.ps1 `
+  -ScreenshotPath "$env:TEMP\codex-dream-skin.png"
+```
+
+验证脚本会自动确认：
+
+- CDP 端点只绑定本机回环地址，并且属于当前官方 Codex 包。
+- 当前渲染页已经加载预期版本的皮肤。
+- 原生侧栏和输入框仍然存在。
+- 皮肤装饰层不会拦截鼠标事件。
+- 当前为首页时，首页主题结构已经正确加载。
+
+随后用生成的截图检查横向溢出和文字对比度，再分别在首页与普通任务页手动检查项目菜单和输入框交互。完整视觉检查项见 [`references/qa-inventory.md`](./references/qa-inventory.md)。
+
+## 更换和保存主题
+
+打开 `Codex Dream Skin - Tray` 后可以：
+
+- 更换 PNG、JPEG 或 WebP 背景图。
+- 保存当前主题并从「已保存主题」切换。
+- 暂停或继续显示皮肤。
+- 重新应用主题，或完整恢复 Codex。
+
+导入图片必须是纯背景，不要使用包含窗口、侧栏、输入框、文字或按钮的效果截图。图片上限为 16 MB；宽或高不能超过 16384 像素，总像素不能超过 5000 万。
+
+## 恢复与卸载快捷方式
+
+恢复官方外观；如果 Codex 正在运行，确认后关闭并重新打开：
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\restore-dream-skin.ps1 `
+  -RestoreBaseTheme -PromptRestart
+```
+
+如需同时删除 Dream Skin 创建的快捷方式，再增加 `-Uninstall`：
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\restore-dream-skin.ps1 `
+  -RestoreBaseTheme -PromptRestart -Uninstall
+```
+
+`-RecoverConfigBackup` 用于明确恢复安装前的完整 `config.toml` 备份。它会先保存当前配置，只应在配置损坏且普通的 `-RestoreBaseTheme` 无法解决时使用。
+
+## 文件与日志位置
+
+| 用途 | 路径 |
+|------|------|
+| Dream Skin 状态根目录 | `%LOCALAPPDATA%\CodexDreamSkin` |
+| 当前主题 | `%LOCALAPPDATA%\CodexDreamSkin\active-theme` |
+| 已保存主题 | `%LOCALAPPDATA%\CodexDreamSkin\themes` |
+| 导入图片归档 | `%LOCALAPPDATA%\CodexDreamSkin\images` |
+| 会话状态 | `%LOCALAPPDATA%\CodexDreamSkin\state.json` |
+| 注入器日志 | `%LOCALAPPDATA%\CodexDreamSkin\injector.log` |
+| 注入器错误日志 | `%LOCALAPPDATA%\CodexDreamSkin\injector-error.log` |
+| 验证日志 | `%LOCALAPPDATA%\CodexDreamSkin\verify.log` |
+| Codex 配置 | `%USERPROFILE%\.codex\config.toml` |
+
+更完整的平台路径说明见 [`../docs/platforms.md`](../docs/platforms.md)。
+
+## 常见问题
+
+### 找不到 Node.js
+
+运行 `node --version`，确认版本为 22 或更高，并重新打开 PowerShell 让新的 `PATH` 生效。
+
+### 找不到官方 Codex 包
+
+运行：
+
+```powershell
+Get-AppxPackage -Name OpenAI.Codex
+```
+
+脚本只接受已注册的官方 Store 包，不会从任意可执行文件路径启动 Codex。
+
+### 安装器要求关闭 Codex
+
+关闭所有 Codex 窗口后再运行安装器。安装期间必须保持配置和应用状态稳定。
+
+### 端口被占用
+
+没有显式指定 `-Port` 时，启动脚本会从默认端口 `9335` 开始寻找空闲端口。显式端口被其他进程占用时，改用另一个端口，不要关闭身份不明的监听进程。
+
+### 验证找不到 CDP 端点
+
+通过 `Codex Dream Skin` 快捷方式启动 Codex，再运行验证脚本。普通 Codex 启动方式不会打开 Dream Skin 所需的调试会话。
+
+### Codex 更新后皮肤失效
+
+重新运行安装器和启动快捷方式。脚本会重新发现当前注册的 Store 包，不依赖旧版本的可执行文件路径。
+
+提交问题时请从仓库的 [Issue 提交页](https://github.com/Fei-Away/Codex-Dream-Skin/issues/new/choose) 选择 Bug 模板，附上系统版本、Codex 来源、复现步骤和相关日志片段。请删除密钥、`auth.json`、中转 token 和私人对话内容。
+
+## 安全边界
+
+- CDP 只绑定 `127.0.0.1`。皮肤运行期间不要运行来路不明的本机程序。
+- 不修改官方 Codex 安装目录、WindowsApps、`app.asar` 或签名。
+- 不写入 API Key、Base URL 或模型供应商配置。
+- 恢复脚本只会控制经过包身份、进程路径和会话状态校验的 Codex 进程。
+
+维护者和代理使用的实现约束见 [`SKILL.md`](./SKILL.md)，运行时排错细节见 [`references/runtime-notes.md`](./references/runtime-notes.md)。


### PR DESCRIPTION
## 中文

### Summary / 摘要

- 新增 `windows/README.md`，为 Windows 用户集中说明运行要求、安装、启动、验证、主题管理、恢复、日志位置和排错顺序。
- 新增独立的 `windows/README.en.md`，与中文文档互相提供语言切换入口。
- 将 Issue chooser 的 Windows 帮助入口从代理使用的 `windows/SKILL.md` 调整为面向用户的 `windows/README.md`。
- 文档中的命令、参数、快捷方式、状态路径、图片限制和安全边界均与当前 Windows 实现逐项核对。

### Type / 类型

- [ ] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [x] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

### Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [x] Docs / repo only / 仅文档或仓库元数据

### Self-check / 自测

#### Docs-only / 仅文档

- [x] Links and wording reviewed / 已检查链接与表述

实际检查结果：

- Windows 文档准确性检查通过：脚本名称、示例命令、参数、语言切换、恢复语义和 Issue chooser 目标均匹配当前实现。
- 仓库 28 个 Markdown 文件的本地链接检查通过。
- Issue chooser 配置通过 YAML 解析，Windows 入口只指向新的用户 README。
- Windows PowerShell 文件语法解析和 Node.js 文件语法检查通过。
- Windows 的 4 个 Node.js 测试文件全部通过。
- `git diff --check` 通过。

#### User-facing / 用户可见变更

本次范围是 Windows 用户文档和 Issue chooser 元数据。运行时脚本、主题资源、版本文件与 changelog 均保持原状。

### Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

### Notes / 补充

- `windows/SKILL.md` 继续作为代理和维护者的技术入口；新的 README 只承担普通用户的安装与排错说明。
- 根 README 和 Windows 运行时文件不在本次改动范围内，从而避开当前开放 PR 的高重叠区域。

---

## English

### Summary

- Add `windows/README.md` as a single Windows user guide for requirements, installation, launch, verification, theme management, recovery, log locations, and troubleshooting.
- Add a separate `windows/README.en.md` and link the two language versions to each other.
- Point the Windows help entry in the issue chooser to the user-facing `windows/README.md` instead of the agent-oriented `windows/SKILL.md`.
- Cross-check every documented command, parameter, shortcut, state path, image limit, and security boundary against the current Windows implementation.

### Type

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Theme / CSS / visual
- [ ] Scripts / install / restore
- [ ] Chore

### Platform

- [ ] macOS
- [x] Windows
- [ ] Both
- [x] Docs / repo only

### Self-check

#### Docs-only

- [x] Links and wording reviewed

Checks completed:

- Windows documentation accuracy check passed for script names, example commands, parameters, language links, restore semantics, and the issue chooser target.
- Repository-local links passed across 28 Markdown files.
- The issue chooser configuration parsed as YAML, with its Windows entry pointing only to the new user README.
- Windows PowerShell syntax parsing and Node.js syntax checks passed.
- All 4 Windows Node.js test files passed.
- `git diff --check` passed.

#### User-facing

This change is limited to Windows user documentation and issue chooser metadata. Runtime scripts, theme assets, version files, and changelogs remain unchanged.

### Security

- [x] Does **not** modify the official Codex install, asar, or signatures
- [x] Does **not** silently write an API Base URL or keys
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable

### Notes

- `windows/SKILL.md` remains the technical entry for agents and maintainers. The new READMEs are focused on user installation and troubleshooting.
- Root READMEs and Windows runtime files are outside this change, which avoids the high-overlap areas in current open pull requests.

Closes #61
