### PR TITLE
[codex] fix(macos): validate Node before state reads

### DIFF
--- a/macos/CHANGELOG.md
+++ b/macos/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - CDP 端点必须由已验证的官方 Codex 可执行文件或其子进程监听；WebSocket 还会校验 loopback、page ID、路径、无重定向，并安全处理畸形消息和发送异常。
 - App 与 bundled Node 必须满足固定的 OpenAI Team ID 和 Apple signing requirement；热应用不再信任外部 `NODE` 或 `state.json` 中缓存的运行时身份，CDP 祖先还会核对进程的真实 executable path。
+- 运行状态读取会在执行 Node 前自行确认已验证的 bundled runtime，避免调用顺序变化重新引入未验证执行；感谢 @guiguili520 报告 #12，以及 @rwang23 提供原始修复实现。
 - 主题配置与图片使用真实路径 containment，拒绝 symlink 越界、空文件、超过 16 MB、单边超过 16384 px 或超过 50 MP 的图片；主题展示文本拒绝换行和控制字符。
 - AppleScript 动态内容全部通过 argv 传递；SwiftBar 过滤主题 ID、文件名和菜单文本，避免主题元数据改变菜单属性或命令参数。
 - `config.toml` 只按严格 UTF-8 读取，拒绝 NUL、歧义多行 TOML、重复 `[desktop]`，通过用户级锁、原始字节核验和同目录原子替换保护中文配置与并发写入。

--- a/macos/references/runtime-notes.md
+++ b/macos/references/runtime-notes.md
@@ -2,6 +2,7 @@
 
 - Discover the official `com.openai.codex` bundle on every launch; do not assume an upgrade keeps the same executable internals.
 - Use `Contents/Resources/cua_node/bin/node` from that bundle. Require Node.js 20+, a valid strict code signature, matching architecture, and OpenAI Team ID `2DC432GLL2` on both app and runtime.
+- State readers that can run before a validated launch must establish this runtime identity at their own execution boundary; never treat an inherited `NODE` value as proof of trust.
 - Do not ship a Node binary and do not depend on a globally installed `node` or `npm`.
 - Launch the official executable through a per-user `launchd` job with `--remote-debugging-address=127.0.0.1` and a selected port. LaunchServices may discard Chromium flags.
 - Prefer port `9341`; scan through `9441` on collision and record the selected port in state.

--- a/macos/scripts/common-macos.sh
+++ b/macos/scripts/common-macos.sh
@@ -268,9 +268,17 @@ codesign_team_id() {
     | /usr/bin/awk -F= '/^TeamIdentifier=/{print $2; exit}'
 }
 
