### PR TITLE
fix(windows): preserve native shell controls

### DIFF
--- a/windows/assets/dream-skin.css
+++ b/windows/assets/dream-skin.css
@@ -97,7 +97,7 @@ html.codex-dream-skin aside.app-shell-left-panel [class*="text-token"] {
 html.codex-dream-skin main.main-surface {
   position: relative;
   isolation: isolate;
-  overflow: hidden !important;
+  overflow: visible !important;
   color: var(--dream-text) !important;
   background: var(--dream-surface) !important;
   border-color: var(--dream-line-soft) !important;
@@ -105,7 +105,6 @@ html.codex-dream-skin main.main-surface {
 }
 
 html.codex-dream-skin main.main-surface > header.app-header-tint {
-  position: relative;
   z-index: 20;
   color: var(--dream-text) !important;
   background: color-mix(in oklab, var(--dream-surface) 94%, transparent) !important;

--- a/windows/tests/ui-shell-css.test.mjs
+++ b/windows/tests/ui-shell-css.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const css = fs.readFileSync(path.join(root, "assets", "dream-skin.css"), "utf8");
+
+const mainRule = css.match(
+  /html\.codex-dream-skin main\.main-surface\s*\{([\s\S]*?)\}/,
+);
+assert.ok(mainRule, "the main Codex surface rule must exist");
+assert.doesNotMatch(
+  mainRule[1],
+  /overflow\s*:\s*hidden\s*!important/,
+  "the skin must not clip native menus and side-panel popovers",
+);
+
+const headerRule = css.match(
+  /html\.codex-dream-skin main\.main-surface\s*>\s*header\.app-header-tint\s*\{([\s\S]*?)\}/,
+);
+assert.ok(headerRule, "the native Codex header rule must exist");
+assert.doesNotMatch(
+  headerRule[1],
+  /position\s*:\s*relative/,
+  "the skin must preserve the native header positioning context",
+);
+
+console.log("ui-shell-css.test.mjs: passed");


### PR DESCRIPTION
## What changed

- Preserve the native Codex header positioning context.
- Stop forcing the main surface to clip overflow, so native title menus and layout popovers can escape their container.
- Add a focused regression test for the Windows shell CSS rules.

## Why

The full-window Dream Skin CSS changed the native header to `position: relative` and forced `overflow: hidden !important` on `main.main-surface`. The title overflow menu and the top-right native layout controls remained visible, but their native popover/toggle behavior was clipped or mispositioned.

## Validation

- `node windows/tests/ui-shell-css.test.mjs`
- `node --check windows/scripts/injector.mjs`
- `node --check windows/assets/renderer-inject.js`

The fix was also checked against a live Windows Codex session with the Dream Skin active.
