### PR TITLE
fix(macos): reject oversized images before sips rasterizes them (#66)

### DIFF
--- a/macos/scripts/check-image-dimensions.mjs
+++ b/macos/scripts/check-image-dimensions.mjs
@@ -6,8 +6,8 @@
 // container header only (PNG/JPEG/WebP) and falls back to `sips -g` metadata for
 // formats the header parser does not recognize (HEIC/TIFF); it never decodes.
 //
-// Exit 0 = within caps or dimensions undeterminable (later checks still apply),
-// 1 = over caps, 2 = usage / unreadable file.
+// Exit 0 = dimensions are known and within caps,
+// 1 = over caps, 2 = usage / unreadable or undetermined dimensions.
 
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -60,7 +60,12 @@ if (!dimensions) {
   }
 }
 
-if (dimensions && overCaps(dimensions.width, dimensions.height)) {
+if (!dimensions) {
+  console.error("Could not determine image dimensions without rasterizing the source.");
+  process.exit(2);
+}
+
+if (overCaps(dimensions.width, dimensions.height)) {
   console.error(
     `Image is ${dimensions.width}×${dimensions.height}px, over the `
     + `${MAX_IMAGE_DIMENSION}px-per-side / ${MAX_IMAGE_PIXELS / 1_000_000}-megapixel safety limit.`,

--- a/macos/scripts/check-image-dimensions.mjs
+++ b/macos/scripts/check-image-dimensions.mjs
@@ -1,0 +1,70 @@
+// Reject oversized images BEFORE anything rasterizes them.
+//
+// `load-image-theme` converts non-JPEG sources with `sips -Z`, which must
+// fully decode the source first — a near-flat 30000×30000 PNG under the 50 MB
+// byte cap would still balloon to gigabytes of pixels. This preflight reads the
+// container header only (PNG/JPEG/WebP) and falls back to `sips -g` metadata for
+// formats the header parser does not recognize (HEIC/TIFF); it never decodes.
+//
+// Exit 0 = within caps or dimensions undeterminable (later checks still apply),
+// 1 = over caps, 2 = usage / unreadable file.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  MAX_IMAGE_DIMENSION,
+  MAX_IMAGE_PIXELS,
+  readRawDimensions,
+} from "./image-metadata.mjs";
+
+const file = process.argv[2];
+if (!file) {
+  console.error("usage: check-image-dimensions.mjs <image>");
+  process.exit(2);
+}
+
+function overCaps(width, height) {
+  return !Number.isSafeInteger(width) || !Number.isSafeInteger(height)
+    || width < 1 || height < 1
+    || width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION
+    || width * height > MAX_IMAGE_PIXELS;
+}
+
+let dimensions = null;
+try {
+  const bytes = new Uint8Array(await fs.readFile(file));
+  dimensions = readRawDimensions(bytes, path.extname(file));
+} catch (error) {
+  console.error(`Could not read image: ${error.message}`);
+  process.exit(2);
+}
+
+// HEIC/TIFF and anything the header parser does not recognize: ask sips for
+// image properties only. Reading properties does not rasterize the file.
+if (!dimensions) {
+  try {
+    const out = execFileSync(
+      "/usr/bin/sips",
+      ["-g", "pixelWidth", "-g", "pixelHeight", file],
+      { encoding: "utf8", timeout: 10000 },
+    );
+    const width = Number(/pixelWidth:\s*(\d+)/.exec(out)?.[1]);
+    const height = Number(/pixelHeight:\s*(\d+)/.exec(out)?.[1]);
+    if (Number.isFinite(width) && Number.isFinite(height)) {
+      dimensions = { width, height };
+    }
+  } catch {
+    // sips unavailable or refused the file: fall through. The 50 MB byte cap and
+    // the inject-time dimension check remain as backstops.
+  }
+}
+
+if (dimensions && overCaps(dimensions.width, dimensions.height)) {
+  console.error(
+    `Image is ${dimensions.width}×${dimensions.height}px, over the `
+    + `${MAX_IMAGE_DIMENSION}px-per-side / ${MAX_IMAGE_PIXELS / 1_000_000}-megapixel safety limit.`,
+  );
+  process.exit(1);
+}
+process.exit(0);

--- a/macos/scripts/image-metadata.mjs
+++ b/macos/scripts/image-metadata.mjs
@@ -119,13 +119,21 @@ export function classifyImageDimensions({ width, height }) {
   };
 }
 
-export function readImageMetadata(value, extension = "") {
+// Raw pixel dimensions straight from the container header — no decode, and no
+// safety-cap classification, so callers can reject oversized images *before*
+// anything rasterizes them. Returns null for formats this header parser does
+// not recognize (e.g. HEIC/TIFF).
+export function readRawDimensions(value, extension = "") {
   const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
   const normalized = extension.toLowerCase();
-  let dimensions = null;
-  if (normalized === ".png" || bytes[0] === 0x89) dimensions = pngDimensions(bytes);
-  else if (normalized === ".jpg" || normalized === ".jpeg" ||
-    (bytes[0] === 0xff && bytes[1] === 0xd8)) dimensions = jpegDimensions(bytes);
-  else if (normalized === ".webp" || ascii(bytes, 8, 4) === "WEBP") dimensions = webpDimensions(bytes);
+  if (normalized === ".png" || bytes[0] === 0x89) return pngDimensions(bytes);
+  if (normalized === ".jpg" || normalized === ".jpeg" ||
+    (bytes[0] === 0xff && bytes[1] === 0xd8)) return jpegDimensions(bytes);
+  if (normalized === ".webp" || ascii(bytes, 8, 4) === "WEBP") return webpDimensions(bytes);
+  return null;
+}
+
+export function readImageMetadata(value, extension = "") {
+  const dimensions = readRawDimensions(value, extension);
   return dimensions ? classifyImageDimensions(dimensions) : null;
 }

--- a/macos/scripts/load-image-theme-macos.sh
+++ b/macos/scripts/load-image-theme-macos.sh
@@ -78,6 +78,10 @@ progress "Loading image..."
 # Fast Node for write-theme (avoid full codesign when possible)
 ensure_node_runtime
 
+# Reject decompression bombs before `sips -Z` rasterizes the full source image.
+"$NODE" "$SCRIPT_DIR/check-image-dimensions.mjs" "$IMAGE" \
+  || fail "Image exceeds the safe pixel budget (max 16384 px per side / 50 megapixels)."
+
 image_name="background.jpg"
 temporary="$THEME_DIR/.background.$$.tmp.jpg"
 prepared="$THEME_DIR/$image_name"

--- a/macos/scripts/load-image-theme-macos.sh
+++ b/macos/scripts/load-image-theme-macos.sh
@@ -80,7 +80,7 @@ ensure_node_runtime
 
 # Reject decompression bombs before `sips -Z` rasterizes the full source image.
 "$NODE" "$SCRIPT_DIR/check-image-dimensions.mjs" "$IMAGE" \
-  || fail "Image exceeds the safe pixel budget (max 16384 px per side / 50 megapixels)."
+  || fail "Image dimensions are invalid or exceed the safe pixel budget (max 16384 px per side / 50 megapixels)."
 
 image_name="background.jpg"
 temporary="$THEME_DIR/.background.$$.tmp.jpg"

--- a/macos/tests/image-metadata.test.mjs
+++ b/macos/tests/image-metadata.test.mjs
@@ -7,6 +7,7 @@ import {
   MAX_IMAGE_PIXELS,
   classifyImageDimensions,
   readImageMetadata,
+  readRawDimensions,
 } from "../scripts/image-metadata.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -104,4 +105,16 @@ assert.deepEqual(readImageMetadata(vp8x, ".webp"), {
 
 assert.equal(readImageMetadata(new Uint8Array([0, 1, 2, 3]), ".png"), null);
 
-console.log("PASS: image dimensions strictly classify PNG, JPEG, VP8L, and VP8X profiles.");
+// readRawDimensions returns real pixel dimensions even beyond the safety caps,
+// so a preflight can reject decompression bombs before anything decodes them.
+assert.deepEqual(readRawDimensions(portal, ".png"), { width: 2168, height: 725 });
+const oversized = new Uint8Array(24);
+oversized.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+oversized.set([0x00, 0x00, 0x00, 0x0d], 8); // IHDR chunk length
+writeAscii(oversized, 12, "IHDR");
+oversized.set([0x00, 0x00, 0x4e, 0x20], 16); // width 20000
+oversized.set([0x00, 0x00, 0x4e, 0x20], 20); // height 20000
+assert.deepEqual(readRawDimensions(oversized, ".png"), { width: 20000, height: 20000 });
+assert.equal(readImageMetadata(oversized, ".png"), null); // 400 MP exceeds the cap
+
+console.log("PASS: image dimensions strictly classify PNG, JPEG, VP8L, and VP8X profiles, and readRawDimensions bypasses caps.");

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -48,6 +48,32 @@ fi
 "$NODE" "$ROOT/tests/renderer-inject.test.mjs"
 "$NODE" "$ROOT/tests/theme-stage.test.mjs"
 
+# check-image-dimensions rejects decompression bombs before sips can rasterize them.
+write_png_header() { # <path> <width> <height>
+  "$NODE" -e '
+    const fs = require("node:fs");
+    const buffer = Buffer.alloc(24);
+    Buffer.from([0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a]).copy(buffer, 0);
+    buffer.writeUInt32BE(13, 8);
+    buffer.write("IHDR", 12, "ascii");
+    buffer.writeUInt32BE(Number(process.argv[2]), 16);
+    buffer.writeUInt32BE(Number(process.argv[3]), 20);
+    fs.writeFileSync(process.argv[1], buffer);
+  ' "$1" "$2" "$3"
+}
+CID_TMP="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/codex-dream-skin-cid.XXXXXX")"
+write_png_header "$CID_TMP/huge.png" 20000 20000
+if "$NODE" "$ROOT/scripts/check-image-dimensions.mjs" "$CID_TMP/huge.png" >/dev/null 2>&1; then
+  printf 'check-image-dimensions accepted a 20000x20000 (400 MP) image.\n' >&2
+  /bin/rm -rf "$CID_TMP"; exit 1
+fi
+write_png_header "$CID_TMP/ok.png" 1600 900
+if ! "$NODE" "$ROOT/scripts/check-image-dimensions.mjs" "$CID_TMP/ok.png" >/dev/null 2>&1; then
+  printf 'check-image-dimensions rejected a valid 1600x900 image.\n' >&2
+  /bin/rm -rf "$CID_TMP"; exit 1
+fi
+/bin/rm -rf "$CID_TMP"
+
 # Every bundled preset must be a valid, injectable theme pack with a preset-* id.
 for preset in "$ROOT"/presets/preset-*/; do
   [ -d "$preset" ] || continue

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -72,6 +72,11 @@ if ! "$NODE" "$ROOT/scripts/check-image-dimensions.mjs" "$CID_TMP/ok.png" >/dev/
   printf 'check-image-dimensions rejected a valid 1600x900 image.\n' >&2
   /bin/rm -rf "$CID_TMP"; exit 1
 fi
+/usr/bin/printf 'not-an-image' > "$CID_TMP/invalid.png"
+if "$NODE" "$ROOT/scripts/check-image-dimensions.mjs" "$CID_TMP/invalid.png" >/dev/null 2>&1; then
+  printf 'check-image-dimensions accepted an image whose dimensions could not be determined safely.\n' >&2
+  /bin/rm -rf "$CID_TMP"; exit 1
+fi
 /bin/rm -rf "$CID_TMP"
 
 # Every bundled preset must be a valid, injectable theme pack with a preset-* id.


### PR DESCRIPTION
## 问题 / What
`load-image-theme` 在转换前只卡了源图**字节**上限(50 MB),随后 `sips -Z` 必须先把整张源图**完全解码**。一张近纯色的 30000×30000 PNG 可以压到 50 MB 以下,却会在解码时膨胀到 ~3.6 GB 像素;而 16384px / 50 MP 的安全上限要到注入时才生效,所以这条路径能在任何尺寸检查前吃爆内存。

Fixes #66.

## 改动 / How
- `image-metadata.mjs`:抽出 `readRawDimensions()` 导出,返回**未经安全上限分类**的原始 header 尺寸,让调用方能在解码前就拒绝。`readImageMetadata()` 改为复用它——行为不变。
- `check-image-dimensions.mjs`(新):PNG/JPEG/WebP 走 header-only 解析;HEIC/TIFF 走 `sips -g pixelWidth/pixelHeight`(只读属性,不光栅化)。超过 16384px/边 或 50 MP → 退出码 1。
- `load-image-theme-macos.sh`:在 `ensure_node_runtime` 之后、`sips -Z` 之前跑这道预检。

## 测试 / Tests
- `image-metadata.test.mjs`:`readRawDimensions` 对超限图也返回真实尺寸(含构造的 20000×20000 PNG header)。
- `run-tests.sh`:新增行为测试——`check-image-dimensions.mjs` 拒绝 20000×20000(400 MP)、接受 1600×900。
- 本地用 Codex 捆绑 Node 验证:新增测试全过;整套 `run-tests.sh` 走到既有的环境依赖步骤(实机 theme-switch,需活动主题/运行中的 Codex)才停,与本改动无关(在干净树上同点同样失败)。

## 未包含 / Not included
多行 TOML 导致 install 整体中止的问题(#67)**特意不在本 PR 修**:现有拒绝是**有意的安全失败**——config 重写器是基于正则的伪解析,多行字符串/数组会骗过它、在 restore 时损坏配置,仓库现有 `multiline` / `multiline-array` 测试正是特意断言拒绝来防这个。安全的修法需要引入真正的 TOML 解析器,已在 #67 记录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
