### PR TITLE
docs(security): explain unauthenticated loopback CDP

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -166,9 +166,11 @@ More detail:
 
 ## Safety
 
-- CDP binds `127.0.0.1` only — avoid untrusted local processes while the theme runs.
+- CDP binds `127.0.0.1` only, but it has **no authentication**; another process on the same computer may still connect and inspect or control the renderer.
+- Pausing the theme or stopping only the injector does not close the debug port of an already running Codex process. Use a full Restore/restart, or quit every Codex process and reopen the official app normally, to end the exposure window.
 - Does not touch the official install directory or code signature.
 - **Never** rewrites API Key / Base URL; relay and theme stay separate.
+- See [`SECURITY.md`](./SECURITY.md) for the complete threat model and operating guidance.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,11 @@ powershell -ExecutionPolicy Bypass -File .\windows\scripts\start-dream-skin.ps1
 
 ## 安全边界
 
-- CDP 只绑 `127.0.0.1`，主题运行期间勿跑来路不明的本机程序
+- CDP 只绑 `127.0.0.1`，但**没有身份认证**；同一台电脑上的其他进程仍可能连接并读取或控制 renderer
+- 暂停主题或只停止 injector 不会关闭已启动 Codex 的调试端口；使用完整 Restore/重启，或退出全部 Codex 后从官方普通入口重新打开，风险窗口才结束
 - 不修改官方安装目录与代码签名
 - **不会**自动改写 API Key / Base URL；中转与换肤分开
+- 完整威胁模型与操作建议见 [`SECURITY.md`](./SECURITY.md)
 
 ## 许可与声明
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security boundary / 安全边界
+
+Codex Dream Skin is an unofficial local customization tool. It avoids modifying
+the official Codex package, but it relies on the Chrome DevTools Protocol (CDP)
+to inject the theme into a running Codex renderer.
+
+Codex Dream Skin 是非官方本地定制工具。它不会修改官方 Codex 安装包，但需要通过
+Chrome DevTools Protocol（CDP）向正在运行的 Codex renderer 注入主题。
+
+## Loopback is not authentication / 回环地址不等于身份认证
+
+The debug listener is restricted to `127.0.0.1`, which prevents a direct
+connection from another machine. CDP itself has no authentication, however.
+While the CDP-enabled Codex process is running, another process on the same
+computer can attempt to connect to that listener.
+
+CDP can inspect page content, execute JavaScript in the renderer, and interact
+with the active session. A hostile local process may therefore be able to read
+visible conversation or workspace data and act with the renderer's privileges.
+A host firewall does not isolate one local process from another, and loopback
+binding must not be described as a sandbox or a trust boundary.
+
+调试端口只绑定 `127.0.0.1`，因此其他电脑不能直接连接；但 CDP 本身没有认证。
+只要带 CDP 参数启动的 Codex 仍在运行，同一台电脑上的其他进程就可能尝试连接。
+
+CDP 能读取页面内容、在 renderer 中执行 JavaScript，并操作当前会话。因此，恶意本机
+进程可能读取可见的对话或工作区数据，并以 renderer 的权限执行操作。本机防火墙不能
+隔离同一设备上的两个进程；“仅回环”不能被理解为沙箱或身份认证边界。
+
+## When exposure starts and ends / 风险窗口何时开始和结束
+
+- The window starts when Dream Skin launches Codex with a
+  `--remote-debugging-port` argument.
+- Pausing the theme, removing its CSS, or stopping only the injector does not
+  remove that launch argument from an already running Codex process.
+- The window ends after the CDP-enabled Codex process has fully exited and the
+  official app has been reopened normally without the Dream Skin launcher.
+- The platform Restore flows can perform that full restart when their restart
+  option is selected. Merely hiding the theme is not equivalent to closing CDP.
+
+- Dream Skin 使用 `--remote-debugging-port` 参数启动 Codex 时，风险窗口开始。
+- 暂停主题、移除 CSS 或只停止 injector，不会从仍在运行的 Codex 进程中移除启动参数。
+- 完全退出该 Codex 进程，并通过普通官方入口重新启动（不经过 Dream Skin 启动器）后，
+  风险窗口才结束。
+- 两个平台的 Restore 流程在选择完整重启时可以完成上述操作；只隐藏主题不等于关闭 CDP。
+
+## Recommended operation / 建议操作
+
+1. Use Dream Skin only on a trusted personal device and trusted OS account.
+2. Do not run unknown executables, scripts, browser extensions, or local
+   development services while a CDP-enabled Codex session is active.
+3. Never forward, proxy, tunnel, or rebind the debug port beyond loopback.
+4. Do not share CDP logs, screenshots, `auth.json`, API keys, relay tokens, or
+   private conversation content in an issue or pull request.
+5. When finished, use a full Restore/restart or quit every Codex process and
+   reopen Codex from its normal official entry point.
+
+1. 只在可信个人设备和可信系统账户中使用 Dream Skin。
+2. CDP 会话运行期间，不要运行来源不明的程序、脚本、浏览器扩展或本地服务。
+3. 不要把调试端口转发、代理、隧道化或重新绑定到非回环地址。
+4. Issue 或 PR 中不要上传 CDP 日志、截图、`auth.json`、API Key、中转 token 或私人对话。
+5. 使用结束后执行完整 Restore/重启，或退出全部 Codex 进程，再从官方普通入口启动。
+
+## What the project validates / 项目会校验什么
+
+The platform scripts validate the expected Codex installation or package,
+process identity, loopback listener ownership, renderer target shape, and
+recorded injector state before performing sensitive lifecycle operations.
+Those checks reduce accidental targeting and stale-process mistakes. They do
+not add authentication to CDP and do not protect Codex from other software that
+is already running on the same computer.
+
+平台脚本会在敏感生命周期操作前校验 Codex 安装或包身份、进程身份、回环监听归属、
+renderer 目标形状和已记录的 injector 状态。这些校验能减少误操作和陈旧进程问题，
+但不会给 CDP 增加认证，也不能防御同一台电脑上已经运行的其他软件。

