### PR TITLE
fix(windows): allow empty tray menu collections

### DIFF
--- a/windows/scripts/tray-dream-skin.ps1
+++ b/windows/scripts/tray-dream-skin.ps1
@@ -50,7 +50,7 @@ try {
 
   function Add-DreamSkinTrayItem {
     param(
-      [Parameter(Mandatory = $true)][System.Windows.Forms.ToolStripItemCollection]$Items,
+      [Parameter(Mandatory = $true)][AllowEmptyCollection()][System.Windows.Forms.ToolStripItemCollection]$Items,
       [Parameter(Mandatory = $true)][string]$Text,
       [AllowNull()][scriptblock]$Action,
       [bool]$Enabled = $true


### PR DESCRIPTION
## Summary / 摘要

- Fixed the Windows tray menu crash when opening an empty menu collection.
- Added `AllowEmptyCollection` to the tray item helper parameter.
- Prevented PowerShell parameter binding errors during tray menu rebuild.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify: `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke / 恢复再应用冒烟测试

### Windows (when code under `windows/` changes)

- [x] Relevant Windows regression tests passed / Windows 相关回归测试已通过
- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 相关脚本已实际运行
- [x] Environment noted below / 已在下方注明环境

## User-facing / 用户可见变更

- [x] N/A — no changelog update required / 无需更新 changelog

## Security / 安全

- [x] Does not modify official Codex install / asar / signatures
- [x] Does not silently write API Base URL or keys
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable

## Notes / 补充

- Test command: `powershell -NoProfile -ExecutionPolicy Bypass -File windows/tests/run-tests.ps1`
- Result: `PASS: config transactions, restore scoping, state safety, argument quoting, and loopback CDP validation.`
- Environment: Windows PowerShell 5.1, .NET Framework 4.8, Windows 10 build 19041.
- The test run emitted cleanup warnings for temporary test artifacts, but the test suite passed.
- No screenshots included; this is a Windows PowerShell tray-menu bug fix.