### PR TITLE
test(docs): verify local documentation links / 验证本地文档链接

### DIFF
--- a/macos/tests/repository-doc-links.test.mjs
+++ b/macos/tests/repository-doc-links.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(here, "..", "..");
+
+async function markdownFiles(directory) {
+  const files = [];
+  for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    if (entry.name === ".git") continue;
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await markdownFiles(entryPath));
+    if (entry.isFile() && entry.name.endsWith(".md")) files.push(entryPath);
+  }
+  return files;
+}
+
+function hrefsFrom(markdown) {
+  const source = markdown.replace(/```[\s\S]*?```/g, "");
+  const hrefs = new Set();
+  const markdownLink = /!?\[[^\]]*\]\((?:<([^>]+)>|([^\s)]+))(?:\s+[^)]*)?\)/g;
+  const referenceLink = /^\s*\[[^\]]+\]:\s*(?:<([^>]+)>|(\S+))/gm;
+  const htmlLink = /\b(?:href|src)=["']([^"']+)["']/gi;
+
+  for (const pattern of [markdownLink, referenceLink, htmlLink]) {
+    for (const match of source.matchAll(pattern)) {
+      hrefs.add(match[1] ?? match[2]);
+    }
+  }
+  return hrefs;
+}
+
+function localTarget(fromFile, href) {
+  const value = href.trim();
+  if (!value || value.startsWith("#") || value.startsWith("/") ||
+      /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(value)) {
+    return null;
+  }
+
+  const pathname = value.split(/[?#]/, 1)[0];
+  if (!pathname) return null;
+  try {
+    return path.resolve(path.dirname(fromFile), decodeURIComponent(pathname));
+  } catch {
+    return path.resolve(path.dirname(fromFile), pathname);
+  }
+}
+
+const failures = [];
+for (const file of await markdownFiles(repositoryRoot)) {
+  const source = await fs.readFile(file, "utf8");
+  for (const href of hrefsFrom(source)) {
+    const target = localTarget(file, href);
+    if (!target) continue;
+    const relativeTarget = path.relative(repositoryRoot, target);
+    const isInsideRepository = relativeTarget === "" ||
+      (!relativeTarget.startsWith(`..${path.sep}`) && relativeTarget !== "..");
+    if (!isInsideRepository || !(await fs.stat(target).then(() => true, () => false))) {
+      failures.push(`${path.relative(repositoryRoot, file)} -> ${href}`);
+    }
+  }
+}
+
+assert.deepEqual(
+  failures,
+  [],
+  `Local documentation references must resolve inside the repository:\n${failures.join("\n")}`,
+);


### PR DESCRIPTION
## 中文

### 摘要

- 新增无依赖的 Node 回归测试，遍历仓库中的 Markdown 文件，检查本地 Markdown 链接、引用式链接和 HTML 的 `href` / `src` 是否解析到仓库内真实文件。
- 外部 URL、页内锚点和 fenced code 示例会被跳过，避免把文档示例当成文件路径。
- 测试放在现有的 `macos/tests` Node 集合中，静态 CI 会自动执行。

### 类型

- [ ] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [x] Chore / 杂项

### 平台

- [ ] macOS
- [ ] Windows
- [ ] Both / 双平台
- [x] Docs / repo only / 仅文档或仓库元数据

### 自测

- [x] `node --test macos/tests/repository-doc-links.test.mjs`
- [x] `node --test windows/tests/*.test.mjs`
- [x] `git diff --check`

### 安全

- [x] 不修改官方 Codex 安装、`app.asar` 或签名。
- [x] 不写入 API Base URL 或 Key。
- [x] CDP 行为不变，仍只使用本机回环地址。

### 说明

- 测试只读取仓库文件，不访问网络，也不修改文档内容。

## English

### Summary

- Adds a dependency-free Node regression test that walks repository Markdown and checks local Markdown links, reference links, and HTML `href` / `src` values against real files inside the repository.
- External URLs, page anchors, and fenced code examples are skipped so documentation examples are not treated as file paths.
- The test lives in the existing `macos/tests` Node set, which the static CI job already runs.

### Type

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Theme / CSS / visual
- [ ] Scripts / install / restore
- [x] Chore

### Platform

- [ ] macOS
- [ ] Windows
- [ ] Both
- [x] Docs / repo only

### Self-check

- [x] `node --test macos/tests/repository-doc-links.test.mjs`
- [x] `node --test windows/tests/*.test.mjs`
- [x] `git diff --check`

### Security

- [x] Does not modify the official Codex install, `app.asar`, or signatures.
- [x] Does not write API Base URLs or keys.
- [x] CDP behavior is unchanged and remains loopback-only.

### Notes

- The test only reads repository files. It does not access the network or modify documentation.