--- a/macos/README.md
+++ b/macos/README.md
@@ -70,7 +70,11 @@ That ZIP contains a visible installer plus a hidden `.codex-dream-skin-studio` e
 8. Config backup/restore requires Codex to be closed, strict UTF-8, an operation
    lock, same-directory atomic replacement, and an unchanged-byte check.
 
-CDP is powerful and unauthenticated on loopback. Prefer Restore when you are done theming.
+CDP is powerful and unauthenticated on loopback. Another process on the same
+computer may connect while the CDP-enabled Codex process is running. Removing
+the CSS or stopping only the injector does not remove the debug-port launch
+argument; use Restore with `--restart-codex`, or fully quit Codex and reopen it
+normally, to end the exposure window. See [`../SECURITY.md`](../SECURITY.md).
 
 ## Bundled presets
 

--- a/windows/README.en.md
+++ b/windows/README.en.md
@@ -142,9 +142,11 @@ Open the repository's [new issue page](https://github.com/Fei-Away/Codex-Dream-S
 
 ## Security boundaries
 
-- CDP binds only to `127.0.0.1`. Avoid untrusted local software while the skin is active.
+- CDP binds only to `127.0.0.1`, but it has no authentication; another process on the same computer may still connect and inspect or control the renderer.
+- Pausing the theme or stopping only the injector does not close the debug port of a running Codex process. Use a full restore with restart, or quit every Codex process and reopen the official app normally, to end the exposure window.
 - The tool does not modify the official Codex installation, WindowsApps, `app.asar`, or signatures.
 - It does not write API keys, Base URLs, or model provider settings.
 - Restore controls only Codex processes that pass package identity, executable path, and recorded session checks.
+- See [`../SECURITY.md`](../SECURITY.md) for the complete threat model and operating guidance.
 
 Maintainer and agent constraints live in [`SKILL.md`](./SKILL.md). See [`references/runtime-notes.md`](./references/runtime-notes.md) for deeper runtime troubleshooting.

--- a/windows/README.md
+++ b/windows/README.md
@@ -142,9 +142,11 @@ Get-AppxPackage -Name OpenAI.Codex
 
 ## 安全边界
 
-- CDP 只绑定 `127.0.0.1`。皮肤运行期间不要运行来路不明的本机程序。
+- CDP 只绑定 `127.0.0.1`，但没有身份认证；同一台电脑上的其他进程仍可能连接并读取或控制 renderer。
+- 暂停主题或只停止 injector 不会关闭正在运行的 Codex 调试端口；执行带重启的完整恢复，或退出全部 Codex 后从官方普通入口重新打开，风险窗口才结束。
 - 不修改官方 Codex 安装目录、WindowsApps、`app.asar` 或签名。
 - 不写入 API Key、Base URL 或模型供应商配置。
 - 恢复脚本只会控制经过包身份、进程路径和会话状态校验的 Codex 进程。
+- 完整威胁模型与操作建议见 [`../SECURITY.md`](../SECURITY.md)。
 
 维护者和代理使用的实现约束见 [`SKILL.md`](./SKILL.md)，运行时排错细节见 [`references/runtime-notes.md`](./references/runtime-notes.md)。


### PR DESCRIPTION
## Summary / 摘要

- Add a bilingual root security-boundary document explaining that loopback CDP is network-restricted but unauthenticated.
- Describe the concrete renderer capabilities available to another local process and distinguish package-integrity checks from CDP authentication.
- Document the exact exposure lifecycle: pausing/removing the skin or stopping only the injector does not remove the debug-port argument from a running Codex process.
- Link the same guidance from both root READMEs and the macOS/Windows platform READMEs, including the full Restore/restart procedure that ends the exposure window.

Closes #18.

## Type / 类型

- [ ] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [x] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [ ] Windows
- [x] Both / 双平台
- [x] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

Check what you actually ran. Skip items that do not apply and say so under Notes.

### Docs-only / 仅文档

- [x] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed)

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised
- [x] Environment noted below (OS build, Codex source)

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy)
- [ ] N/A — no user-facing change

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures
- [x] Does **not** silently write API Base URL or keys
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable

## Notes / 补充

- Verified every changed Markdown file is valid UTF-8 and every relative link resolves to an existing repository path.
- Reviewed the lifecycle wording against both restore implementations: macOS requires the restart option to remove the running process's debug argument; Windows full restore closes the saved CDP session and can relaunch the official app normally.
- `git diff --check`: PASS.
- No runtime code, theme asset, installer behavior, CDP binding, configuration, or release version changes.
- Platform test, Doctor, Verify, and restore checkboxes are not applicable to this documentation-only PR.
- Changelogs are intentionally unchanged because the PR only makes the existing security model explicit.
- Environment used for repository/link review: Windows 11 build 26200.