+remember_validated_runtime_identity() {
+  DREAM_SKIN_VALIDATED_RUNTIME_PID="$$"
+  DREAM_SKIN_VALIDATED_RUNTIME_BUNDLE="$CODEX_BUNDLE"
+  DREAM_SKIN_VALIDATED_RUNTIME_EXE="$CODEX_EXE"
+  DREAM_SKIN_VALIDATED_RUNTIME_NODE="$NODE"
+}
+
 require_signed_node_runtime() {
   [ "$(/usr/bin/uname -s)" = "Darwin" ] || fail "This launcher requires macOS."
-  [ -n "${CODEX_BUNDLE:-}" ] || fail "Discover the ChatGPT app before validating its runtime."
+  [ -n "${CODEX_BUNDLE:-}" ] && [ -n "${CODEX_EXE:-}" ] \
+    || fail "Discover the ChatGPT app before validating its runtime."
 
   RUNTIME_NODE="$CODEX_BUNDLE/Contents/Resources/cua_node/bin/node"
   [ -x "$RUNTIME_NODE" ] || fail "The signed Node.js runtime bundled with ChatGPT was not found: $RUNTIME_NODE"
@@ -298,6 +306,7 @@ require_signed_node_runtime() {
 
   NODE="$RUNTIME_NODE"
   export NODE RUNTIME_NODE NODE_VERSION CODEX_TEAM_ID NODE_TEAM_ID
+  remember_validated_runtime_identity
 }
 
 verify_macos_app_signature() {
@@ -513,6 +522,7 @@ wait_for_cdp() {
 
 state_field() {
   local key="$1"
+  ensure_node_runtime
   "$NODE" -e '
     const fs = require("node:fs");
     const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))[process.argv[2]];
@@ -741,10 +751,6 @@ ensure_node_runtime() {
   fi
   discover_codex_app
   require_signed_node_runtime
-  DREAM_SKIN_VALIDATED_RUNTIME_PID="$$"
-  DREAM_SKIN_VALIDATED_RUNTIME_BUNDLE="$CODEX_BUNDLE"
-  DREAM_SKIN_VALIDATED_RUNTIME_EXE="$CODEX_EXE"
-  DREAM_SKIN_VALIDATED_RUNTIME_NODE="$NODE"
 }
 
 # Fast path when CDP is already open: restart injector + one-shot inject.

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -225,19 +225,21 @@ RUNTIME_HOME="$TMP/runtime-home"
 RUNTIME_STATE_ROOT="$RUNTIME_HOME/Library/Application Support/CodexDreamSkinStudio"
 RUNTIME_STATE="$RUNTIME_STATE_ROOT/state.json"
 STATE_EVAL_MARKER="$TMP/state-eval-marker"
+UNTRUSTED_NODE_MARKER="$TMP/untrusted-node-executed"
 UNTRUSTED_BUNDLE="$TMP/evil-root/Codex \"Skin\".app"
 UNTRUSTED_EXE="$UNTRUSTED_BUNDLE/Contents/MacOS/ChatGPT"
 UNTRUSTED_VERSION="1.1.2 \$(touch \"$STATE_EVAL_MARKER\") ; echo pwned"
 UNTRUSTED_TEAM_ID="TEAM'ID"
 /bin/mkdir -p "$RUNTIME_STATE_ROOT" "$UNTRUSTED_BUNDLE/Contents/MacOS"
-/usr/bin/printf '#!/bin/bash\ntrue\n' > "$UNTRUSTED_EXE"
+/usr/bin/printf '#!/bin/bash\n/usr/bin/touch "${UNTRUSTED_NODE_MARKER:?}"\nexit 97\n' > "$UNTRUSTED_EXE"
 /bin/chmod +x "$UNTRUSTED_EXE"
 "$NODE" -e '
   const fs = require("node:fs");
   const [file, codexBundle, codexExe, codexVersion, codexTeamId] = process.argv.slice(1);
   fs.writeFileSync(file, `${JSON.stringify({ codexBundle, codexExe, codexVersion, codexTeamId })}\n`);
 ' "$RUNTIME_STATE" "$UNTRUSTED_BUNDLE" "$UNTRUSTED_EXE" "$UNTRUSTED_VERSION" "$UNTRUSTED_TEAM_ID"
-/usr/bin/env HOME="$RUNTIME_HOME" NODE="$UNTRUSTED_EXE" NODE_VERSION="untrusted" /bin/bash -c '
+/usr/bin/env HOME="$RUNTIME_HOME" NODE="$UNTRUSTED_EXE" NODE_VERSION="untrusted" \
+  UNTRUSTED_NODE_MARKER="$UNTRUSTED_NODE_MARKER" /bin/bash -c '
   . "$1/scripts/common-macos.sh"
   TRUSTED_BUNDLE="$2"
   TRUSTED_EXE="$3"
@@ -255,7 +257,9 @@ UNTRUSTED_TEAM_ID="TEAM'ID"
     NODE="$TRUSTED_NODE"
     NODE_VERSION="v22.0.0"
     CODEX_TEAM_ID="2DC432GLL2"
+    remember_validated_runtime_identity
   }
+  state_field codexVersion >/dev/null
   ensure_node_runtime
   ensure_node_runtime
   [ "$DISCOVER_CALLS" -eq 1 ]
@@ -265,6 +269,10 @@ UNTRUSTED_TEAM_ID="TEAM'ID"
   [ "$CODEX_EXE" = "$TRUSTED_EXE" ]
   [ "$CODEX_TEAM_ID" = "2DC432GLL2" ]
 ' _ "$ROOT" "/trusted/ChatGPT.app" "/trusted/ChatGPT.app/Contents/MacOS/ChatGPT" "$NODE"
+[ ! -e "$UNTRUSTED_NODE_MARKER" ] || {
+  printf 'state_field executed an inherited, unvalidated Node runtime.\n' >&2
+  exit 1
+}
 [ ! -e "$STATE_EVAL_MARKER" ] || {
   printf 'Runtime state values were evaluated as shell code.\n' >&2
   exit 1


### PR DESCRIPTION
## Summary / 摘要

- Make `state_field` establish the signed bundled-Node identity before it executes Node, so an inherited `NODE` cannot cross the state-read boundary even if caller order changes.
- Record successful runtime validation at the validation source and reuse the existing per-process identity cache without repeating signature checks.
- Add a sentinel regression that makes `state_field` the first runtime consumer and fails if the inherited executable runs at all.
- Credit issue reporter @guiguili520 and original fix contributor @rwang23 (Renfei Wang); the commit also carries Renfei Wang's `Co-authored-by` trailer.

Addresses #12. Supersedes the conflicting implementation in #125 while preserving its author credit.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [x] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [x] `macos/tests/run-tests.sh` passed / 已通过
- [x] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [x] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

- Passed `/bin/bash -n macos/scripts/common-macos.sh` and `/bin/bash -n macos/tests/run-tests.sh`.
- Passed `cd macos && npm test`, including runtime-state safety, signature, configuration round-trip, and Doctor regression checks.
- Real installed-environment Doctor passed on `darwin-x86_64` with ChatGPT `26.715.21425`, Team ID `2DC432GLL2`, bundled Node `v24.14.0`, valid official signature, and `modifiesAppAsar: false`.
- Live verify and restore/re-apply smoke are not applicable: this change does not modify injection, CSS, renderer, start, install, restore, or visual behavior. The deterministic inherited-Node sentinel directly covers the changed boundary.
- No screenshots: this is a non-visual runtime-security fix.
