### PR TITLE
docs(repo): add contribution guide

### DIFF
--- a/.github/CONTRIBUTING.en.md
+++ b/.github/CONTRIBUTING.en.md
@@ -1,0 +1,82 @@
+# Contributing guide
+
+<p align="center">
+  <a href="./CONTRIBUTING.md">中文</a> · <strong>English</strong>
+</p>
+
+Thanks for contributing to Codex Dream Skin. The project loads external themes into the official Codex desktop app through loopback CDP. macOS and Windows have separate install, injection, and restore paths, so choose the target platform before changing files.
+
+## Before you start
+
+1. Read the [project README](../README.en.md) and [platform reference](../docs/platforms.md). macOS usage is documented in [`macos/README.md`](../macos/README.md), while Windows implementation constraints live in [`windows/SKILL.md`](../windows/SKILL.md).
+2. Search the [existing issues](https://github.com/Fei-Away/Codex-Dream-Skin/issues) and [open pull requests](https://github.com/Fei-Away/Codex-Dream-Skin/pulls). If an active change already touches the same files, add to that discussion or split out a smaller change with no overlap.
+3. Create a branch from the latest upstream `main`. Keep each pull request focused on one problem. Do not mix a new theme, a runtime fix, and unrelated cleanup.
+
+## Filing an issue
+
+Use the repository's [bug or feature request forms](./ISSUE_TEMPLATE/) and search for duplicates first.
+
+A bug report should include:
+
+- The target platform, operating system version, and Codex installation source.
+- Stable reproduction steps, plus the expected and actual results.
+- Relevant logs or screenshots. Remove keys, `auth.json`, relay tokens, user-specific paths, and private conversations.
+- The last known working version or commit, when you can identify it.
+
+A feature request should explain the use case, expected behavior, alternatives considered, and whether it targets macOS, Windows, or both.
+
+## Development and verification
+
+Fork the repository and base your branch on the latest upstream `main`. Reuse existing scripts and platform helpers where possible. A small change should not require a new dependency.
+
+### macOS
+
+Run the full test suite:
+
+```bash
+(cd macos && npm test)
+```
+
+Check the environment and installation:
+
+```bash
+macos/scripts/doctor-macos.sh
+```
+
+For injection, CSS, launch, or restore changes, also run `macos/scripts/verify-dream-skin-macos.sh` and inspect both the home and normal task routes.
+
+### Windows
+
+Run the Windows regression suite:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\tests\run-tests.ps1
+```
+
+For install, launch, injection, or restore changes, exercise the affected scripts and `windows/scripts/verify-dream-skin.ps1`. Include the Windows version and Codex source in the pull request.
+
+### Documentation or repository metadata only
+
+Review every new or changed link and command, then run:
+
+```bash
+git diff --check
+```
+
+## Change constraints
+
+- Use two-space indentation in shell, PowerShell, JavaScript, JSON, and CSS. Keep `set -euo pipefail` in shell entry points, use ESM for Node files, and name scripts in kebab-case.
+- Add tests for affected install, start, inject, verify, pause, or restore behavior. Configuration changes must cover Chinese or other non-ASCII project names and preserve unrelated TOML content.
+- Read `config.toml` as strict UTF-8, write it atomically, and keep a recoverable backup. Do not rewrite it through an API that depends on the system's default encoding.
+- CDP must bind only to loopback. Do not modify the official `.app`, WindowsApps, `app.asar`, code signatures, API keys, or Base URLs.
+- Commit only files required by the change. Keep logs, temporary directories, build output, private screenshots, and local configuration out of the pull request.
+
+## Opening a pull request
+
+1. Use a `type(scope): summary` title, such as `fix(windows): preserve UTF-8 config on restore`.
+2. Complete the [pull request template](./pull_request_template.md) and check only the verification you completed. If a platform check is blocked by the environment, name the specific blocker in Notes and include the available static or fixture evidence.
+3. Link the issue with `Closes #123`. Visual changes need screenshots of the home and task routes with private conversations and credentials removed.
+4. User-visible macOS changes should update [`macos/CHANGELOG.md`](../macos/CHANGELOG.md). Update `macos/VERSION` when the change warrants a release. User-visible Windows changes should update [`windows/CHANGELOG.md`](../windows/CHANGELOG.md).
+5. Before submitting, review the diff, test output, and branch history against upstream `main`. Remove unrelated commits from the pull request.
+
+Maintainers may ask for a smaller scope, more evidence, or resolution of overlap with another open pull request. Continue updating the original pull request instead of opening duplicates for the same change.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# 贡献指南
+
+<p align="center">
+  <strong>中文</strong> · <a href="./CONTRIBUTING.en.md">English</a>
+</p>
+
+感谢你为 Codex Dream Skin 提交改进。这个项目通过本机回环 CDP 给官方 Codex 桌面应用加载外部主题。macOS 和 Windows 有独立的安装、注入与恢复路径，请先确定改动属于哪个平台，再缩小范围。
+
+## 开始之前
+
+1. 阅读[项目 README](../README.md)和[平台对照](../docs/platforms.md)。macOS 的使用说明在 [`macos/README.md`](../macos/README.md)，Windows 的实现约束在 [`windows/SKILL.md`](../windows/SKILL.md)。
+2. 搜索[现有 Issue](https://github.com/Fei-Away/Codex-Dream-Skin/issues)和[开放 PR](https://github.com/Fei-Away/Codex-Dream-Skin/pulls)。相同文件已有活跃改动时，优先补充原讨论，或把新方案拆成不重叠的小改动。
+3. 从最新的上游 `main` 创建分支。一个 PR 只解决一个问题，不要把新主题、运行时修复和无关整理混在一起。
+
+## 提交 Issue
+
+请使用仓库的 [Bug 或功能建议表单](./ISSUE_TEMPLATE/)。提交前先搜索重复项。
+
+Bug 报告应包含：
+
+- 目标平台、系统版本和 Codex 安装来源。
+- 能稳定复现的步骤，以及期望结果和实际结果。
+- 相关日志或截图。请先删除密钥、`auth.json`、中转 token、用户名路径和私人对话。
+- 最近一次已知正常的版本或提交，如果能够确认。
+
+功能建议应说明要解决的使用场景、期望行为、考虑过的替代方案，以及 macOS、Windows 或双平台范围。
+
+## 开发与验证
+
+请先 fork 仓库，并让分支基于最新的上游 `main`。尽量复用现有脚本和平台 helper，不要为小改动增加新依赖。
+
+### macOS
+
+运行完整测试：
+
+```bash
+(cd macos && npm test)
+```
+
+环境与安装诊断：
+
+```bash
+macos/scripts/doctor-macos.sh
+```
+
+改动注入、CSS、启动或恢复流程时，还要运行 `macos/scripts/verify-dream-skin-macos.sh`，并检查首页与普通任务页。
+
+### Windows
+
+运行 Windows 回归测试：
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\tests\run-tests.ps1
+```
+
+改动安装、启动、注入或恢复流程时，请运行对应脚本和 `windows/scripts/verify-dream-skin.ps1`，并在 PR 中注明 Windows 版本与 Codex 来源。
+
+### 仅文档或仓库元数据
+
+检查所有新增或修改的链接与命令，并运行：
+
+```bash
+git diff --check
+```
+
+## 改动约束
+
+- Shell、PowerShell、JavaScript、JSON 和 CSS 使用两个空格缩进。Shell 入口沿用 `set -euo pipefail`，Node 文件使用 ESM，脚本名称使用 kebab-case。
+- 为受影响的安装、启动、注入、验证、暂停或恢复行为补充测试。配置变更要覆盖中文或其他非 ASCII 项目名，并保留无关 TOML 内容。
+- `config.toml` 必须按严格 UTF-8 读取，原子写入，并保留可恢复备份。不要使用依赖系统默认编码的 API 重写它。
+- CDP 只能绑定本机回环地址。不要修改官方 `.app`、WindowsApps、`app.asar`、代码签名、API Key 或 Base URL。
+- 只提交这次改动需要的文件。不要带入日志、临时目录、构建产物、私人截图或本机配置。
+
+## 提交 PR
+
+1. 使用 `type(scope): summary` 标题，例如 `fix(windows): preserve UTF-8 config on restore`。
+2. 填完整 [PR 模板](./pull_request_template.md)，只勾选实际完成的检查。平台检查受环境限制时，在 Notes 写清具体限制，并提供能完成的静态检查或夹具测试结果。
+3. 用 `Closes #123` 关联对应 Issue。视觉改动要附首页和任务页截图，截图中不能包含私人对话或凭证。
+4. 用户可见的 macOS 改动应更新 [`macos/CHANGELOG.md`](../macos/CHANGELOG.md)；需要发布的新版本再更新 `macos/VERSION`。Windows 用户可见改动应更新 [`windows/CHANGELOG.md`](../windows/CHANGELOG.md)。
+5. 提交前重新检查 diff、测试结果和分支与上游 `main` 的差异，确认 PR 中没有无关提交。
+
+维护者可能要求缩小范围、补充验证或解决与其他开放 PR 的重叠。请继续在原 PR 更新，不要为同一改动重复开多个 PR。


### PR DESCRIPTION
## 中文

### 摘要

- 新增 `.github/CONTRIBUTING.md`，作为 GitHub 可识别的中文贡献入口。
- 新增 `.github/CONTRIBUTING.en.md`，提供内容对应、独立可读的英文指南，并在两份文件之间加入语言切换。
- 把仓库现有的 Issue/PR 流程、macOS 与 Windows 验证命令、文档检查、安全边界、changelog 规则和冲突规避方法整理为一条清晰的贡献路径。

### 类型

- [ ] 缺陷修复
- [ ] 新功能
- [x] 文档
- [ ] 主题或视觉
- [ ] 脚本或安装恢复
- [ ] 杂项

### 平台

- [ ] macOS
- [ ] Windows
- [ ] 双平台
- [x] 仅文档或仓库元数据

### 自测

- [x] 已检查全部新增链接、命令和表述。
- [x] 贡献指南定向校验通过：语言切换、章节结构、平台命令、路径和安全约束均已覆盖。
- [x] 仓库 Markdown 本地链接审计通过，共检查 28 个 Markdown 文件。
- [x] 新贡献者阅读测试通过，Issue 提交、文档检查、Windows 测试、CDP 边界、Issue 关联、重叠处理和 changelog 七项问题均可直接从指南中找到答案。
- [x] `git diff --check origin/main...HEAD` 通过。

### 用户可见变更

- [x] 无产品界面或运行时变更；这是面向贡献者的仓库文档。

### 安全

- [x] 未修改官方 Codex 安装、`app.asar` 或签名。
- [x] 未写入 API Base URL、API Key 或其他凭证。
- [x] 指南明确要求 CDP 仅绑定本机回环地址。

### 补充

- Closes #69
- 本 PR 只新增两个 `.github/CONTRIBUTING*` 文件，不修改根 README、PR 模板、主题资源或平台运行时代码。
- 分支基于当前上游 `main` 提交 `5fd8af5`，提交前已检查全部开放 PR，没有发现对这两个目标路径的改动。
- 选择 `.github/` 是因为 GitHub 会识别并在贡献入口以及创建 Issue/PR 时展示贡献指南，同时可以减少根目录改动和冲突面。参考：[GitHub 贡献指南文档](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors)。

## English

### Summary

- Add `.github/CONTRIBUTING.md` as a GitHub-recognized Chinese contribution entry point.
- Add `.github/CONTRIBUTING.en.md` as a complete standalone English guide, with language links between both files.
- Consolidate the repository's existing issue and pull request workflow, macOS and Windows verification commands, documentation checks, security boundaries, changelog rules, and overlap prevention into one contributor path.

### Type

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Theme / CSS / visual
- [ ] Scripts / install / restore
- [ ] Chore

### Platform

- [ ] macOS
- [ ] Windows
- [ ] Both
- [x] Docs / repo only

### Self-check

- [x] Every new link, command, and instruction was reviewed.
- [x] The focused contribution-guide validator passed for language links, section structure, platform commands, paths, and security constraints.
- [x] The repository-local Markdown link audit passed across 28 Markdown files.
- [x] The contributor reader test passed for all seven questions: issue filing, docs checks, Windows tests, the CDP boundary, issue linking, overlap handling, and changelog rules.
- [x] `git diff --check origin/main...HEAD` passed.

### User-facing change

- [x] N/A - this is contributor-facing repository documentation with no product UI or runtime change.

### Security

- [x] Does not modify the official Codex installation, `app.asar`, or signatures.
- [x] Does not write API Base URLs, API keys, or other credentials.
- [x] The guide explicitly keeps CDP bound to loopback.

### Notes

- Related issue: #69
- This pull request adds only the two `.github/CONTRIBUTING*` files. It leaves the root README, pull request template, theme assets, and platform runtime code unchanged.
- The branch is based on the current upstream `main` commit `5fd8af5`. All open pull requests were checked before submission, with no exact path overlap on either target file.
- `.github/` is used because GitHub recognizes and surfaces contribution guidelines at contribution entry points and while opening issues or pull requests, while keeping the root and conflict surface small. Reference: [GitHub documentation for contribution guidelines](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors).
