### PR TITLE
ci(macos): run native repository regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,25 @@ jobs:
       - name: Run Windows regression suite
         shell: cmd
         run: ${{ matrix.executable }} -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\windows\tests\run-tests.ps1
+
+  macos-tests:
+    name: macOS repository regressions
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Locate runner Node.js
+        id: node
+        shell: bash
+        run: echo "path=$(command -v node)" >> "$GITHUB_OUTPUT"
+
+      - name: Run macOS regressions without installed-app checks
+        shell: bash
+        env:
+          NODE: ${{ steps.node.outputs.path }}
+          CODEX_DREAM_SKIN_SKIP_SIGNED_RUNTIME_TESTS: "1"
+          CODEX_DREAM_SKIN_SKIP_DOCTOR: "1"
+        run: ./macos/tests/run-tests.sh

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -201,34 +201,42 @@ fi
   [ "$seeded" -eq 2 ] || exit 1
 ' _ "$ROOT"
 
-# Theme switches stage files and publish theme.json last, preserving a complete
-# active pack while the watcher is running.
-SWITCH_HOME="$TMP/switch-home"
-SWITCH_STATE="$SWITCH_HOME/Library/Application Support/CodexDreamSkinStudio"
-/bin/mkdir -p "$SWITCH_STATE/themes/preset-switch-fixture" "$SWITCH_STATE/theme"
-/bin/cp "$ROOT/assets/portal-hero.png" "$SWITCH_STATE/themes/preset-switch-fixture/background.png"
-/usr/bin/printf '%s\n' \
-  '{"schemaVersion":1,"id":"preset-switch-fixture","name":"切换测试","image":"background.png"}' \
-  > "$SWITCH_STATE/themes/preset-switch-fixture/theme.json"
-/usr/bin/printf '%s\n' '{"schemaVersion":1,"id":"old","name":"旧主题","image":"old.png"}' \
-  > "$SWITCH_STATE/theme/theme.json"
-: > "$SWITCH_STATE/theme/old.png"
-if /usr/bin/env HOME="$SWITCH_HOME" NODE="$NODE" \
-  "$ROOT/scripts/switch-theme-macos.sh" --id '../escape' --no-apply >/dev/null 2>&1; then
-  printf 'switch-theme unexpectedly accepted a path traversal theme id.\n' >&2
-  exit 1
+run_signed_runtime_switch_test() {
+  local switch_home="$TMP/switch-home"
+  local switch_state="$switch_home/Library/Application Support/CodexDreamSkinStudio"
+  /bin/mkdir -p "$switch_state/themes/preset-switch-fixture" "$switch_state/theme"
+  /bin/cp "$ROOT/assets/portal-hero.png" "$switch_state/themes/preset-switch-fixture/background.png"
+  /usr/bin/printf '%s\n' \
+    '{"schemaVersion":1,"id":"preset-switch-fixture","name":"切换测试","image":"background.png"}' \
+    > "$switch_state/themes/preset-switch-fixture/theme.json"
+  /usr/bin/printf '%s\n' '{"schemaVersion":1,"id":"old","name":"旧主题","image":"old.png"}' \
+    > "$switch_state/theme/theme.json"
+  : > "$switch_state/theme/old.png"
+  if /usr/bin/env HOME="$switch_home" NODE="$NODE" \
+    "$ROOT/scripts/switch-theme-macos.sh" --id '../escape' --no-apply >/dev/null 2>&1; then
+    printf 'switch-theme unexpectedly accepted a path traversal theme id.\n' >&2
+    exit 1
+  fi
+  /usr/bin/env HOME="$switch_home" NODE="$NODE" \
+    "$ROOT/scripts/switch-theme-macos.sh" --id preset-switch-fixture --no-apply >/dev/null
+  /usr/bin/cmp -s "$switch_state/theme/background.png" \
+    "$switch_state/themes/preset-switch-fixture/background.png"
+  [ ! -e "$switch_state/theme/old.png" ]
+  "$NODE" -e '
+    const fs = require("fs");
+    const theme = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    if (theme.id !== "preset-switch-fixture" || theme.name !== "切换测试") process.exit(1);
+  ' "$switch_state/theme/theme.json"
+  [ -z "$(/usr/bin/find "$switch_state" -maxdepth 1 -name '.theme-switch.*' -print -quit)" ]
+}
+
+if [ "${CODEX_DREAM_SKIN_SKIP_SIGNED_RUNTIME_TESTS:-0}" = "1" ]; then
+  printf 'SKIP: switch-theme integration requires an installed, signed Codex app.\n'
+  SWITCH_RUNTIME_RESULT="skipped"
+else
+  run_signed_runtime_switch_test
+  SWITCH_RUNTIME_RESULT="passed"
 fi
