### PR TITLE
feat(windows): clarify launcher and theme manager UX

### DIFF
--- a/windows/README.en.md
+++ b/windows/README.en.md
@@ -24,8 +24,8 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-dream-
 
 The installer validates the official Codex Store package and Node.js, saves a recoverable appearance baseline, and initializes the local theme store. By default it also creates these shortcuts:
 
-- `Codex Dream Skin`: launch or reapply the skin.
-- `Codex Dream Skin - Tray`: open the system tray theme controls.
+- `Codex Dream Skin`: silently launch or reapply the skin; failures show an error dialog and log path.
+- `Codex Dream Skin - Theme Manager`: open the system tray theme controls.
 - `Codex Dream Skin - Restore`: restore the stock appearance and close the saved CDP session.
 
 Pass `-Port` during installation to use a fixed custom port. Valid ports range from `1024` through `65535`.
@@ -36,7 +36,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-dream-
 
 ## Launch and verify
 
-The `Codex Dream Skin` shortcut is the recommended launcher. It asks for confirmation before restarting an open Codex window.
+The `Codex Dream Skin` shortcut is the recommended launcher. Successful launches do not show a PowerShell window. It asks for confirmation before restarting an open Codex window; failures show an error dialog and write details to `launcher-error.log`. The command-line start script below remains available for terminal troubleshooting.
 
 Command-line launch:
 
@@ -63,7 +63,7 @@ Next, use the generated screenshot to check horizontal overflow and text contras
 
 ## Change and save themes
 
-Open `Codex Dream Skin - Tray` to:
+Open `Codex Dream Skin - Theme Manager` to:
 
 - Import a PNG, JPEG, or WebP background.
 - Save the active theme and switch through saved themes.
@@ -101,6 +101,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\restore-dream-
 | Session state | `%LOCALAPPDATA%\CodexDreamSkin\state.json` |
 | Injector log | `%LOCALAPPDATA%\CodexDreamSkin\injector.log` |
 | Injector error log | `%LOCALAPPDATA%\CodexDreamSkin\injector-error.log` |
+| Launcher error log | `%LOCALAPPDATA%\CodexDreamSkin\launcher-error.log` |
 | Verification log | `%LOCALAPPDATA%\CodexDreamSkin\verify.log` |
 | Codex configuration | `%USERPROFILE%\.codex\config.toml` |
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -24,8 +24,8 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-dream-
 
 安装器会校验官方 Codex Store 包和 Node.js，保存可恢复的外观配置，并初始化本地主题仓库。默认还会创建这些快捷方式：
 
-- `Codex Dream Skin`：启动或重新应用皮肤。
-- `Codex Dream Skin - Tray`：打开系统托盘主题控制。
+- `Codex Dream Skin`：静默启动或重新应用皮肤；失败时显示错误对话框和日志路径。
+- `Codex Dream Skin - Theme Manager`：打开系统托盘主题控制。
 - `Codex Dream Skin - Restore`：恢复官方外观并关闭已保存的 CDP 会话。
 
 如需使用自定义端口，可以在安装时传入 `-Port`。端口范围必须是 `1024` 到 `65535`。
@@ -36,7 +36,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-dream-
 
 ## 启动与验证
 
-推荐从 `Codex Dream Skin` 快捷方式启动。它发现 Codex 已经运行时会先询问是否重启。
+推荐从 `Codex Dream Skin` 快捷方式启动。正常启动不显示 PowerShell 窗口；它发现 Codex 已经运行时会先询问是否重启，失败时会显示错误对话框并将详情写入 `launcher-error.log`。排查问题时仍可直接运行下面的命令行启动脚本。
 
 命令行启动：
 
@@ -63,7 +63,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify-dream-s
 
 ## 更换和保存主题
 
-打开 `Codex Dream Skin - Tray` 后可以：
+打开 `Codex Dream Skin - Theme Manager` 后可以：
 
 - 更换 PNG、JPEG 或 WebP 背景图。
 - 保存当前主题并从「已保存主题」切换。
@@ -101,6 +101,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\restore-dream-
 | 会话状态 | `%LOCALAPPDATA%\CodexDreamSkin\state.json` |
 | 注入器日志 | `%LOCALAPPDATA%\CodexDreamSkin\injector.log` |
 | 注入器错误日志 | `%LOCALAPPDATA%\CodexDreamSkin\injector-error.log` |
