### PR TITLE
fix(macos): scope multiline-array check to [desktop] body only

### DIFF
--- a/macos/CHANGELOG.md
+++ b/macos/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### 修复
+
+- `theme-config.mjs` 将「多行数组」检查从整份 `config.toml` 收窄到 `[desktop]` 段内。此前 Codex 桌面自身会把 `notify` 等顶层数组序列化为跨行形式，导致安装或切主题时抛出 `Refusing to rewrite TOML containing multiline arrays.`，即便脚本从不改写这些字段；现在仅当 `[desktop]` 段内本身出现跨行数组时才拒绝写入，其余保护（多行字符串、重复段、软链、非 UTF-8、字节校验、原子替换、备份 schema）保持不变。
+
 ## 1.2.0 — 2026-07-17
 
 ### 新增

--- a/macos/scripts/theme-config.mjs
+++ b/macos/scripts/theme-config.mjs
@@ -232,8 +232,13 @@ async function main() {
   if (content.includes('"""') || content.includes("'''")) {
     throw new Error("Refusing to rewrite TOML containing multiline strings.");
   }
-  assertSupportedTomlLayout(content);
   let section = desktopSection(content);
+  // Only enforce the multiline-array restriction inside the [desktop] section
+  // that we actually rewrite. Multiline arrays elsewhere in config.toml
+  // (e.g. a top-level `notify = [ ... ]` that Codex itself formats across
+  // multiple lines) do not affect the [desktop] replacements and must not
+  // block installs or theme switches.
+  if (section) assertSupportedTomlLayout(section.body);
 
   if (mode === "install") {
     if (!section) {

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -813,6 +813,29 @@ MULTILINE_ARRAY_CONFIG="$TMP/config-multiline-array.toml"
 assert_theme_config_install_rejected multiline-array "$MULTILINE_ARRAY_CONFIG" \
   "$TMP/config-multiline-array-backup.json"
 
+# A multiline array outside [desktop] must not block install/restore. Codex
+# itself sometimes serializes top-level arrays like `notify = [ ... ]` across
+# several lines; theme-config.mjs only rewrites keys inside [desktop] and must
+# tolerate that layout everywhere else.
+OUTSIDE_MULTILINE_CONFIG="$TMP/config-outside-multiline-array.toml"
+OUTSIDE_MULTILINE_BACKUP="$TMP/config-outside-multiline-array-backup.json"
+/usr/bin/printf '%s\n' \
+  'notify = [' \
+  '    "/opt/notify",' \
+  '    "turn-ended",' \
+  ']' \
+  'model = "gpt-5"' \
+  '' \
+  '[desktop]' \
+  'appearanceTheme = "system"' \
+  > "$OUTSIDE_MULTILINE_CONFIG"
+/bin/cp "$OUTSIDE_MULTILINE_CONFIG" "$TMP/original-outside-multiline.toml"
+"$NODE" "$ROOT/scripts/theme-config.mjs" install \
+  "$OUTSIDE_MULTILINE_CONFIG" "$OUTSIDE_MULTILINE_BACKUP" >/dev/null
+"$NODE" "$ROOT/scripts/theme-config.mjs" restore \
+  "$OUTSIDE_MULTILINE_CONFIG" "$OUTSIDE_MULTILINE_BACKUP" >/dev/null
+/usr/bin/cmp -s "$OUTSIDE_MULTILINE_CONFIG" "$TMP/original-outside-multiline.toml"
+
 CRLF_CONFIG="$TMP/config-crlf.toml"
 CRLF_BACKUP="$TMP/config-crlf-backup.json"
 /usr/bin/printf '\357\273\277model = "gpt-5"\r\nproject = "中文项目"\r\n\r\n[desktop]\r\nappearanceTheme = "system"\r\n' \


### PR DESCRIPTION
## Summary

Closes the multiline-array assertion failure when the user's `~/.codex/config.toml` contains multiline arrays outside the `[desktop]` section (e.g. `notify = [...]` with line breaks).

### Root Cause

`theme-config.mjs` reads the entire `config.toml`, calls `assertSupportedTomlLayout(content)` which rejects any TOML file containing multiline arrays. However the script only ever modifies keys inside the `[desktop]` section — a small, single-line-only region. The blanket check is unnecessarily strict.

### Fix

Move the multiline-array assertion from the full file content to just the extracted `[desktop]` section body, so the script only validates the region it actually touches.

### Changes

| File | Change |
|------|--------|
| `macos/scripts/theme-config.mjs` | Scope `assertSupportedTomlLayout` to the `[desktop]` section body (the only region the script modifies) |
| `macos/tests/run-tests.sh` | Add `test_multiline_array_outside_desktop` to verify the fix with a real-world multiline array outside `[desktop]` |
| `macos/CHANGELOG.md` | Add `Unreleased` entry |

### Testing

```bash
cd macos && bash tests/run-tests.sh
```

All existing tests pass, plus the new `test_multiline_array_outside_desktop` case.

### Notes

- macOS only. Windows (`windows/scripts/config-utf8.ps1`) has a symmetrical implementation but was not modified as I have no Windows environment to validate against.
- This is a draft PR — feedback welcome!