-/usr/bin/env HOME="$SWITCH_HOME" NODE="$NODE" \
-  "$ROOT/scripts/switch-theme-macos.sh" --id preset-switch-fixture --no-apply >/dev/null
-/usr/bin/cmp -s "$SWITCH_STATE/theme/background.png" \
-  "$SWITCH_STATE/themes/preset-switch-fixture/background.png"
-[ ! -e "$SWITCH_STATE/theme/old.png" ]
-"$NODE" -e '
-  const fs = require("fs");
-  const theme = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-  if (theme.id !== "preset-switch-fixture" || theme.name !== "切换测试") process.exit(1);
-' "$SWITCH_STATE/theme/theme.json"
-[ -z "$(/usr/bin/find "$SWITCH_STATE" -maxdepth 1 -name '.theme-switch.*' -print -quit)" ]
 
 RUNTIME_HOME="$TMP/runtime-home"
 RUNTIME_STATE_ROOT="$RUNTIME_HOME/Library/Application Support/CodexDreamSkinStudio"
@@ -297,6 +305,7 @@ UNTRUSTED_TEAM_ID="TEAM'ID"
   if pid_is_codex_executable "$$" || pid_is_codex_descendant "$$"; then exit 1; fi
 ' _ "$ROOT"
 
+run_signed_runtime_state_tests() {
 # A reused live PID must never be killed or treated as a successfully stopped
 # injector when its command identity does not match the recorded watcher.
 STOP_HOME="$TMP/stop-home"
@@ -489,6 +498,15 @@ for state_payload in '{' '{}'; do
   ' _ "$ROOT" "$TEST_INJECTOR_JOB_LABEL"
   /usr/bin/cmp -s "$STOP_STATE_ROOT/state.json" "$STOP_STATE_ROOT/state.original"
 done
+}
+
+if [ "${CODEX_DREAM_SKIN_SKIP_SIGNED_RUNTIME_TESTS:-0}" = "1" ]; then
+  printf 'SKIP: runtime-state integration requires an installed, signed Codex app.\n'
+  RUNTIME_STATE_RESULT="skipped"
+else
+  run_signed_runtime_state_tests
+  RUNTIME_STATE_RESULT="passed"
+fi
 
 /bin/mkdir -p "$TMP/theme"
 /bin/cp "$ROOT/assets/portal-hero.png" "$TMP/theme/background.png"
@@ -823,6 +841,13 @@ CRLF_BACKUP="$TMP/config-crlf-backup.json"
 /usr/bin/cmp -s "$CRLF_CONFIG" "$TMP/original-crlf.toml"
 
 /usr/bin/env -u HOME /bin/bash -c '. "$1/scripts/common-macos.sh"; [ -n "$HOME" ] && [ "$SKIN_VERSION" = "1.2.0" ]' _ "$ROOT"
-"$ROOT/scripts/doctor-macos.sh" >/dev/null
+if [ "${CODEX_DREAM_SKIN_SKIP_DOCTOR:-0}" = "1" ]; then
+  printf 'SKIP: Doctor requires an installed, signed Codex app.\n'
+  DOCTOR_RESULT="skipped"
+else
+  "$ROOT/scripts/doctor-macos.sh" >/dev/null
+  DOCTOR_RESULT="passed"
+fi
 