+| 启动器错误日志 | `%LOCALAPPDATA%\CodexDreamSkin\launcher-error.log` |
 | 验证日志 | `%LOCALAPPDATA%\CodexDreamSkin\verify.log` |
 | Codex 配置 | `%USERPROFILE%\.codex\config.toml` |
 

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -55,6 +55,7 @@ function Get-DreamSkinRuntimeEnginePaths {
   return [pscustomobject]@{
     Root = $root
     Scripts = $scripts
+    Launcher = Join-Path $scripts 'launch-dream-skin.ps1'
     Start = Join-Path $scripts 'start-dream-skin.ps1'
     Restore = Join-Path $scripts 'restore-dream-skin.ps1'
     Tray = Join-Path $scripts 'tray-dream-skin.ps1'
@@ -135,6 +136,7 @@ function Install-DreamSkinRuntimeEngine {
     'scripts\image-metadata.mjs',
     'scripts\injector.mjs',
     'scripts\install-dream-skin.ps1',
+    'scripts\launch-dream-skin.ps1',
     'scripts\restore-dream-skin.ps1',
     'scripts\start-dream-skin.ps1',
     'scripts\theme-windows.ps1',

--- a/windows/scripts/install-dream-skin.ps1
+++ b/windows/scripts/install-dream-skin.ps1
@@ -4,6 +4,46 @@ param(
   [switch]$NoShortcuts
 )
 
+function Install-DreamSkinShortcuts {
+  param(
+    [Parameter(Mandatory = $true)][object]$WScriptShell,
+    [Parameter(Mandatory = $true)][string]$DesktopDirectory,
+    [Parameter(Mandatory = $true)][string]$StartMenuDirectory,
+    [Parameter(Mandatory = $true)][string]$PowerShellPath,
+    [Parameter(Mandatory = $true)][psobject]$Engine,
+    [string]$PortArgument = ''
+  )
+  foreach ($folder in @($DesktopDirectory, $StartMenuDirectory)) {
+    Remove-Item -LiteralPath (Join-Path $folder 'Codex Dream Skin - Tray.lnk') `
+      -Force -ErrorAction SilentlyContinue
+  }
+
+  foreach ($folder in @($DesktopDirectory, $StartMenuDirectory)) {
+    $shortcut = $WScriptShell.CreateShortcut((Join-Path $folder 'Codex Dream Skin.lnk'))
+    $shortcut.TargetPath = $PowerShellPath
+    $shortcut.Arguments = "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$($Engine.Launcher)`"$PortArgument"
+    $shortcut.WorkingDirectory = $Engine.Root
+    $shortcut.Description = 'Launch or reapply Codex Dream Skin'
+    $shortcut.Save()
+  }
+
+  $restore = $WScriptShell.CreateShortcut((Join-Path $DesktopDirectory 'Codex Dream Skin - Restore.lnk'))
+  $restore.TargetPath = $PowerShellPath
+  $restore.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$($Engine.Restore)`"$PortArgument -RestoreBaseTheme -PromptRestart"
+  $restore.WorkingDirectory = $Engine.Root
+  $restore.Description = 'Restore the official Codex appearance and close the CDP session'
+  $restore.Save()
+
+  foreach ($folder in @($DesktopDirectory, $StartMenuDirectory)) {
+    $manager = $WScriptShell.CreateShortcut((Join-Path $folder 'Codex Dream Skin - Theme Manager.lnk'))
+    $manager.TargetPath = $PowerShellPath
+    $manager.Arguments = "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$($Engine.Tray)`"$PortArgument"
+    $manager.WorkingDirectory = $Engine.Root
+    $manager.Description = 'Open Codex Dream Skin status and theme controls in the system tray'
+    $manager.Save()
+  }
+}
+
 $ErrorActionPreference = 'Stop'
 $PortExplicit = $PSBoundParameters.ContainsKey('Port')
 $SkillRoot = Split-Path -Parent $PSScriptRoot
@@ -49,35 +89,11 @@ try {
     $desktop = [Environment]::GetFolderPath('Desktop')
     $startMenu = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
     $powershell = (Get-Command powershell.exe -ErrorAction Stop).Source
-    $startScript = $engine.Start
-    $restoreScript = $engine.Restore
     $trayScript = $engine.Tray
     $portArgument = if ($PortExplicit) { " -Port $Port" } else { '' }
-
-    foreach ($folder in @($desktop, $startMenu)) {
-      $shortcut = $shell.CreateShortcut((Join-Path $folder 'Codex Dream Skin.lnk'))
-      $shortcut.TargetPath = $powershell
-      $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$startScript`"$portArgument -PromptRestart"
-      $shortcut.WorkingDirectory = $engine.Root
-      $shortcut.Description = 'Launch the official Codex app with Codex Dream Skin'
-      $shortcut.Save()
-    }
-
-    $restore = $shell.CreateShortcut((Join-Path $desktop 'Codex Dream Skin - Restore.lnk'))
-    $restore.TargetPath = $powershell
-    $restore.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$restoreScript`"$portArgument -RestoreBaseTheme -PromptRestart"
-    $restore.WorkingDirectory = $engine.Root
-    $restore.Description = 'Restore the official Codex appearance and close the CDP session'
-    $restore.Save()
-
-    foreach ($folder in @($desktop, $startMenu)) {
-      $tray = $shell.CreateShortcut((Join-Path $folder 'Codex Dream Skin - Tray.lnk'))
-      $tray.TargetPath = $powershell
-      $tray.Arguments = "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$trayScript`"$portArgument"
-      $tray.WorkingDirectory = $engine.Root
-      $tray.Description = 'Open Codex Dream Skin status and theme controls in the system tray'
-      $tray.Save()
-    }
+    Install-DreamSkinShortcuts -WScriptShell $shell -DesktopDirectory $desktop `
+      -StartMenuDirectory $startMenu -PowerShellPath $powershell -Engine $engine `
+      -PortArgument $portArgument
     Start-Process -FilePath $powershell -ArgumentList `
       "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$trayScript`"$portArgument" `
       -WindowStyle Hidden | Out-Null
@@ -86,7 +102,7 @@ try {
   if ($NoShortcuts) {
     Write-Host "Codex Dream Skin base theme installed at $($engine.Root). Run $($engine.Start) to launch it."
   } else {
-    Write-Host 'Codex Dream Skin installed. The launch shortcut asks before restarting an open Codex window.'
+    Write-Host 'Codex Dream Skin installed. Launch applies the skin, Theme Manager opens tray controls, and Restore returns to the stock appearance.'
   }
 } finally {
   Exit-DreamSkinOperationLock -Mutex $operationLock

--- a/windows/scripts/launch-dream-skin.ps1
+++ b/windows/scripts/launch-dream-skin.ps1
@@ -1,0 +1,51 @@
+[CmdletBinding()]
+param([int]$Port = 9335)
+
+$ErrorActionPreference = 'Stop'
+$portExplicit = $PSBoundParameters.ContainsKey('Port')
+$startScript = Join-Path $PSScriptRoot 'start-dream-skin.ps1'
+
+function Write-DreamSkinLauncherError {
+  param(
+    [Parameter(Mandatory = $true)][System.Exception]$Exception,
+    [Parameter(Mandatory = $true)][int]$Port,
+    [Parameter(Mandatory = $true)][string]$LauncherPath,
+    [Parameter(Mandatory = $true)][string]$StartScriptPath,
+    [string]$StateRoot = (Join-Path $env:LOCALAPPDATA 'CodexDreamSkin')
+  )
+  $fullStateRoot = [System.IO.Path]::GetFullPath($StateRoot)
+  [System.IO.Directory]::CreateDirectory($fullStateRoot) | Out-Null
+  $logPath = Join-Path $fullStateRoot 'launcher-error.log'
+  $singleLineMessage = ([string]$Exception.Message -replace '[\r\n]+', ' ').Trim()
+  $lines = @(
+    "timestamp=$([DateTime]::UtcNow.ToString('o'))",
+    "port=$Port",
+    "exceptionType=$($Exception.GetType().FullName)",
+    "message=$singleLineMessage",
+    "launcherPath=$([System.IO.Path]::GetFullPath($LauncherPath))",
+    "startScriptPath=$([System.IO.Path]::GetFullPath($StartScriptPath))"
+  )
+  $utf8WithoutBom = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText($logPath, ($lines -join [Environment]::NewLine), $utf8WithoutBom)
+  return $logPath
+}
+
+try {
+  $startParameters = @{ PromptRestart = $true }
+  if ($portExplicit) { $startParameters.Port = $Port }
+  & $startScript @startParameters
+  exit 0
+} catch {
+  $logPath = Write-DreamSkinLauncherError -Exception $_.Exception -Port $Port `
+    -LauncherPath $PSCommandPath -StartScriptPath $startScript
+  try {
+    Add-Type -AssemblyName System.Windows.Forms
+    [void][System.Windows.Forms.MessageBox]::Show(
+      "Codex Dream Skin could not start.`n`nDetails were written to:`n$logPath",
+      'Codex Dream Skin',
+      [System.Windows.Forms.MessageBoxButtons]::OK,
+      [System.Windows.Forms.MessageBoxIcon]::Error
+    )
+  } catch {}
+  exit 1
+}

--- a/windows/scripts/restore-dream-skin.ps1
+++ b/windows/scripts/restore-dream-skin.ps1
@@ -155,8 +155,10 @@ try {
         (Join-Path $desktop 'Codex Dream Skin.lnk'),
         (Join-Path $desktop 'Codex Dream Skin - Restore.lnk'),
         (Join-Path $desktop 'Codex Dream Skin - Tray.lnk'),
+        (Join-Path $desktop 'Codex Dream Skin - Theme Manager.lnk'),
         (Join-Path $startMenu 'Codex Dream Skin.lnk'),
-        (Join-Path $startMenu 'Codex Dream Skin - Tray.lnk')
+        (Join-Path $startMenu 'Codex Dream Skin - Tray.lnk'),
+        (Join-Path $startMenu 'Codex Dream Skin - Theme Manager.lnk')
       ) | ForEach-Object { Remove-Item -LiteralPath $_ -Force -ErrorAction SilentlyContinue }
     }
 

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -30,6 +30,7 @@ try {
       -Recurse -File -Force
   )
   if ($runtimeSourceFiles.Count -ne $runtimeEngineFiles.Count -or
+    -not (Test-DreamSkinPathWithin -Path $engine.Launcher -Root $runtimeStateRoot) -or
     -not (Test-DreamSkinPathWithin -Path $engine.Start -Root $runtimeStateRoot) -or
     -not (Test-DreamSkinPathWithin -Path $engine.Restore -Root $runtimeStateRoot) -or
     -not (Test-DreamSkinPathWithin -Path $engine.Tray -Root $runtimeStateRoot)) {
@@ -123,18 +124,160 @@ try {
   if ($trayGuardIndex -lt 0 -or $engineInstallIndex -le $trayGuardIndex) {
     throw 'Installer does not reject an active source-bound tray before replacing the runtime engine.'
   }
-  foreach ($requiredShortcutBinding in @(
-    '$startScript = $engine.Start',
-    '$restoreScript = $engine.Restore',
-    '$trayScript = $engine.Tray',
-    '$shortcut.WorkingDirectory = $engine.Root',
-    '$restore.WorkingDirectory = $engine.Root',
-    '$tray.WorkingDirectory = $engine.Root'
-  )) {
+  foreach ($requiredShortcutBinding in @('$Engine.Launcher', '$Engine.Restore', '$Engine.Tray', '$Engine.Root')) {
     if (-not $installSource.Contains($requiredShortcutBinding)) {
       throw "Installer shortcut still depends on its source checkout: $requiredShortcutBinding"
     }
   }
+
+  $installTokens = $null
+  $installParseErrors = $null
+  $installAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    $installSource, [ref]$installTokens, [ref]$installParseErrors
+  )
+  if ($installParseErrors.Count -gt 0) { throw "Installer failed to parse: $($installParseErrors[0].Message)" }
+  $shortcutHelperAst = $installAst.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+      $node.Name -eq 'Install-DreamSkinShortcuts'
+  }, $true)
+  if ($null -eq $shortcutHelperAst) { throw 'Installer shortcut helper could not be loaded for migration checks.' }
+  Invoke-Expression $shortcutHelperAst.Extent.Text
+
+  $shortcutTestRoot = Join-Path $temporaryRoot 'shortcut-test'
+  $testDesktop = Join-Path $shortcutTestRoot 'Desktop'
+  $testStartMenu = Join-Path $shortcutTestRoot 'Start Menu'
+  $testEngineRoot = Join-Path $shortcutTestRoot 'engine'
+  $testScripts = Join-Path $testEngineRoot 'scripts'
+  foreach ($directory in @($testDesktop, $testStartMenu, $testScripts)) {
+    [System.IO.Directory]::CreateDirectory($directory) | Out-Null
+  }
+  $testEngine = [pscustomobject]@{
+    Root = $testEngineRoot
+    Launcher = Join-Path $testScripts 'launch-dream-skin.ps1'
+    Start = Join-Path $testScripts 'start-dream-skin.ps1'
+    Restore = Join-Path $testScripts 'restore-dream-skin.ps1'
+    Tray = Join-Path $testScripts 'tray-dream-skin.ps1'
+  }
+  foreach ($scriptPath in @($testEngine.Launcher, $testEngine.Start, $testEngine.Restore, $testEngine.Tray)) {
+    [System.IO.File]::WriteAllText($scriptPath, '# shortcut target')
+  }
+  $wscript = New-Object -ComObject WScript.Shell
+  foreach ($folder in @($testDesktop, $testStartMenu)) {
+    $legacy = $wscript.CreateShortcut((Join-Path $folder 'Codex Dream Skin - Tray.lnk'))
+    $legacy.TargetPath = $env:ComSpec
+    $legacy.Save()
+  }
+  $unrelatedPath = Join-Path $testDesktop 'Keep This Shortcut.lnk'
+  $unrelated = $wscript.CreateShortcut($unrelatedPath)
+  $unrelated.TargetPath = $env:ComSpec
+  $unrelated.Save()
+
+  $testPowerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
+  Install-DreamSkinShortcuts -WScriptShell $wscript -DesktopDirectory $testDesktop `
+    -StartMenuDirectory $testStartMenu -PowerShellPath $testPowerShell -Engine $testEngine `
+    -PortArgument ' -Port 9444'
+  foreach ($folder in @($testDesktop, $testStartMenu)) {
+    if (Test-Path -LiteralPath (Join-Path $folder 'Codex Dream Skin - Tray.lnk')) {
+      throw 'Shortcut migration left an exact legacy Tray shortcut behind.'
+    }
+    $launchPath = Join-Path $folder 'Codex Dream Skin.lnk'
+    $managerPath = Join-Path $folder 'Codex Dream Skin - Theme Manager.lnk'
+    if (-not (Test-Path -LiteralPath $launchPath) -or -not (Test-Path -LiteralPath $managerPath)) {
+      throw 'Shortcut migration did not create Launch and Theme Manager in both target folders.'
+    }
+    $launch = $wscript.CreateShortcut($launchPath)
+    $manager = $wscript.CreateShortcut($managerPath)
+    if (-not (Test-DreamSkinPathEqual -Left $launch.TargetPath -Right $testPowerShell) -or
+      -not $launch.Arguments.Contains('-WindowStyle Hidden') -or
+      -not $launch.Arguments.Contains($testEngine.Launcher) -or
+      -not $launch.Arguments.Contains('-Port 9444') -or
+      -not (Test-DreamSkinPathEqual -Left $launch.WorkingDirectory -Right $testEngine.Root) -or
+      $launch.Description -cne 'Launch or reapply Codex Dream Skin') {
+      throw 'Launch shortcut is not hidden or does not target the shortcut-only launcher.'
+    }
+    if (-not $manager.Arguments.Contains($testEngine.Tray) -or
+      -not (Test-DreamSkinPathEqual -Left $manager.WorkingDirectory -Right $testEngine.Root) -or
+      $manager.Description -cne 'Open Codex Dream Skin status and theme controls in the system tray') {
+      throw 'Theme Manager shortcut does not target the tray controls.'
+    }
+  }
+  $restoreShortcutPath = Join-Path $testDesktop 'Codex Dream Skin - Restore.lnk'
+  if (-not (Test-Path -LiteralPath $restoreShortcutPath) -or -not (Test-Path -LiteralPath $unrelatedPath)) {
+    throw 'Shortcut migration removed an unrelated shortcut or omitted Restore.'
+  }
+  $restoreShortcut = $wscript.CreateShortcut($restoreShortcutPath)
+  if (-not $restoreShortcut.Arguments.Contains($testEngine.Restore) -or
+    -not $restoreShortcut.Arguments.Contains('-RestoreBaseTheme -PromptRestart')) {
+    throw 'Restore shortcut behavior changed during migration.'
+  }
+
+  $launcherSource = Read-DreamSkinUtf8File -Path (Join-Path $Root 'scripts\launch-dream-skin.ps1')
+  $launcherTokens = $null
+  $launcherParseErrors = $null
+  $launcherAst = [System.Management.Automation.Language.Parser]::ParseInput(
+    $launcherSource, [ref]$launcherTokens, [ref]$launcherParseErrors
+  )
+  if ($launcherParseErrors.Count -gt 0) { throw "Launcher failed to parse: $($launcherParseErrors[0].Message)" }
+  $loggerAst = $launcherAst.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+      $node.Name -eq 'Write-DreamSkinLauncherError'
+  }, $true)
+  if ($null -eq $loggerAst) { throw 'Launcher error logger could not be loaded for behavior checks.' }
+  Invoke-Expression $loggerAst.Extent.Text
+  $loggerRoot = Join-Path $temporaryRoot 'launcher-log-test'
+  $syntheticException = [System.InvalidOperationException]::new("synthetic launcher failure`r`nsecond line")
+  $testLauncherPath = Join-Path $testScripts 'launch-dream-skin.ps1'
+  $logPath = Write-DreamSkinLauncherError -Exception $syntheticException -Port 9444 `
+    -LauncherPath $testLauncherPath -StartScriptPath $testEngine.Start -StateRoot $loggerRoot
+  $launcherLog = Read-DreamSkinUtf8File -Path $logPath
+  foreach ($requiredLogField in @(
+    'port=9444',
+    'exceptionType=System.InvalidOperationException',
+    'message=synthetic launcher failure second line',
+    "launcherPath=$([System.IO.Path]::GetFullPath($testLauncherPath))",
+    "startScriptPath=$([System.IO.Path]::GetFullPath($testEngine.Start))"
+  )) {
+    if (-not $launcherLog.Contains($requiredLogField)) { throw "Launcher error log is missing: $requiredLogField" }
+  }
+  $timestampLine = @($launcherLog -split '[\r\n]+' | Where-Object { $_ -like 'timestamp=*' })
+  $parsedTimestamp = [DateTimeOffset]::MinValue
+  if ($timestampLine.Count -ne 1 -or
+    -not [DateTimeOffset]::TryParse($timestampLine[0].Substring(10), [ref]$parsedTimestamp) -or
+    $parsedTimestamp.Offset -ne [TimeSpan]::Zero -or -not $timestampLine[0].EndsWith('Z') -or
+    $launcherLog.Contains('config.toml') -or $launcherLog.Contains('DREAM_SKIN_TEST_SECRET')) {
+    throw 'Launcher error log timestamp or sensitive-data boundary is invalid.'
+  }
+
+  $launcherExecutionRoot = Join-Path $shortcutTestRoot 'launcher-execution'
+  [System.IO.Directory]::CreateDirectory($launcherExecutionRoot) | Out-Null
+  Copy-Item -LiteralPath (Join-Path $Root 'scripts\launch-dream-skin.ps1') `
+    -Destination (Join-Path $launcherExecutionRoot 'launch-dream-skin.ps1')
+  $fakeStartSource = @'
+[CmdletBinding()]
+param([int]$Port = 9335, [switch]$PromptRestart)
+$result = "$Port|$PromptRestart|$($PSBoundParameters.ContainsKey('Port'))"
+[System.IO.File]::WriteAllText((Join-Path $PSScriptRoot 'forwarded-parameters.txt'), $result)
+'@
+  [System.IO.File]::WriteAllText(
+    (Join-Path $launcherExecutionRoot 'start-dream-skin.ps1'),
+    $fakeStartSource
+  )
+  $testLauncher = Join-Path $launcherExecutionRoot 'launch-dream-skin.ps1'
+  & $testPowerShell -NoProfile -ExecutionPolicy Bypass -File $testLauncher
+  if ($LASTEXITCODE -ne 0 -or
+    (Read-DreamSkinUtf8File -Path (Join-Path $launcherExecutionRoot 'forwarded-parameters.txt')) -cne
+      '9335|True|False') {
+    throw 'Launcher does not forward the default PromptRestart invocation correctly.'
+  }
+  & $testPowerShell -NoProfile -ExecutionPolicy Bypass -File $testLauncher -Port 9444
+  if ($LASTEXITCODE -ne 0 -or
+    (Read-DreamSkinUtf8File -Path (Join-Path $launcherExecutionRoot 'forwarded-parameters.txt')) -cne
+      '9444|True|True') {
+    throw 'Launcher does not forward an explicitly selected port correctly.'
+  }
+  Remove-Item -LiteralPath $shortcutTestRoot, $loggerRoot -Recurse -Force
 
   Remove-Item -LiteralPath $runtimeSourceRoot -Recurse -Force
   foreach ($installedScript in Get-ChildItem -LiteralPath $engine.Scripts -Filter '*.ps1' -File) {
@@ -148,6 +291,7 @@ try {
     }
   }
   if (-not (Test-Path -LiteralPath $engine.Start -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $engine.Launcher -PathType Leaf) -or
     -not (Test-Path -LiteralPath $engine.Restore -PathType Leaf) -or
     -not (Test-Path -LiteralPath $engine.Tray -PathType Leaf)) {
     throw 'Installed launch, restore, or tray entry point disappeared with the source checkout.'
@@ -734,6 +878,11 @@ try {
     throw 'Tray menu metadata enumeration still performs full image parsing on every open.'
   }
   $restoreSource = Read-DreamSkinUtf8File -Path (Join-Path $Root 'scripts\restore-dream-skin.ps1')
+  foreach ($managerShortcutName in @('Codex Dream Skin - Tray.lnk', 'Codex Dream Skin - Theme Manager.lnk')) {
+    if (-not $restoreSource.Contains($managerShortcutName)) {
+      throw "Complete uninstall does not remove shortcut name: $managerShortcutName"
+    }
+  }
   if (-not $restoreSource.Contains('Stop-DreamSkinTrayProcess')) {
     throw 'Complete restore does not stop a separately launched tray process.'
   }
@@ -761,6 +910,20 @@ try {
     -not $startSource.Contains('$pauseCleared = $true') -or
     -not $startSource.Contains('Set-DreamSkinPaused -Paused $true -StateRoot $StateRoot')) {
     throw 'Start does not preserve an existing pause marker when startup rolls back.'
+  }
+
+  $readmeZh = Read-DreamSkinUtf8File -Path (Join-Path $Root 'README.md')
+  $readmeEn = Read-DreamSkinUtf8File -Path (Join-Path $Root 'README.en.md')
+  foreach ($documentation in @($readmeZh, $readmeEn)) {
+    foreach ($requiredLauncherDocumentation in @(
+      'Codex Dream Skin - Theme Manager',
+      'launcher-error.log',
+      'start-dream-skin.ps1'
+    )) {
+      if (-not $documentation.Contains($requiredLauncherDocumentation)) {
+        throw "Windows documentation is missing launcher guidance: $requiredLauncherDocumentation"
+      }
+    }
   }
 
   $rendererSource = Read-DreamSkinUtf8File -Path (Join-Path $Root 'assets\renderer-inject.js')


### PR DESCRIPTION
## Summary

- Add a shortcut-only hidden launcher wrapper while preserving `start-dream-skin.ps1` as the terminal entry point.
- Write a bounded UTF-8 launcher error log and show its path in an error dialog; normal and cancelled launches exit successfully, caught failures exit 1.
- Rename the tray shortcut to `Codex Dream Skin - Theme Manager`, migrate only the exact legacy shortcut names, and update uninstall/docs.
- Extract shortcut creation and error formatting into behavior-tested helpers.

## Compatibility and migration

- `Codex Dream Skin` remains the launch shortcut but now runs without a successful PowerShell console window.
- `Codex Dream Skin - Theme Manager` opens tray controls.
- Reinstall removes only the exact old `Codex Dream Skin - Tray.lnk` entries and preserves unrelated shortcuts.
- Custom `-Port` is forwarded only when explicitly configured; `-PromptRestart` is always forwarded.

## Checks

- Real child-process coverage for default and explicit-port wrapper forwarding.
- Temporary-folder WScript.Shell shortcut migration coverage.
- Launcher log field, single-line message, UTC timestamp, and sensitive-data boundary coverage.
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\tests\run-tests.ps1`
- `node --check .\windows\scripts\injector.mjs`
- `node --check .\windows\assets\renderer-inject.js`
- `git diff --check upstream/main...HEAD`

Closes #86