### PR TITLE
fix(windows): remove unused renderer profile state

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Windows Changelog
 
+## Unreleased
+
+### 修复
+
+- 渲染器不再注入 CSS 从未消费的 `dream-theme-light`、`dream-art-standard`、`dream-focus-*` class 与 `--dream-focus-*` 变量；现有的明暗、宽图、安全区、任务模式和二维焦点行为保持不变，旧版本遗留的无效标记仍会在热重注入或恢复时清理。
+
 ## 1.2.0 — 2026-07-17
 
 ### 新增

--- a/windows/assets/renderer-inject.js
+++ b/windows/assets/renderer-inject.js
@@ -4,13 +4,8 @@
   const CHROME_ID = "codex-dream-skin-chrome";
   const ROOT_CLASSES = [
     "codex-dream-skin",
-    "dream-theme-light",
     "dream-theme-dark",
     "dream-art-wide",
-    "dream-art-standard",
-    "dream-focus-left",
-    "dream-focus-center",
-    "dream-focus-right",
     "dream-safe-left",
     "dream-safe-center",
     "dream-safe-right",
@@ -22,12 +17,18 @@
   const ROOT_PROPERTIES = [
     "--dream-art",
     "--dream-art-position",
-    "--dream-focus-x",
-    "--dream-focus-y",
     "--dream-accent",
     "--dream-accent-ink",
     "--dream-image-luma",
   ];
+  const LEGACY_PROFILE_CLASSES = [
+    "dream-theme-light",
+    "dream-art-standard",
+    "dream-focus-left",
+    "dream-focus-center",
+    "dream-focus-right",
+  ];
+  const LEGACY_PROFILE_PROPERTIES = ["--dream-focus-x", "--dream-focus-y"];
   const HOME_UTILITY_CLASS = "dream-home-utility";
   const installToken = {};
   let samplingNativeShell = false;
@@ -277,8 +278,10 @@
 
   const clearSkinDom = () => {
     const root = document.documentElement;
-    root?.classList.remove(...ROOT_CLASSES);
-    for (const property of ROOT_PROPERTIES) root?.style.removeProperty(property);
+    root?.classList.remove(...ROOT_CLASSES, ...LEGACY_PROFILE_CLASSES);
+    for (const property of [...ROOT_PROPERTIES, ...LEGACY_PROFILE_PROPERTIES]) {
+      root?.style.removeProperty(property);
+    }
     document.querySelectorAll(".dream-home").forEach((node) => node.classList.remove("dream-home"));
     document.querySelectorAll(".dream-task").forEach((node) => node.classList.remove("dream-task"));
     document.querySelectorAll(".dream-home-shell").forEach((node) => node.classList.remove("dream-home-shell"));
@@ -299,13 +302,10 @@
       : config.taskMode;
     const accent = config.accent || `rgb(${profile.accent.join(" ")})`;
     const accentInk = luminance(...profile.accent) > .42 ? "rgb(26 24 28)" : "rgb(250 248 251)";
-    root.classList.toggle("dream-theme-light", appearance === "light");
+    root.classList.remove(...LEGACY_PROFILE_CLASSES);
+    for (const property of LEGACY_PROFILE_PROPERTIES) root.style.removeProperty(property);
     root.classList.toggle("dream-theme-dark", appearance === "dark");
     root.classList.toggle("dream-art-wide", profile.aspect >= 1.75);
-    root.classList.toggle("dream-art-standard", profile.aspect < 1.75);
-    for (const value of ["left", "center", "right"]) {
-      root.classList.toggle(`dream-focus-${value}`, focus === value);
-    }
     for (const value of ["left", "center", "right", "none"]) {
       root.classList.toggle(`dream-safe-${value}`, safeArea === value);
     }
@@ -314,8 +314,6 @@
     }
     root.style.setProperty("--dream-art", `url("${artUrl}")`);
     root.style.setProperty("--dream-art-position", `${Math.round(focusX * 100)}% ${Math.round(focusY * 100)}%`);
-    root.style.setProperty("--dream-focus-x", String(focusX));
-    root.style.setProperty("--dream-focus-y", String(focusY));
     root.style.setProperty("--dream-accent", accent);
     root.style.setProperty("--dream-accent-ink", accentInk);
     root.style.setProperty("--dream-image-luma", profile.luma.toFixed(3));

--- a/windows/scripts/injector.mjs
+++ b/windows/scripts/injector.mjs
@@ -537,16 +537,18 @@ async function removeFromSession(session) {
     window.__CODEX_DREAM_SKIN_DISABLED__ = true;
     const state = window.__CODEX_DREAM_SKIN_STATE__;
     if (state?.cleanup) return state.cleanup();
+    // Keep pre-cleanup no-op profile markers here so upgrades remove stale state.
     document.documentElement?.classList.remove(
-      'codex-dream-skin', 'dream-theme-light', 'dream-theme-dark',
-      'dream-art-wide', 'dream-art-standard', 'dream-focus-left',
-      'dream-focus-center', 'dream-focus-right', 'dream-safe-left',
+      'codex-dream-skin', 'dream-theme-dark', 'dream-art-wide',
+      'dream-safe-left',
       'dream-safe-center', 'dream-safe-right', 'dream-safe-none',
-      'dream-task-ambient', 'dream-task-banner', 'dream-task-off'
+      'dream-task-ambient', 'dream-task-banner', 'dream-task-off',
+      'dream-theme-light', 'dream-art-standard', 'dream-focus-left',
+      'dream-focus-center', 'dream-focus-right'
     );
     for (const property of [
-      '--dream-art', '--dream-art-position', '--dream-focus-x', '--dream-focus-y',
-      '--dream-accent', '--dream-accent-ink', '--dream-image-luma'
+      '--dream-art', '--dream-art-position', '--dream-accent', '--dream-accent-ink',
+      '--dream-image-luma', '--dream-focus-x', '--dream-focus-y'
     ]) document.documentElement?.style.removeProperty(property);
     document.querySelectorAll('.dream-home').forEach((node) => node.classList.remove('dream-home'));
     document.querySelectorAll('.dream-task').forEach((node) => node.classList.remove('dream-task'));

--- a/windows/tests/renderer-inject.test.mjs
+++ b/windows/tests/renderer-inject.test.mjs
@@ -13,6 +13,21 @@ const buildPayload = (config = {}) => template
   .replace("__DREAM_ART_JSON__", JSON.stringify("data:image/png;base64,AA=="))
   .replace("__DREAM_THEME_JSON__", JSON.stringify(config));
 const payload = buildPayload();
+const legacyProfileClasses = [
+  "dream-theme-light",
+  "dream-art-standard",
+  "dream-focus-left",
+  "dream-focus-center",
+  "dream-focus-right",
+];
+const legacyProfileProperties = ["--dream-focus-x", "--dream-focus-y"];
+
+for (const className of legacyProfileClasses) {
+  assert.equal(css.includes(`.${className}`), false, `${className} has no Windows CSS consumer.`);
+}
+for (const property of legacyProfileProperties) {
+  assert.equal(css.includes(property), false, `${property} has no Windows CSS consumer.`);
+}
 
 assert.doesNotMatch(
   css,
@@ -31,8 +46,11 @@ function createFixture({
   analysisFixture = null,
 }) {
   const nodes = new Map();
-  const rootClasses = new Set(staleSkin ? ["codex-dream-skin"] : []);
-  const rootStyles = new Map(staleSkin ? [["--dream-art", "url(\"blob:stale\")"]] : []);
+  const rootClasses = new Set(staleSkin ? ["codex-dream-skin", ...legacyProfileClasses] : []);
+  const rootStyles = new Map(staleSkin ? [
+    ["--dream-art", "url(\"blob:stale\")"],
+    ...legacyProfileProperties.map((property) => [property, ".5"]),
+  ] : []);
   const revokedUrls = [];
   const observers = [];
   let objectUrlCount = 0;
@@ -229,6 +247,15 @@ function createFixture({
   };
 }
 
+function assertNoLegacyProfileState(fixture, label) {
+  for (const className of legacyProfileClasses) {
+    assert.equal(fixture.rootClasses.has(className), false, `${label} must not inject ${className}.`);
+  }
+  for (const property of legacyProfileProperties) {
+    assert.equal(fixture.rootStyles.has(property), false, `${label} must not inject ${property}.`);
+  }
+}
+
 const main = createFixture({ shellPresent: true });
 const mainResult = vm.runInNewContext(payload, main.context);
 assert.equal(mainResult.installed, true);
@@ -237,7 +264,7 @@ assert.equal(main.rootStyles.get("--dream-art"), 'url("blob:fixture-1")');
 assert.equal(main.nodes.has("codex-dream-skin-style"), true);
 assert.equal(main.nodes.has("codex-dream-skin-chrome"), true);
 assert.equal(main.rootClasses.has("dream-theme-dark"), true);
-assert.equal(main.rootClasses.has("dream-art-standard"), true);
+assertNoLegacyProfileState(main, "Default profile");
 assert.equal(main.rootClasses.has("dream-task-ambient"), true);
 assert.equal(main.routeClasses.has("dream-task"), true);
 assert.equal(main.context.window.__CODEX_DREAM_SKIN_STATE__.cleanup(), true);
@@ -266,6 +293,7 @@ assert.equal(auxiliary.rootClasses.has("codex-dream-skin"), false);
 assert.equal(auxiliary.rootStyles.has("--dream-art"), false);
 assert.equal(auxiliary.nodes.has("codex-dream-skin-style"), false);
 assert.equal(auxiliary.nodes.has("codex-dream-skin-chrome"), false);
+assertNoLegacyProfileState(auxiliary, "Auxiliary cleanup");
 
 auxiliary.setShellPresent(true);
 auxiliary.context.window.__CODEX_DREAM_SKIN_STATE__.ensure();
@@ -285,9 +313,8 @@ const configuredPayload = buildPayload({
 });
 const configuredResult = vm.runInNewContext(configuredPayload, configured.context);
 assert.equal(configuredResult.adaptive, true);
-assert.equal(configured.rootClasses.has("dream-theme-light"), true);
 assert.equal(configured.rootClasses.has("dream-theme-dark"), false);
-assert.equal(configured.rootClasses.has("dream-focus-left"), true);
+assertNoLegacyProfileState(configured, "Explicit light/focus profile");
 assert.equal(configured.rootClasses.has("dream-safe-right"), true);
 assert.equal(configured.rootClasses.has("dream-task-off"), true);
 assert.equal(configured.rootStyles.get("--dream-art-position"), "15% 80%");
@@ -315,7 +342,7 @@ const analyzed = createFixture({
 vm.runInNewContext(payload, analyzed.context);
 await Promise.resolve();
 assert.equal(analyzed.rootClasses.has("dream-theme-dark"), true);
-assert.equal(analyzed.rootClasses.has("dream-theme-light"), false);
+assertNoLegacyProfileState(analyzed, "Analyzed wide profile");
 assert.equal(analyzed.rootClasses.has("dream-art-wide"), true);
 assert.equal(analyzed.rootClasses.has("dream-task-banner"), true);
 assert.equal(analyzed.rootClasses.has("dream-safe-left"), true);
@@ -327,7 +354,7 @@ const standardArt = createFixture({
 });
 vm.runInNewContext(payload, standardArt.context);
 await Promise.resolve();
-assert.equal(standardArt.rootClasses.has("dream-art-standard"), true);
+assertNoLegacyProfileState(standardArt, "Standard-aspect profile");
 assert.equal(standardArt.rootClasses.has("dream-task-ambient"), true);
 assert.equal(standardArt.rootClasses.has("dream-task-banner"), false);
 
@@ -343,8 +370,8 @@ assert.equal(mediumWide.rootClasses.has("dream-task-banner"), false);
 
 const nativeLight = createFixture({ shellPresent: true, shellAppearance: "light" });
 vm.runInNewContext(payload, nativeLight.context);
-assert.equal(nativeLight.rootClasses.has("dream-theme-light"), true);
 assert.equal(nativeLight.rootClasses.has("dream-theme-dark"), false);
+assertNoLegacyProfileState(nativeLight, "Native light profile");
 
 const nativeComputedDark = createFixture({
   shellPresent: true,
@@ -354,7 +381,7 @@ const nativeComputedDark = createFixture({
 });
 vm.runInNewContext(payload, nativeComputedDark.context);
 assert.equal(nativeComputedDark.rootClasses.has("dream-theme-dark"), true);
-assert.equal(nativeComputedDark.rootClasses.has("dream-theme-light"), false);
+assertNoLegacyProfileState(nativeComputedDark, "Native computed dark profile");
 nativeComputedDark.context.window.__CODEX_DREAM_SKIN_STATE__.ensure();
 assert.equal(nativeComputedDark.rootClasses.has("dream-theme-dark"), true);
 const nativeObserver = nativeComputedDark.observers[0];
@@ -366,6 +393,11 @@ assert.equal(nativeObserver.takeRecords().length, 0,
 const metadataWide = createFixture({ shellPresent: true });
 vm.runInNewContext(buildPayload({ artMetadata: { ratio: 16 / 9 } }), metadataWide.context);
 assert.equal(metadataWide.rootClasses.has("dream-art-wide"), true);
-assert.equal(metadataWide.rootClasses.has("dream-art-standard"), false);
+assertNoLegacyProfileState(metadataWide, "Metadata-wide profile");
 
-console.log("PASS: renderer applies adaptive theme metadata and preserves transparent auxiliary windows.");
+const legacyReinjection = createFixture({ shellPresent: true, staleSkin: true });
+vm.runInNewContext(payload, legacyReinjection.context);
+assert.equal(legacyReinjection.rootClasses.has("dream-theme-dark"), true);
+assertNoLegacyProfileState(legacyReinjection, "Legacy reinjection cleanup");
+
+console.log("PASS: renderer applies only CSS-backed profile state and cleans legacy no-op markers.");


### PR DESCRIPTION
## Summary / 摘要

- Stop injecting the Windows renderer classes `dream-theme-light`, `dream-art-standard`, and `dream-focus-*` because no Windows CSS rule consumes them.
- Stop writing the unused `--dream-focus-x` and `--dream-focus-y` properties; the existing two-dimensional `--dream-art-position` value remains the single focus contract.
- Preserve every active behavior (`dream-theme-dark`, wide art, safe area, task mode, accent, and art position) while retaining the old no-op names only in upgrade/removal cleanup paths.
- Add renderer regressions for explicit light/focus themes, analyzed standard and wide images, auxiliary-window cleanup, and reinjection over legacy state.

Closes #81.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [x] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

Check what you actually ran. Skip items that do not apply and say so under Notes.
请勾选**实际跑过**的项；不适用的在 Notes 说明。

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [x] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [x] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

- `node --check .\windows\assets\renderer-inject.js`, `node --check .\windows\scripts\injector.mjs`, and `node .\windows\tests\renderer-inject.test.mjs`: PASS.
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\tests\run-tests.ps1`: PASS. The expected warning lines are fault-injection coverage for runtime/config cleanup paths.
- The Windows renderer regression proves the removed names have no CSS consumer, are never emitted by light/dark, standard/wide, explicit/analyzed, home/task profiles, and are still removed from auxiliary windows and legacy reinjection state.
- The runnable macOS Node checks `image-metadata.test.mjs`, `injector-bootstrap.test.mjs`, and `renderer-inject.test.mjs` passed. `theme-stage.test.mjs` cannot pass on Windows because its expected symbolic-link rejection uses macOS filesystem semantics; no macOS file changed.
- Live Windows Verify was not run because applying this renderer branch would restart or replace the active Codex session hosting this task. The change intentionally removes CSS-inert state only; simulated renderer coverage verifies both home/task state and cleanup behavior.
- Install/start/verify/restore, macOS Doctor, macOS live Verify, restore/re-apply, and docs-only checks are not applicable to the changed paths.
- Updated `windows/CHANGELOG.md`; the template's macOS changelog checkbox does not apply to this Windows-only maintenance fix.
- `git diff --check`: PASS. No dependency, network behavior, configuration write, official package mutation, CDP binding, or executable-content path is added.
- Environment: Windows 11 Home build 26200; Windows PowerShell 5.1.26100.8875; Node.js 24.17.0; Microsoft Store `OpenAI.Codex` package 26.707.12708.0.
