### PR TITLE
perf(macos): throttle renderer mutation refreshes

### DIFF
--- a/macos/CHANGELOG.md
+++ b/macos/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### 性能
+
+- 连续的 renderer DOM 变更现在以 120ms 窗口合并路由刷新，不再在流式输出期间按 `requestAnimationFrame` 频率重复扫描完整界面；外观、布局和路由状态仍在同一窗口内更新。
+
 ## 1.2.0 — 2026-07-17
 
 ### 新增

--- a/macos/assets/renderer-inject.js
+++ b/macos/assets/renderer-inject.js
@@ -11,6 +11,7 @@
   ];
   const VERSION = __DREAM_SKIN_VERSION_JSON__;
   const STYLE_REVISION = __DREAM_SKIN_STYLE_REVISION_JSON__;
+  const ROUTE_SETTLE_MS = 120;
   const THEME = themeConfig && typeof themeConfig === "object" ? themeConfig : {};
   const ART = THEME.art && typeof THEME.art === "object" ? THEME.art : {};
   const ART_METADATA = THEME.artMetadata && typeof THEME.artMetadata === "object"
@@ -662,9 +663,6 @@
     state?.resizeObserver?.disconnect();
     if (state?.timer) clearInterval(state.timer);
     if (state?.scheduler?.timeout) clearTimeout(state.scheduler.timeout);
-    if (state?.scheduler?.frame != null && typeof cancelAnimationFrame === "function") {
-      cancelAnimationFrame(state.scheduler.frame);
-    }
     if (analysisTimer) clearTimeout(analysisTimer);
     if (state?.resizeHandler) window.removeEventListener("resize", state.resizeHandler);
     if (state?.mediaHandler && state?.mediaQuery) {
@@ -675,13 +673,9 @@
     return true;
   };
 
-  const scheduler = { timeout: null, frame: null, root: false, route: false, layout: false };
+  const scheduler = { timeout: null, root: false, route: false, layout: false };
   const flushScheduledEnsure = () => {
-    if (scheduler.frame !== null && typeof cancelAnimationFrame === "function") {
-      cancelAnimationFrame(scheduler.frame);
-    }
     if (scheduler.timeout) clearTimeout(scheduler.timeout);
-    scheduler.frame = null;
     scheduler.timeout = null;
     const pending = { root: scheduler.root, route: scheduler.route, layout: scheduler.layout };
     scheduler.root = false;
@@ -693,13 +687,8 @@
     scheduler.root ||= root;
     scheduler.route ||= route;
     scheduler.layout ||= layout;
-    if (scheduler.timeout || scheduler.frame !== null) return;
-    if (typeof requestAnimationFrame === "function") {
-      scheduler.frame = requestAnimationFrame(flushScheduledEnsure);
-      scheduler.timeout = setTimeout(flushScheduledEnsure, 96);
-    } else {
-      scheduler.timeout = setTimeout(flushScheduledEnsure, 64);
-    }
+    if (scheduler.timeout) return;
+    scheduler.timeout = setTimeout(flushScheduledEnsure, ROUTE_SETTLE_MS);
   };
   const observer = new MutationObserver(() => scheduleEnsure({ route: true }));
   rootObserver = new MutationObserver(() => {

--- a/macos/tests/renderer-inject.test.mjs
+++ b/macos/tests/renderer-inject.test.mjs
@@ -358,7 +358,12 @@ assert.equal(defaultMetrics.routePasses, 1);
 assert.equal(defaultMetrics.layoutReads, 1);
 for (let index = 0; index < 50; index += 1) defaults.observers[0].callback([]);
 assert.equal(defaults.timers.size, 1, "Mutation bursts should coalesce into one scheduled ensure.");
-defaults.flushTimers(64);
+assert.deepEqual(
+  [...defaults.timers.values()].map(({ delay }) => delay),
+  [120],
+  "Continuous renderer mutations should be capped below animation-frame frequency.",
+);
+defaults.flushTimers(120);
 assert.equal(defaultMetrics.rootPasses, 1, "Subtree mutations must not recompute root theme tokens.");
 assert.equal(defaultMetrics.routePasses, 2);
 assert.equal(defaultMetrics.layoutReads, 1, "Subtree mutations must not force shell layout reads.");
@@ -367,7 +372,7 @@ assert.ok(defaults.resizeObservers[0].target);
 defaults.shellBox.left = 196;
 defaults.shellBox.width = 1084;
 defaults.resizeObservers[0].callback([]);
-defaults.flushTimers(64);
+defaults.flushTimers(120);
 assert.equal(defaultMetrics.layoutReads, 2, "Shell ResizeObserver changes must refresh chrome geometry.");
 const defaultChrome = defaults.nodes.get("codex-dream-skin-chrome");
 assert.equal(defaultChrome.style.values.get("left"), "196px");
@@ -395,7 +400,7 @@ assert.equal(shellFollow.attributes.get("data-dream-shell"), "light");
 defaults.root.className = "";
 defaults.body.setAttribute("data-theme", "dark");
 defaults.observers[1].callback([{ type: "attributes", target: defaults.body }]);
-defaults.flushTimers(64);
+defaults.flushTimers(120);
 assert.equal(defaults.attributes.get("data-dream-shell"), "dark", "Body theme changes must apply without the fallback interval.");
 
 const synchronousWide = createFixture({


### PR DESCRIPTION
## Summary / 摘要

- Replace animation-frame mutation refreshes with one 120ms settlement window in the macOS renderer.
- Coalesce continuous streamed DOM changes into at most one route scan per window while preserving accumulated root, route, and layout work flags.
- Remove the now-unused frame bookkeeping and add a deterministic regression assertion for the scheduling interval.

Addresses #72.

This is a focused continuation of the useful renderer-overhead direction from closed PR #35. The current main branch already contains newer write/layout optimizations, so this PR only addresses the remaining animation-frame-frequency scan path.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [x] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

Check what you actually ran. Skip items that do not apply and say so under Notes.

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed)

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised
- [x] Environment noted below (OS build, Codex source)

### User-facing / 用户可见变更

- [x] Updated `macos/CHANGELOG.md` (no version bump)
- [ ] N/A — no user-facing change

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures
- [x] Does **not** silently write API Base URL or keys
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable

## Notes / 补充

- macOS renderer regression: PASS. Fifty consecutive subtree mutation callbacks produce one scheduled route refresh with an asserted 120ms delay.
- macOS image-metadata, injector-bootstrap, renderer, and payload checks: PASS.
- Windows aggregate suite: PASS. Cleanup warnings are deliberate forced-failure fixtures.
- `node --check macos/assets/renderer-inject.js` and `git diff --check`: PASS.
- The complete macOS shell suite, Doctor, live injection, and live CPU profiling were not run because this contribution was prepared on Windows.
- The 120ms interval caps continuous mutation-driven scans at approximately 8.3 per second instead of animation-frame frequency while keeping UI state latency below the existing Windows renderer's 180ms window.
- The 4-second safety interval, image analysis, CDP polling, CSS, and visual output are unchanged.
- No screenshot is included because this is a scheduling-only performance change with no intended visual difference.
- Environment: Windows 11 build 26200; Codex Desktop Microsoft Store 26.707.12708; Node.js 24.17.0; Windows PowerShell 5.1.
