### PR TITLE
fix(macos): validate trusted Node before hot reapply

### DIFF
--- a/macos/CHANGELOG.md
+++ b/macos/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### 安全
 
+- 热切换现在会重新发现并校验官方 Codex bundle，在执行注入器前按 Apple 信任链、固定 OpenAI Team ID、架构和最低版本校验内置 Node；不再信任继承的 `NODE` 或 bundle 路径。
 - CDP 端点必须由已验证的官方 Codex 可执行文件或其子进程监听；WebSocket 还会校验 loopback、page ID、路径、无重定向，并安全处理畸形消息和发送异常。
 - 主题配置与图片使用真实路径 containment，拒绝 symlink 越界、空文件、超过 16 MB、单边超过 16384 px 或超过 50 MP 的图片；主题展示文本拒绝换行和控制字符。
 - AppleScript 动态内容全部通过 argv 传递；SwiftBar 过滤主题 ID、文件名和菜单文本，避免主题元数据改变菜单属性或命令参数。

--- a/macos/CHANGELOG.md
+++ b/macos/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### 安全
 
-- 热切换现在会重新发现并校验官方 Codex bundle，在执行注入器前按 Apple 信任链、固定 OpenAI Team ID、架构和最低版本校验内置 Node；不再信任继承的 `NODE` 或 bundle 路径。
+- 热切换和菜单栏应用现在都会重新发现并校验官方 Codex bundle，在执行注入器或读取状态前按 Apple 信任链、固定 OpenAI Team ID、架构和最低版本校验内置 Node；不再信任继承的 `NODE` 或 bundle 路径。
 - CDP 端点必须由已验证的官方 Codex 可执行文件或其子进程监听；WebSocket 还会校验 loopback、page ID、路径、无重定向，并安全处理畸形消息和发送异常。
 - 主题配置与图片使用真实路径 containment，拒绝 symlink 越界、空文件、超过 16 MB、单边超过 16384 px 或超过 50 MP 的图片；主题展示文本拒绝换行和控制字符。
 - AppleScript 动态内容全部通过 argv 传递；SwiftBar 过滤主题 ID、文件名和菜单文本，避免主题元数据改变菜单属性或命令参数。

--- a/macos/scripts/apply-from-menubar-macos.sh
+++ b/macos/scripts/apply-from-menubar-macos.sh
@@ -51,12 +51,6 @@ progress "已收到点击…"
   exit 1
 }
 
-PORT=9341
-if [ -f "$STATE_PATH" ]; then
-  saved_port="$(state_field port 2>/dev/null || true)"
-  [ -n "${saved_port:-}" ] && PORT="$saved_port"
-fi
-
 CHEAP_RUNNING="false"
 /usr/bin/pgrep -x ChatGPT >/dev/null 2>&1 && CHEAP_RUNNING="true"
 
@@ -82,6 +76,14 @@ fi
 if ! require_macos_runtime >>"$LOG_OUT" 2>&1; then
   alert "Codex 运行时校验失败。"
   exit 1
+fi
+
+# state_field runs the bundled Node runtime, so do not inspect saved state
+# until the official runtime has been selected and validated.
+PORT=9341
+if [ -f "$STATE_PATH" ]; then
+  saved_port="$(state_field port 2>/dev/null || true)"
+  [ -n "${saved_port:-}" ] && PORT="$saved_port"
 fi
 
 ensure_state_root

--- a/macos/scripts/common-macos.sh
+++ b/macos/scripts/common-macos.sh
@@ -25,7 +25,8 @@ APP_ERROR_LOG="$STATE_ROOT/codex-launch-error.log"
 START_ERROR_LOG="$STATE_ROOT/start-error.log"
 CODEX_APP_JOB_LABEL="com.openai.codex-dream-skin-studio.app"
 INJECTOR_JOB_LABEL="com.openai.codex-dream-skin-studio.injector"