-printf 'PASS: syntax, payload, bundled presets, preset seeding, runtime-state safety, custom-theme, config round-trips, HOME recovery, signature, and doctor checks.\n'
+printf 'PASS: syntax, payload, bundled presets, preset seeding, runtime-state safety, custom-theme, config round-trips, HOME recovery, signature, switch-theme signed runtime %s, runtime-state integration %s, and Doctor %s.\n' \
+  "$SWITCH_RUNTIME_RESULT" "$RUNTIME_STATE_RESULT" "$DOCTOR_RESULT"


### PR DESCRIPTION
## Summary / 摘要

### 中文

- 为 `#140` 增加 `macos-latest` 原生回归作业。它使用 `actions/setup-node` 提供的 Node 22 绝对路径运行现有 `macos/tests/run-tests.sh`。
- 测试入口新增 `CODEX_DREAM_SKIN_SKIP_SIGNED_RUNTIME_TESTS=1` 与 `CODEX_DREAM_SKIN_SKIP_DOCTOR=1` 两个明确分支。它们只跳过需要已安装、已签名 Codex 应用的 `switch-theme --no-apply`、runtime-state/status 运行时集成夹具与 `doctor-macos.sh`；未设置变量时，本地测试仍照常运行这些检查。
- CI 日志和最终摘要会明确写出 `switch-theme`、runtime-state/status 签名运行时检查与 Doctor 被跳过。这条作业不覆盖签名应用、实时 CDP 或界面验证。

Fixes #140.

### English

- Add the native `macos-latest` regression job requested in `#140`. It passes the absolute Node 22 path from `actions/setup-node` to the existing `macos/tests/run-tests.sh` entry point.
- Add explicit `CODEX_DREAM_SKIN_SKIP_SIGNED_RUNTIME_TESTS=1` and `CODEX_DREAM_SKIN_SKIP_DOCTOR=1` branches in the test runner. They skip only the `switch-theme --no-apply` and runtime-state/status runtime integration fixtures plus `doctor-macos.sh`, which require an installed, signed Codex app. Local runs still execute those checks when the variables are absent.
- CI logs and the final summary state that the `switch-theme`, runtime-state/status signed-runtime checks, and Doctor were skipped. This job does not cover a signed app, live CDP, or UI verification.

Fixes #140.

## Type / 类型

- [ ] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [x] Chore / 杂项

## Platform / 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

Check what you actually ran. Skip items that do not apply and say so under Notes.
请勾选**实际跑过**的项；不适用的在 Notes 说明。

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [x] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [x] N/A: no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

### 中文

- GitHub Actions 的原生 macOS 作业已通过：[`macOS repository regressions`](https://github.com/Fei-Away/Codex-Dream-Skin/actions/runs/29618967214/job/88009971949) 已实际运行 `macos/tests/run-tests.sh`，并明确记录三个签名应用依赖检查被跳过。
- 本地已验证：工作流 YAML 解析并确认 macOS job 与两个 hosted-runner 标志、全部 guard 的跳过和默认路径、`bash -n macos/tests/run-tests.sh`、三个可移植 macOS Node 回归、payload 检查，以及 `git diff --check`。
- `theme-stage.test.mjs` 在 Windows 11 本机因 symlink fixture 的 `EPERM` 退出；该原生链接测试已在上述 macOS runner 中通过。
- 此 PR 只改 CI 和测试入口。它不更改安装、启动、注入、恢复或主题渲染行为。

### English

- The native GitHub Actions macOS job passed: [`macOS repository regressions`](https://github.com/Fei-Away/Codex-Dream-Skin/actions/runs/29618967214/job/88009971949) actually ran `macos/tests/run-tests.sh` and explicitly logged the three skipped signed-app-dependent checks.
- Local checks passed: YAML parsing and macOS job assertions, every hosted-runner guard's skip and default path with a fake Doctor executable, `bash -n macos/tests/run-tests.sh`, three portable macOS Node regressions, payload validation, and `git diff --check`.
- `theme-stage.test.mjs` exited with `EPERM` on the Windows 11 host when creating its symlink fixture. That native-link test passed on the macOS runner above.
- This PR changes CI and the test entry point only. It does not alter installation, startup, injection, restore, or theme rendering behavior.
