### PR TITLE
fix(windows): preserve image validation stderr

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -34,6 +34,7 @@
 - 记录中的 injector PID 若仍存活但身份不匹配，启动与恢复会保留 state 并中止，不再归档后继续操作未知进程。
 - Windows PowerShell 5.1 现在使用同目录临时备份调用 `File.Replace`，避免空备份参数被绑定为非法路径而导致现有 `config.toml` 无法更新。
 - 修复 Windows PowerShell 5.1 下注入器/Node 一旦向 stderr 输出（崩溃堆栈、超时报错、Node 警告）就把启动脚本炸成 `NativeCommandError` 的问题：现在原生命令统一经 `Invoke-DreamSkinNative` 执行，verify 失败时 `verify.log` 能真正写出本次输出与退出码，回滚清除注入的路径也不再被 stderr 干扰误判。
+- 图片元数据校验也统一经 `Invoke-DreamSkinNative` 执行并隔离 stderr；PowerShell 5.1 下的 Node 警告不再中断主题导入或污染 JSON，非法图片仍显示稳定的尺寸安全提示。
 - 带引号键名和 CRLF 的 `[desktop]` 配置现在可以逐字节往返恢复；新版 Codex 写入的非冲突 `[desktop.*]` 子表会原样保留，仅在子表与 Dream Skin 必须管理的标量键冲突时拒绝修改。
 - Codex 的启动、失败回滚和恢复重开统一通过已注册 Store 包清单中的 AppUserModelId 激活，不再直接执行可能被 WindowsApps 权限拒绝的 `ChatGPT.exe`；CDP 和自定义 profile 参数仍通过系统包激活接口传递。
 - 安装与 `-RestoreBaseTheme` 现在严格按 UTF-8 读取，保留原换行风格，并以无 BOM、同目录原子替换方式写回 `config.toml`，避免中文项目名称乱码或导致 Codex 无法启动。

--- a/windows/scripts/theme-windows.ps1
+++ b/windows/scripts/theme-windows.ps1
@@ -49,16 +49,18 @@ function Ensure-DreamSkinManagedDirectory {
 
 function Get-DreamSkinValidatedImageMetadata {
   param([Parameter(Mandatory = $true)][string]$Path)
-  if (-not (Get-Command Get-DreamSkinNodeRuntime -ErrorAction SilentlyContinue)) {
+  if (-not (Get-Command Get-DreamSkinNodeRuntime -ErrorAction SilentlyContinue) -or
+    -not (Get-Command Invoke-DreamSkinNative -ErrorAction SilentlyContinue)) {
     throw 'Node.js runtime validation is unavailable for image metadata checks.'
   }
   $node = Get-DreamSkinNodeRuntime
   $metadataScript = Join-Path $PSScriptRoot 'image-metadata.mjs'
-  $output = @(& $node.Path $metadataScript '--check' ([System.IO.Path]::GetFullPath($Path)) 2>&1)
-  if ($LASTEXITCODE -ne 0) {
+  $probe = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+    $metadataScript, '--check', ([System.IO.Path]::GetFullPath($Path))) -DiscardStderr
+  if ($probe.ExitCode -ne 0) {
     throw "Image metadata is invalid or exceeds the 16384px / 50MP safety limit: $Path"
   }
-  try { $metadata = ($output -join "`n") | ConvertFrom-Json -ErrorAction Stop } catch {
+  try { $metadata = ($probe.Output -join "`n") | ConvertFrom-Json -ErrorAction Stop } catch {
     throw "Image metadata helper returned invalid output: $Path"
   }
   if ($null -eq $metadata -or $null -eq $metadata.width -or $null -eq $metadata.height) {

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -783,6 +783,8 @@ try {
     '[System.IO.FileAttributes]::ReparsePoint',
     'Ensure-DreamSkinManagedDirectory',
     'Get-DreamSkinValidatedImageMetadata',
+    'Invoke-DreamSkinNative',
+    '-DiscardStderr',
     '16384px / 50MP safety limit',
     'Assert-DreamSkinImageFile -Path $temporary',
     'Assert-DreamSkinImageFile -Path $imageArchive'
@@ -806,6 +808,29 @@ try {
     '-e', "process.stderr.write('ignored-warning\n'); process.stdout.write('kept-output')") -DiscardStderr
   if ($discardedProbe.ExitCode -ne 0 -or ($discardedProbe.Output -join '') -cne 'kept-output') {
     throw 'Native stderr discard changed stdout or the real exit code.'
+  }
+
+  $previousNodeOptions = $env:NODE_OPTIONS
+  try {
+    $env:NODE_OPTIONS = '--import=data:text/javascript,process.stderr.write(%22dream-skin-metadata-warning%5Cn%22)'
+    Get-DreamSkinValidatedImageMetadata -Path (Join-Path $Root 'assets\dream-reference.jpg')
+    $friendlyMetadataFailure = $null
+    try {
+      Get-DreamSkinValidatedImageMetadata -Path (Join-Path $temporaryRoot 'invalid-metadata.png')
+    } catch {
+      $friendlyMetadataFailure = $_
+    }
+    if ($null -eq $friendlyMetadataFailure -or
+      $friendlyMetadataFailure.Exception.Message -notlike 'Image metadata is invalid or exceeds*' -or
+      $friendlyMetadataFailure.FullyQualifiedErrorId -like '*NativeCommandError*') {
+      throw 'Image metadata stderr did not preserve success output and the friendly validation error under Stop preference.'
+    }
+  } finally {
+    if ($null -eq $previousNodeOptions) {
+      Remove-Item Env:\NODE_OPTIONS -ErrorAction SilentlyContinue
+    } else {
+      $env:NODE_OPTIONS = $previousNodeOptions
+    }
   }
 
   $selfTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(


### PR DESCRIPTION
## Summary / 摘要

- Route Windows image-metadata validation through the existing `Invoke-DreamSkinNative` compatibility wrapper instead of invoking Node with a direct `2>&1` redirection.
- Discard helper stderr while preserving stdout and the real exit code, so harmless Node warnings cannot terminate PowerShell 5.1 or corrupt the JSON metadata result.
- Preserve the existing friendly size-safety error for invalid images.
- Add a real PowerShell 5.1 regression that injects Node stderr on both successful and failing metadata checks.

## Root cause / 根因

Windows PowerShell 5.1 promotes redirected native stderr to `ErrorRecord` objects. With `$ErrorActionPreference = 'Stop'`, the direct image-helper invocation could terminate on its first stderr line before reading `$LASTEXITCODE`, bypassing the repository's native-command compatibility layer and its stable validation message.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

Check what you actually ran. Skip items that do not apply and say so under Notes.
请勾选**实际跑过**的项；不适用的在 Notes 说明。

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [x] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [x] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

- Passed twice: `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\tests\run-tests.ps1`.
- The regression uses a Node `data:` preload to emit stderr under `$ErrorActionPreference = 'Stop'`; a valid image still parses, while an invalid image returns the friendly `Image metadata is invalid or exceeds...` error rather than `NativeCommandError`.
- The warning lines in the suite output are expected fault-injection coverage for runtime and atomic-cleanup failure paths.
- Passed: PowerShell parser checks for the changed scripts and `git diff --check`.
- Updated `windows/CHANGELOG.md`; the template's changelog checkbox is macOS-specific.
- Environment: Windows 11 build 26200; Windows PowerShell 5.1.26100.8875; Node.js 22.22.2.
- No live Codex restart or renderer injection was needed because the change is isolated to pre-import image validation.

Fixes #112