-EXPECTED_CODEX_TEAM_ID="${CODEX_EXPECTED_TEAM_ID:-2DC432GLL2}"
+EXPECTED_CODEX_TEAM_ID="2DC432GLL2"
+EXPECTED_CODEX_REQUIREMENT="anchor apple generic and certificate leaf[subject.OU] = \"$EXPECTED_CODEX_TEAM_ID\""
 SKIN_VERSION="1.2.0"
 
 fail() {
@@ -92,6 +93,10 @@ discover_codex_app() {
   local executable_name=""
   local configured="${CODEX_APP_BUNDLE:-}"
 
+  CODEX_BUNDLE=""
+  CODEX_EXE=""
+  CODEX_VERSION=""
+
   for candidate in "$configured" \
     "/Applications/ChatGPT.app" "$HOME/Applications/ChatGPT.app" \
     "/Applications/Codex.app" "$HOME/Applications/Codex.app"; do
@@ -125,23 +130,25 @@ codesign_team_id() {
     | /usr/bin/awk -F= '/^TeamIdentifier=/{print $2; exit}'
 }
 
-require_macos_runtime() {
+require_macos_node_runtime() {
   [ "$(/usr/bin/uname -s)" = "Darwin" ] || fail "This launcher requires macOS."
   [ -n "${CODEX_BUNDLE:-}" ] || fail "Discover the Codex app before validating its runtime."
 
   RUNTIME_NODE="$CODEX_BUNDLE/Contents/Resources/cua_node/bin/node"
   [ -x "$RUNTIME_NODE" ] || fail "The signed Node.js runtime bundled with Codex was not found: $RUNTIME_NODE"
-  /usr/bin/codesign --verify --deep --strict "$CODEX_BUNDLE" >/dev/null 2>&1 \
+  /usr/bin/codesign --verify --strict \
+    --test-requirement "=$EXPECTED_CODEX_REQUIREMENT" "$CODEX_BUNDLE" >/dev/null 2>&1 \
     || fail "The Codex app signature is not valid. Restore or reinstall the official app before continuing."
-  /usr/bin/codesign --verify --strict "$RUNTIME_NODE" >/dev/null 2>&1 \
+  /usr/bin/codesign --verify --strict \
+    --test-requirement "=$EXPECTED_CODEX_REQUIREMENT" "$RUNTIME_NODE" >/dev/null 2>&1 \
     || fail "The Node.js runtime bundled with Codex failed code-signature validation."
 
   CODEX_TEAM_ID="$(codesign_team_id "$CODEX_BUNDLE")"
   NODE_TEAM_ID="$(codesign_team_id "$RUNTIME_NODE")"
   [ "$CODEX_TEAM_ID" = "$EXPECTED_CODEX_TEAM_ID" ] \
     || fail "Unexpected Codex signing team: ${CODEX_TEAM_ID:-missing}."
-  [ "$NODE_TEAM_ID" = "$CODEX_TEAM_ID" ] \
-    || fail "The bundled Node.js signer does not match the Codex app signer."
+  [ "$NODE_TEAM_ID" = "$EXPECTED_CODEX_TEAM_ID" ] \
+    || fail "Unexpected bundled Node.js signing team: ${NODE_TEAM_ID:-missing}."
 
   local machine_arch
   local node_major
@@ -156,6 +163,14 @@ require_macos_runtime() {
 
   NODE="$RUNTIME_NODE"
   export NODE RUNTIME_NODE NODE_VERSION CODEX_TEAM_ID NODE_TEAM_ID
+}
+
+require_macos_runtime() {
+  [ "$(/usr/bin/uname -s)" = "Darwin" ] || fail "This launcher requires macOS."
+  [ -n "${CODEX_BUNDLE:-}" ] || fail "Discover the Codex app before validating its runtime."
+  /usr/bin/codesign --verify --deep --strict "$CODEX_BUNDLE" >/dev/null 2>&1 \
+    || fail "The Codex app signature is not valid. Restore or reinstall the official app before continuing."
+  require_macos_node_runtime
 }
 
 codex_main_pids() {
@@ -514,44 +529,11 @@ launch_injector_daemon() {
   fail "The injector did not start. See $INJECTOR_ERROR_LOG and $INJECTOR_LOG"
 }
 
-# Resolve Node quickly: prefer known Codex path, else full runtime check.
+# Resolve Node through the official Codex bundle before it can run the injector.
 ensure_node_runtime() {
-  if [ -n "${NODE:-}" ] && [ -x "${NODE:-}" ]; then
-    if [ -z "${NODE_VERSION:-}" ]; then
-      NODE_VERSION="$("$NODE" --version 2>/dev/null || echo unknown)"
-      export NODE_VERSION
-    fi
-    # Fill CODEX_* if missing so write_state does not explode under set -u
-    : "${CODEX_BUNDLE:=}"
-    : "${CODEX_EXE:=}"
-    : "${CODEX_VERSION:=}"
-    : "${CODEX_TEAM_ID:=}"
-    return 0
-  fi
-  local candidate cand_bundle
-  for candidate in \
-    "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node" \
-    "/Applications/Codex.app/Contents/Resources/cua_node/bin/node" \
-    "$HOME/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node" \
-    "$HOME/Applications/Codex.app/Contents/Resources/cua_node/bin/node"
-  do
-    if [ -x "$candidate" ]; then
-      NODE="$candidate"
-      NODE_VERSION="$("$NODE" --version 2>/dev/null || echo unknown)"
-      export NODE NODE_VERSION
-      # Derive the bundle from the chosen node so CODEX_* matches the app that
-      # actually exists on disk (Codex.app vs renamed ChatGPT.app).
-      cand_bundle="${candidate%/Contents/Resources/cua_node/bin/node}"
-      : "${CODEX_BUNDLE:=$cand_bundle}"
-      : "${CODEX_EXE:=$cand_bundle/Contents/MacOS/ChatGPT}"
-      : "${CODEX_VERSION:=}"
-      : "${CODEX_TEAM_ID:=}"
-      restore_runtime_context_from_state
-      return 0
-    fi
-  done
+  unset CODEX_BUNDLE CODEX_EXE CODEX_VERSION CODEX_TEAM_ID
   discover_codex_app
-  require_macos_runtime
+  require_macos_node_runtime
 }
 
 # Fast path when CDP is already open: restart injector + one-shot inject.

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -295,6 +295,17 @@ TRUSTED_NODE="$TMP/trusted-node"
 /usr/bin/grep -F -q -- '--test-requirement "=$EXPECTED_CODEX_REQUIREMENT" "$CODEX_BUNDLE"' "$ROOT/scripts/common-macos.sh"
 /usr/bin/grep -F -q -- '--test-requirement "=$EXPECTED_CODEX_REQUIREMENT" "$RUNTIME_NODE"' "$ROOT/scripts/common-macos.sh"
 
+# The menu-bar entrypoint must validate the official runtime before reading
+# state through state_field, which executes the selected bundled Node binary.
+MENUBAR_APPLY="$ROOT/scripts/apply-from-menubar-macos.sh"
+MENUBAR_RUNTIME_LINE="$(/usr/bin/grep -n -F 'if ! require_macos_runtime' "$MENUBAR_APPLY" | /usr/bin/head -n 1 | /usr/bin/cut -d: -f1)"
+MENUBAR_STATE_LINE="$(/usr/bin/grep -n -F 'saved_port="$(state_field port' "$MENUBAR_APPLY" | /usr/bin/head -n 1 | /usr/bin/cut -d: -f1)"
+[ -n "$MENUBAR_RUNTIME_LINE" ] && [ -n "$MENUBAR_STATE_LINE" ] \
+  && [ "$MENUBAR_RUNTIME_LINE" -lt "$MENUBAR_STATE_LINE" ] || {
+  printf 'Menu-bar state reads must follow official runtime validation.\n' >&2
+  exit 1
+}
+
 # A reused live PID must never be killed or treated as a successfully stopped
 # injector when its command identity does not match the recorded watcher.
 STOP_HOME="$TMP/stop-home"

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -231,9 +231,9 @@ EXPECTED_TEAM_ID="TEAM'ID"
   const [file, codexBundle, codexExe, codexVersion, codexTeamId] = process.argv.slice(1);
   fs.writeFileSync(file, `${JSON.stringify({ codexBundle, codexExe, codexVersion, codexTeamId })}\n`);
 ' "$RUNTIME_STATE" "$EXPECTED_BUNDLE" "$EXPECTED_EXE" "$EXPECTED_VERSION" "$EXPECTED_TEAM_ID"
-/usr/bin/env -u NODE -u NODE_VERSION HOME="$RUNTIME_HOME" /bin/bash -c '
+/usr/bin/env NODE="$NODE" HOME="$RUNTIME_HOME" /bin/bash -c '
   . "$1/scripts/common-macos.sh"
-  ensure_node_runtime
+  restore_runtime_context_from_state
   [ "$CODEX_BUNDLE" = "$2" ]
   [ "$CODEX_EXE" = "$3" ]
   [ "$CODEX_VERSION" = "$4" ]
@@ -243,6 +243,57 @@ EXPECTED_TEAM_ID="TEAM'ID"
   printf 'Runtime state values were evaluated as shell code.\n' >&2
   exit 1
 }
+
+# The hot path must ignore an inherited NODE and call the trusted bundled-node
+# validation after discovering the official Codex bundle.
+FAST_RUNTIME_MARKER="$TMP/runtime-fast-path.log"
+UNTRUSTED_NODE="$TMP/untrusted-node"
+UNTRUSTED_NODE_MARKER="$TMP/untrusted-node-executed"
+INHERITED_BUNDLE="$TMP/inherited-Codex.app"
+TRUSTED_NODE="$TMP/trusted-node"
+/usr/bin/printf '%s\n' \
+  '#!/bin/bash' \
+  'printf "untrusted\\n" >> "$UNTRUSTED_NODE_MARKER"' \
+  'exit 0' > "$UNTRUSTED_NODE"
+/usr/bin/printf '#!/bin/bash\nexit 0\n' > "$TRUSTED_NODE"
+/bin/chmod +x "$UNTRUSTED_NODE" "$TRUSTED_NODE"
+/usr/bin/env HOME="$RUNTIME_HOME" NODE="$UNTRUSTED_NODE" CODEX_EXPECTED_TEAM_ID="UNTRUSTED" \
+  CODEX_BUNDLE="$INHERITED_BUNDLE" CODEX_EXE="/tmp/untrusted-codex" CODEX_VERSION="untrusted" \
+  CODEX_TEAM_ID="UNTRUSTED" UNTRUSTED_NODE_MARKER="$UNTRUSTED_NODE_MARKER" /bin/bash -c '
+  . "$1/scripts/common-macos.sh"
+  [ "$EXPECTED_CODEX_TEAM_ID" = "2DC432GLL2" ]
+  test_bundle="$2"
+  test_trusted_node="$3"
+  test_marker="$4"
+  discover_codex_app() {
+    [ -z "${CODEX_BUNDLE:-}" ]
+    [ -z "${CODEX_EXE:-}" ]
+    [ -z "${CODEX_VERSION:-}" ]
+    [ -z "${CODEX_TEAM_ID:-}" ]
+    CODEX_BUNDLE="$test_bundle"
+    CODEX_EXE="$test_bundle/Contents/MacOS/ChatGPT"
+    CODEX_VERSION="test"
+    export CODEX_BUNDLE CODEX_EXE CODEX_VERSION
+    printf "discover\\n" >> "$test_marker"
+  }
+  require_macos_node_runtime() {
+    NODE="$test_trusted_node"
+    RUNTIME_NODE="$test_trusted_node"
+    NODE_VERSION="v22.0.0"
+    CODEX_TEAM_ID="2DC432GLL2"
+    NODE_TEAM_ID="2DC432GLL2"
+    export NODE RUNTIME_NODE NODE_VERSION CODEX_TEAM_ID NODE_TEAM_ID
+    printf "validate\\n" >> "$test_marker"
+  }
+  ensure_node_runtime
+  [ "$NODE" = "$test_trusted_node" ]
+  [ ! -e "$UNTRUSTED_NODE_MARKER" ]
+' _ "$ROOT" "$EXPECTED_BUNDLE" "$TRUSTED_NODE" "$FAST_RUNTIME_MARKER"
+/usr/bin/grep -Fx -q 'discover' "$FAST_RUNTIME_MARKER"
+/usr/bin/grep -Fx -q 'validate' "$FAST_RUNTIME_MARKER"
+/usr/bin/grep -F -q 'EXPECTED_CODEX_REQUIREMENT="anchor apple generic' "$ROOT/scripts/common-macos.sh"
+/usr/bin/grep -F -q -- '--test-requirement "=$EXPECTED_CODEX_REQUIREMENT" "$CODEX_BUNDLE"' "$ROOT/scripts/common-macos.sh"
+/usr/bin/grep -F -q -- '--test-requirement "=$EXPECTED_CODEX_REQUIREMENT" "$RUNTIME_NODE"' "$ROOT/scripts/common-macos.sh"
 
 # A reused live PID must never be killed or treated as a successfully stopped
 # injector when its command identity does not match the recorded watcher.


### PR DESCRIPTION
## Summary / 摘要

### 中文

- 修复 #12：热切换不再接受继承的 `NODE` 或固定路径候选，而是重新发现官方 Codex bundle。
- 在任何内置 Node 执行前，对 bundle 和内置 Node 同时执行 Apple 信任链与固定 OpenAI Team ID 校验，并保留架构与最低 Node 版本检查。
- 菜单栏应用流程现在会先校验官方运行时，再通过 Node 读取已保存的状态端口。
- 新增回归断言，覆盖继承运行时/缓存 bundle 上下文被清除、受信任运行时校验被调用，以及菜单栏状态读取顺序。

### English

- Fixes #12: hot reapply no longer accepts an inherited `NODE` or fixed-path candidate; it rediscovers the official Codex bundle.
- Before any bundled Node execution, both the bundle and bundled Node are checked against the Apple trust anchor and pinned OpenAI Team ID, while architecture and minimum Node-version checks remain in place.
- The menu-bar apply flow now validates the official runtime before it reads the saved state port through Node.
- Adds regression assertions for clearing inherited runtime/cache context, invoking trusted runtime validation, and preserving the menu-bar validation order.

Fixes #12

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [x] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

### 中文

- 已通过全部 macOS shell 脚本的 `bash -n` 检查、3 个便携 Node 回归模块、`injector.mjs --check-payload`，以及针对继承运行时与菜单栏顺序的 focused regression fixture。
- `macos/tests/run-tests.sh`、Doctor 和真实桌面验证需在安装了已签名 Codex 的 macOS 环境补跑；本次 Windows 主机未执行这些平台专属步骤。
- 本次为运行时安全行为改动，无视觉界面变化，因此不附截图。

### English

- Passed `bash -n` for all macOS shell scripts, three portable Node regression modules, `injector.mjs --check-payload`, and focused regression fixtures for inherited runtime handling and menu-bar ordering.
- The full `macos/tests/run-tests.sh`, Doctor, and live desktop verification need a macOS host with a signed Codex installation; those platform-specific steps were not run on this Windows host.
- This is a runtime-security behavior change with no visual UI change, so no screenshot is included.
