### PR TITLE
feat(windows): add managed Dream Skin icon

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Windows Changelog
 
+## Unreleased
+
+### 新增
+
+- 安装器会用纯 PowerShell/System.Drawing 生成原创的 7 尺寸 Dream Skin ICO，并把受管 engine 中的稳定图标绑定到启动、托盘与恢复快捷方式；托盘在图标缺失或损坏时安全回退到 Windows 系统图标。
+
 ## 1.2.0 — 2026-07-17
 
 ### 新增

--- a/windows/README.en.md
+++ b/windows/README.en.md
@@ -28,6 +28,8 @@ The installer validates the official Codex Store package and Node.js, saves a re
 - `Codex Dream Skin - Tray`: open the system tray theme controls.
 - `Codex Dream Skin - Restore`: restore the stock appearance and close the saved CDP session.
 
+The installer generates an original multi-size Dream Skin icon inside the managed engine and assigns it to the tray and these shortcuts, so it remains available after the source checkout is moved or removed. The tray safely falls back to the Windows system icon when the resource is missing or damaged.
+
 Pass `-Port` during installation to use a fixed custom port. Valid ports range from `1024` through `65535`.
 
 ```powershell

--- a/windows/README.md
+++ b/windows/README.md
@@ -28,6 +28,8 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-dream-
 - `Codex Dream Skin - Tray`：打开系统托盘主题控制。
 - `Codex Dream Skin - Restore`：恢复官方外观并关闭已保存的 CDP 会话。
 
+安装器会在受管 engine 中生成原创的多尺寸 Dream Skin 图标，并将其用于托盘和以上快捷方式；因此移动或删除源码仓库后图标仍然有效。资源缺失或损坏时，托盘会自动回退到 Windows 系统图标。
+
 如需使用自定义端口，可以在安装时传入 `-Port`。端口范围必须是 `1024` 到 `65535`。
 
 ```powershell

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -132,6 +132,7 @@ function Install-DreamSkinRuntimeEngine {
     'assets\theme.json',
     'scripts\common-windows.ps1',
     'scripts\config-utf8.ps1',
+    'scripts\icon-windows.ps1',
     'scripts\image-metadata.mjs',
     'scripts\injector.mjs',
     'scripts\install-dream-skin.ps1',

--- a/windows/scripts/icon-windows.ps1
+++ b/windows/scripts/icon-windows.ps1
@@ -1,0 +1,169 @@
+Add-Type -AssemblyName System.Drawing
+
+function New-DreamSkinRoundedRectanglePath {
+  param(
+    [Parameter(Mandatory = $true)][single]$X,
+    [Parameter(Mandatory = $true)][single]$Y,
+    [Parameter(Mandatory = $true)][single]$Width,
+    [Parameter(Mandatory = $true)][single]$Height,
+    [Parameter(Mandatory = $true)][single]$Radius
+  )
+  $diameter = [single]($Radius * 2)
+  $path = [System.Drawing.Drawing2D.GraphicsPath]::new()
+  [void]$path.AddArc($X, $Y, $diameter, $diameter, 180, 90)
+  [void]$path.AddArc($X + $Width - $diameter, $Y, $diameter, $diameter, 270, 90)
+  [void]$path.AddArc($X + $Width - $diameter, $Y + $Height - $diameter, $diameter, $diameter, 0, 90)
+  [void]$path.AddArc($X, $Y + $Height - $diameter, $diameter, $diameter, 90, 90)
+  $path.CloseFigure()
+  return $path
+}
+
+function New-DreamSkinIconFrame {
+  param([Parameter(Mandatory = $true)][ValidateRange(16, 256)][int]$Size)
+  $scale = [single]($Size / 64.0)
+  $bitmap = [System.Drawing.Bitmap]::new(
+    $Size,
+    $Size,
+    [System.Drawing.Imaging.PixelFormat]::Format32bppArgb
+  )
+  $graphics = $null
+  $background = $null
+  $gradient = $null
+  $border = $null
+  $brushPen = $null
+  $sparklePen = $null
+  $paintDrop = $null
+  $memory = $null
+  try {
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    $graphics.Clear([System.Drawing.Color]::Transparent)
+    $graphics.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::AntiAlias
+    $graphics.PixelOffsetMode = [System.Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+    $background = New-DreamSkinRoundedRectanglePath `
+      -X (2 * $scale) -Y (2 * $scale) -Width (60 * $scale) -Height (60 * $scale) -Radius (14 * $scale)
+    $gradient = [System.Drawing.Drawing2D.LinearGradientBrush]::new(
+      [System.Drawing.RectangleF]::new(0, 0, $Size, $Size),
+      [System.Drawing.Color]::FromArgb(255, 92, 103, 232),
+      [System.Drawing.Color]::FromArgb(255, 244, 82, 146),
+      42.0
+    )
+    $graphics.FillPath($gradient, $background)
+
+    $border = [System.Drawing.Pen]::new(
+      [System.Drawing.Color]::FromArgb(115, 255, 255, 255),
+      [single][Math]::Max(1.0, 1.5 * $scale)
+    )
+    $graphics.DrawPath($border, $background)
+
+    $brushPen = [System.Drawing.Pen]::new(
+      [System.Drawing.Color]::White,
+      [single][Math]::Max(1.8, 6.0 * $scale)
+    )
+    $brushPen.StartCap = [System.Drawing.Drawing2D.LineCap]::Round
+    $brushPen.EndCap = [System.Drawing.Drawing2D.LineCap]::Round
+    $graphics.DrawLine($brushPen, 18 * $scale, 47 * $scale, 39 * $scale, 26 * $scale)
+
+    $paintDrop = [System.Drawing.SolidBrush]::new([System.Drawing.Color]::FromArgb(255, 116, 236, 226))
+    $graphics.FillEllipse($paintDrop, 13 * $scale, 42 * $scale, 10 * $scale, 10 * $scale)
+
+    $sparklePen = [System.Drawing.Pen]::new(
+      [System.Drawing.Color]::White,
+      [single][Math]::Max(1.2, 2.5 * $scale)
+    )
+    $sparklePen.StartCap = [System.Drawing.Drawing2D.LineCap]::Round
+    $sparklePen.EndCap = [System.Drawing.Drawing2D.LineCap]::Round
+    $graphics.DrawLine($sparklePen, 47 * $scale, 11 * $scale, 47 * $scale, 22 * $scale)
+    $graphics.DrawLine($sparklePen, 41.5 * $scale, 16.5 * $scale, 52.5 * $scale, 16.5 * $scale)
+    $graphics.DrawLine($sparklePen, 50 * $scale, 31 * $scale, 50 * $scale, 37 * $scale)
+    $graphics.DrawLine($sparklePen, 47 * $scale, 34 * $scale, 53 * $scale, 34 * $scale)
+
+    $memory = [System.IO.MemoryStream]::new()
+    $bitmap.Save($memory, [System.Drawing.Imaging.ImageFormat]::Png)
+    return ,([byte[]]$memory.ToArray())
+  } finally {
+    if ($null -ne $memory) { $memory.Dispose() }
+    if ($null -ne $paintDrop) { $paintDrop.Dispose() }
+    if ($null -ne $sparklePen) { $sparklePen.Dispose() }
+    if ($null -ne $brushPen) { $brushPen.Dispose() }
+    if ($null -ne $border) { $border.Dispose() }
+    if ($null -ne $gradient) { $gradient.Dispose() }
+    if ($null -ne $background) { $background.Dispose() }
+    if ($null -ne $graphics) { $graphics.Dispose() }
+    $bitmap.Dispose()
+  }
+}
+
+function Get-DreamSkinIcon {
+  param([Parameter(Mandatory = $true)][string]$Path)
+  try {
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) { return $null }
+    if ((Get-Item -LiteralPath $fullPath -Force).Length -lt 22) { return $null }
+    return [System.Drawing.Icon]::new($fullPath)
+  } catch {
+    return $null
+  }
+}
+
+function New-DreamSkinIconFile {
+  param([Parameter(Mandatory = $true)][string]$Path)
+  $fullPath = [System.IO.Path]::GetFullPath($Path)
+  $directory = [System.IO.Path]::GetDirectoryName($fullPath)
+  if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
+    throw "Dream Skin icon directory does not exist: $directory"
+  }
+  $sizes = @(16, 24, 32, 48, 64, 128, 256)
+  $frames = [System.Collections.Generic.List[byte[]]]::new()
+  foreach ($size in $sizes) {
+    $frames.Add([byte[]](New-DreamSkinIconFrame -Size $size))
+  }
+
+  $temporary = Join-Path $directory ('.dream-skin-icon-' + [guid]::NewGuid().ToString('N') + '.tmp')
+  $stream = $null
+  $writer = $null
+  try {
+    $stream = [System.IO.FileStream]::new(
+      $temporary,
+      [System.IO.FileMode]::CreateNew,
+      [System.IO.FileAccess]::Write,
+      [System.IO.FileShare]::None
+    )
+    $writer = [System.IO.BinaryWriter]::new($stream)
+    $writer.Write([uint16]0)
+    $writer.Write([uint16]1)
+    $writer.Write([uint16]$frames.Count)
+    $offset = [uint32](6 + (16 * $frames.Count))
+    for ($index = 0; $index -lt $frames.Count; $index++) {
+      $size = $sizes[$index]
+      $frame = $frames[$index]
+      $encodedSize = if ($size -eq 256) { [byte]0 } else { [byte]$size }
+      $writer.Write($encodedSize)
+      $writer.Write($encodedSize)
+      $writer.Write([byte]0)
+      $writer.Write([byte]0)
+      $writer.Write([uint16]1)
+      $writer.Write([uint16]32)
+      $writer.Write([uint32]$frame.Length)
+      $writer.Write($offset)
+      $offset = [uint32]($offset + $frame.Length)
+    }
+    foreach ($frame in $frames) { $writer.Write([byte[]]$frame) }
+    $writer.Flush()
+    $writer.Dispose()
+    $writer = $null
+    $stream.Dispose()
+    $stream = $null
+
+    $validationIcon = Get-DreamSkinIcon -Path $temporary
+    if ($null -eq $validationIcon) { throw 'Generated Dream Skin icon failed validation.' }
+    $validationIcon.Dispose()
+    Move-Item -LiteralPath $temporary -Destination $fullPath -Force -ErrorAction Stop
+    return $fullPath
+  } finally {
+    if ($null -ne $writer) { $writer.Dispose() }
+    if ($null -ne $stream) { $stream.Dispose() }
+    if (Test-Path -LiteralPath $temporary) {
+      Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+    }
+  }
+}

--- a/windows/scripts/install-dream-skin.ps1
+++ b/windows/scripts/install-dream-skin.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = 'Stop'
 $PortExplicit = $PSBoundParameters.ContainsKey('Port')
 $SkillRoot = Split-Path -Parent $PSScriptRoot
 . (Join-Path $PSScriptRoot 'common-windows.ps1')
+. (Join-Path $PSScriptRoot 'icon-windows.ps1')
 . (Join-Path $PSScriptRoot 'theme-windows.ps1')
 
 $operationLock = Enter-DreamSkinOperationLock
@@ -39,6 +40,13 @@ try {
     throw 'Exit the Codex Dream Skin tray before reinstalling so every shortcut can move to the new runtime safely.'
   }
   $engine = Install-DreamSkinRuntimeEngine -SkillRoot $SkillRoot -StateRoot $StateRoot
+  $iconPath = Join-Path $engine.Root 'assets\dream-skin.ico'
+  try {
+    $iconPath = New-DreamSkinIconFile -Path $iconPath
+  } catch {
+    Write-Warning "Could not create the Dream Skin icon; system icon fallback will be used: $($_.Exception.Message)"
+    $iconPath = $null
+  }
   $null = Initialize-DreamSkinThemeStore -SkillRoot $engine.Root -StateRoot $StateRoot
   $ConfigPath = Join-Path $HOME '.codex\config.toml'
   $BackupPath = Join-Path $StateRoot 'config.before-dream-skin.toml'
@@ -60,6 +68,7 @@ try {
       $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$startScript`"$portArgument -PromptRestart"
       $shortcut.WorkingDirectory = $engine.Root
       $shortcut.Description = 'Launch the official Codex app with Codex Dream Skin'
+      if ($null -ne $iconPath) { $shortcut.IconLocation = "$iconPath,0" }
       $shortcut.Save()
     }
 
@@ -68,6 +77,7 @@ try {
     $restore.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$restoreScript`"$portArgument -RestoreBaseTheme -PromptRestart"
     $restore.WorkingDirectory = $engine.Root
     $restore.Description = 'Restore the official Codex appearance and close the CDP session'
+    if ($null -ne $iconPath) { $restore.IconLocation = "$iconPath,0" }
     $restore.Save()
 
     foreach ($folder in @($desktop, $startMenu)) {
@@ -76,6 +86,7 @@ try {
       $tray.Arguments = "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$trayScript`"$portArgument"
       $tray.WorkingDirectory = $engine.Root
       $tray.Description = 'Open Codex Dream Skin status and theme controls in the system tray'
+      if ($null -ne $iconPath) { $tray.IconLocation = "$iconPath,0" }
       $tray.Save()
     }
     Start-Process -FilePath $powershell -ArgumentList `

--- a/windows/scripts/tray-dream-skin.ps1
+++ b/windows/scripts/tray-dream-skin.ps1
@@ -6,6 +6,7 @@ Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 Add-Type -AssemblyName Microsoft.VisualBasic
 . (Join-Path $PSScriptRoot 'common-windows.ps1')
+. (Join-Path $PSScriptRoot 'icon-windows.ps1')
 . (Join-Path $PSScriptRoot 'theme-windows.ps1')
 
 Assert-DreamSkinPort -Port $Port
@@ -19,12 +20,18 @@ $restoreScript = Join-Path $PSScriptRoot 'restore-dream-skin.ps1'
 $sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
 $mutex = [System.Threading.Mutex]::new($false, "Local\CodexDreamSkin.$sid.Tray")
 $acquired = $false
+$customIcon = $null
 try {
   try { $acquired = $mutex.WaitOne(0) } catch [System.Threading.AbandonedMutexException] { $acquired = $true }
   if (-not $acquired) { exit 0 }
 
   $notify = [System.Windows.Forms.NotifyIcon]::new()
-  $notify.Icon = [System.Drawing.SystemIcons]::Application
+  $customIcon = Get-DreamSkinIcon -Path (Join-Path $SkillRoot 'assets\dream-skin.ico')
+  if ($null -ne $customIcon) {
+    $notify.Icon = $customIcon
+  } else {
+    $notify.Icon = [System.Drawing.SystemIcons]::Application
+  }
   $notify.Text = 'Codex Dream Skin'
   $notify.Visible = $true
   $menu = [System.Windows.Forms.ContextMenuStrip]::new()
@@ -162,6 +169,7 @@ try {
   [System.Windows.Forms.Application]::Run()
 } finally {
   if ($null -ne $notify) { $notify.Dispose() }
+  if ($null -ne $customIcon) { $customIcon.Dispose() }
   if ($acquired) { try { $mutex.ReleaseMutex() } catch {} }
   $mutex.Dispose()
 }

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -4,6 +4,7 @@ param([switch]$EngineOnly)
 $ErrorActionPreference = 'Stop'
 $Root = Split-Path -Parent $PSScriptRoot
 . (Join-Path $Root 'scripts\common-windows.ps1')
+. (Join-Path $Root 'scripts\icon-windows.ps1')
 . (Join-Path $Root 'scripts\theme-windows.ps1')
 
 $temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) "codex-dream-skin-tests-$PID-$([guid]::NewGuid().ToString('N'))"
@@ -129,12 +130,41 @@ try {
     '$trayScript = $engine.Tray',
     '$shortcut.WorkingDirectory = $engine.Root',
     '$restore.WorkingDirectory = $engine.Root',
-    '$tray.WorkingDirectory = $engine.Root'
+    '$tray.WorkingDirectory = $engine.Root',
+    '$shortcut.IconLocation = "$iconPath,0"',
+    '$restore.IconLocation = "$iconPath,0"',
+    '$tray.IconLocation = "$iconPath,0"'
   )) {
     if (-not $installSource.Contains($requiredShortcutBinding)) {
       throw "Installer shortcut still depends on its source checkout: $requiredShortcutBinding"
     }
   }
+
+  $installedIcon = Join-Path $engine.Root 'assets\dream-skin.ico'
+  $null = New-DreamSkinIconFile -Path $installedIcon
+  $iconBytes = [System.IO.File]::ReadAllBytes($installedIcon)
+  if ($iconBytes.Length -lt 22 -or
+    [System.BitConverter]::ToUInt16($iconBytes, 0) -ne 0 -or
+    [System.BitConverter]::ToUInt16($iconBytes, 2) -ne 1 -or
+    [System.BitConverter]::ToUInt16($iconBytes, 4) -ne 7) {
+    throw 'Generated Dream Skin icon does not contain a valid seven-frame ICO directory.'
+  }
+  $iconSizes = for ($index = 0; $index -lt 7; $index++) {
+    $width = [int]$iconBytes[6 + (16 * $index)]
+    if ($width -eq 0) { 256 } else { $width }
+  }
+  if (($iconSizes -join ',') -cne '16,24,32,48,64,128,256') {
+    throw "Generated Dream Skin icon has the wrong frame sizes: $($iconSizes -join ',')"
+  }
+  $loadedIcon = Get-DreamSkinIcon -Path $installedIcon
+  if ($null -eq $loadedIcon) { throw 'Generated Dream Skin icon could not be loaded by System.Drawing.' }
+  $loadedIcon.Dispose()
+  $corruptIcon = Join-Path $temporaryRoot 'corrupt.ico'
+  [System.IO.File]::WriteAllBytes($corruptIcon, [byte[]](0, 1, 2, 3))
+  if ($null -ne (Get-DreamSkinIcon -Path $corruptIcon)) {
+    throw 'Corrupt Dream Skin icon did not use the safe fallback path.'
+  }
+  Remove-Item -LiteralPath $corruptIcon -Force
 
   Remove-Item -LiteralPath $runtimeSourceRoot -Recurse -Force
   foreach ($installedScript in Get-ChildItem -LiteralPath $engine.Scripts -Filter '*.ps1' -File) {
@@ -149,8 +179,9 @@ try {
   }
   if (-not (Test-Path -LiteralPath $engine.Start -PathType Leaf) -or
     -not (Test-Path -LiteralPath $engine.Restore -PathType Leaf) -or
-    -not (Test-Path -LiteralPath $engine.Tray -PathType Leaf)) {
-    throw 'Installed launch, restore, or tray entry point disappeared with the source checkout.'
+    -not (Test-Path -LiteralPath $engine.Tray -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $installedIcon -PathType Leaf)) {
+    throw 'Installed launch, restore, tray, or icon resource disappeared with the source checkout.'
   }
   Remove-Item -LiteralPath $invalidRuntimeRoot, $runtimeStateRoot -Recurse -Force
 


### PR DESCRIPTION
## Summary / 摘要

- Generate an original Dream Skin ICO at install time with seven PNG-compressed sizes from 16px through 256px, using only bundled PowerShell and System.Drawing APIs.
- Store the generated icon inside the managed runtime so Start Menu, desktop, restore, and tray shortcuts remain valid after the source checkout is moved or removed.
- Load the same managed icon in the notification area, with a safe Windows system-icon fallback when the resource is missing, corrupt, or cannot be generated.
- Add PowerShell 5.1 regression coverage for ICO structure, Windows icon loading, corrupt-resource fallback, shortcut bindings, and source-independent runtime staging.
- Document the user-visible behavior in both Windows READMEs and the Windows changelog.

Closes #85.

## Type / 类型

- [ ] Bug fix / 缺陷修复
- [x] Feature / 新功能
- [ ] Docs / 文档
- [x] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

Check what you actually ran. Skip items that do not apply and say so under Notes.
请勾选**实际跑过**的项；不适用的在 Notes 说明。

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [x] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [x] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\tests\run-tests.ps1`: PASS. This covers managed runtime staging/replacement, generated ICO headers and all seven frame sizes, `System.Drawing.Icon` loading, corrupt-resource fallback, source-removal survival, and shortcut icon bindings.
- Generated the real multi-frame ICO separately, loaded it through the same runtime helper, extracted the 256px frame, and visually reviewed transparency, padding, contrast, and legibility.
- Parsed every changed PowerShell file with the Windows PowerShell parser and ran `git diff --check`: PASS.
- The icon is drawn deterministically from code; no downloaded image, external asset license, new dependency, official package patch, or user-controlled executable content is introduced.
- Updated `windows/CHANGELOG.md`; the template's macOS changelog checkbox does not apply to this Windows-only change.
- macOS tests, Doctor, live Verify, restore/re-apply smoke, and docs-only checks do not apply because no macOS path changes and this is not a docs-only PR.
- Environment: Windows 11 Home build 26200; Windows PowerShell 5.1.26100.8875; Microsoft Store `OpenAI.Codex` package 26.707.12708.0.
