### PR TITLE
修复 Gothic Void Crusade 暗色主题的对比度和边框

### DIFF
--- a/macos/assets/dream-skin.css
+++ b/macos/assets/dream-skin.css
@@ -1202,6 +1202,22 @@ html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
 
 html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
   .dream-skin-home .dream-skin-home-utility {
+  background: rgb(var(--ds-panel-rgb) / .92) !important;
+  color: var(--ds-text) !important;
+  margin-top: 8px !important;
+  border: 1px solid rgb(var(--ds-accent-rgb) / .34) !important;
+  border-radius: 18px !important;
+  box-shadow:
+    0 8px 22px rgb(var(--ds-bg-rgb) / .20),
+    inset 0 1px rgb(var(--ds-text-rgb) / .10) !important;
+}
+
+/* Keep the typed-home project bar readable during the short route-sync window
+   before Codex's generated utility bar receives its stable skin class. */
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  [role="main"]:has([data-feature="game-source"]) [class*="_homeUtilityBar_"] {
+  background: rgb(var(--ds-panel-rgb) / .92) !important;
+  color: var(--ds-text) !important;
   margin-top: 8px !important;
   border: 1px solid rgb(var(--ds-accent-rgb) / .34) !important;
   border-radius: 18px !important;
@@ -1211,11 +1227,69 @@ html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
 }
 
 html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  [role="main"]:has([data-feature="game-source"]) [class*="_homeUtilityBar_"] button {
+  color: rgb(var(--ds-muted-rgb) / .96) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  [role="main"]:has([data-feature="game-source"]) [class*="_homeUtilityBar_"] button * {
+  color: currentColor !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
   .dream-skin-home .group\/home-suggestions button.group\/home-suggestion-list-item {
   border: 1px solid rgb(var(--ds-accent-rgb) / .26) !important;
   box-shadow:
     0 8px 22px rgb(var(--ds-bg-rgb) / .18),
     inset 0 0 0 1px rgb(var(--ds-accent-rgb) / .08) !important;
+}
+
+/* The thread summary is rendered as a floating native dropdown, so bridge its
+   light-shell tokens only when Gothic is the active preset. */
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  div[class~="bg-token-dropdown-background"][class~="rounded-3xl"]:has([data-slot="thread-summary-panel-item-button"]) {
+  --color-token-dropdown-background: rgb(var(--ds-panel-rgb) / .94);
+  --color-token-conversation-summary-trailing: rgb(var(--ds-muted-rgb) / .82);
+  --color-token-border-default: rgb(var(--ds-accent-rgb) / .26);
+  --color-token-list-hover-background: rgb(var(--ds-accent-rgb) / .12);
+  background: rgb(var(--ds-panel-rgb) / .94) !important;
+  color: var(--ds-text) !important;
+  border: 1px solid rgb(var(--ds-accent-rgb) / .36) !important;
+  box-shadow:
+    0 18px 48px rgb(var(--ds-bg-rgb) / .42),
+    inset 0 1px rgb(var(--ds-text-rgb) / .10) !important;
+  backdrop-filter: blur(16px) saturate(108%);
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  div[class~="bg-token-dropdown-background"]:has([data-slot="thread-summary-panel-item-button"])
+  header[class~="bg-token-dropdown-background"] {
+  background: rgb(var(--ds-panel-rgb) / .96) !important;
+  color: var(--ds-accent) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  div[class~="bg-token-dropdown-background"]:has([data-slot="thread-summary-panel-item-button"])
+  :is([data-slot="thread-summary-panel-item-button"], [data-slot="thread-summary-panel-item-label"]) {
+  color: rgb(var(--ds-muted-rgb) / .96) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  div[class~="bg-token-dropdown-background"]:has([data-slot="thread-summary-panel-item-button"])
+  :is([data-slot="thread-summary-panel-section-actions"], [class~="text-token-conversation-summary-trailing"]) {
+  color: rgb(var(--ds-muted-rgb) / .82) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  div[class~="bg-token-dropdown-background"]:has([data-slot="thread-summary-panel-item-button"])
+  [data-slot="thread-summary-panel-item-button"]:hover {
+  color: var(--ds-text) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  div[class~="bg-token-dropdown-background"]:has([data-slot="thread-summary-panel-item-button"])
+  svg {
+  color: currentColor !important;
 }
 
 html.codex-dream-skin .ProseMirror {

--- a/macos/assets/dream-skin.css
+++ b/macos/assets/dream-skin.css
@@ -263,6 +263,20 @@ html.codex-dream-skin aside.app-shell-left-panel [aria-current="page"] svg {
   color: var(--ds-accent) !important;
 }
 
+/* The selected thread title uses VS Code's native foreground variable rather
+   than a Codex text token. Override it only for this dark preset so other
+   skins retain their own selected-row treatment. */
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  aside.app-shell-left-panel
+  [data-app-action-sidebar-thread-active="true"][aria-current="page"] {
+  --vscode-foreground: var(--ds-text) !important;
+  background: rgb(var(--ds-accent-rgb) / .16) !important;
+  border-color: rgb(var(--ds-accent-rgb) / .38) !important;
+  box-shadow:
+    0 5px 16px rgb(var(--ds-bg-rgb) / .22),
+    inset 0 0 0 1px rgb(var(--ds-text-rgb) / .04) !important;
+}
+
 html.codex-dream-skin main.main-surface {
   position: relative !important;
   isolation: isolate;
@@ -412,6 +426,146 @@ html.codex-dream-skin main.main-surface:not(.dream-skin-home-shell) [role="main"
   text-shadow:
     0 1px 2px rgb(var(--ds-bg-rgb) / .72),
     0 0 10px rgb(var(--ds-bg-rgb) / .46);
+}
+
+/* Utility routes such as the Plugins directory keep explicit native text
+   token classes. When this dark preset is used over a native light shell,
+   align those tokens with the selected skin instead. */
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface {
+  --vscode-foreground: var(--ds-text);
+  --vscode-descriptionForeground: rgb(var(--ds-muted-rgb) / .92);
+  --color-token-foreground: var(--ds-text);
+  --color-token-text-primary: var(--ds-text);
+  --color-token-text-secondary: rgb(var(--ds-muted-rgb) / .92);
+  --color-token-text-tertiary: rgb(var(--ds-muted-rgb) / .74);
+  --color-token-conversation-body: rgb(var(--ds-muted-rgb) / .90);
+  --color-token-description-foreground: rgb(var(--ds-muted-rgb) / .86);
+  --color-token-input-placeholder-foreground: rgb(var(--ds-muted-rgb) / .78);
+  --color-token-button-tertiary-foreground: var(--ds-text);
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface [data-oai-writing-block-surface] {
+  --wb-text-primary: var(--ds-text) !important;
+  --wb-text-secondary: rgb(var(--ds-muted-rgb) / .92) !important;
+  --wb-text-tertiary: rgb(var(--ds-muted-rgb) / .74) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface
+  :is([class~="text-token-foreground"], [class~="text-token-text-primary"]) {
+  color: var(--ds-text) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface
+  :is(
+    [class~="text-token-text-secondary"],
+    [class~="text-token-text-tertiary"],
+    [class~="text-token-muted-foreground"],
+    [class~="text-token-description-foreground"],
+    [class~="text-token-input-placeholder-foreground"]
+  ) {
+  color: var(--ds-muted) !important;
+}
+
+/* Activity headers use a separate conversation-body token, including a
+   generated descendant variant that carries !important. */
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface
+  :is(
+    [class~="text-token-conversation-body"],
+    [class*="!text-token-conversation-body"] *:not(button)
+  ) {
+  color: rgb(var(--ds-muted-rgb) / .90) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface
+  :is(
+    [class~="text-token-conversation-body"],
+    [class*="!text-token-conversation-body"] *:not(button)
+  ) svg {
+  color: currentColor !important;
+}
+
+/* Native fenced-code surfaces are transparent on this preset, so their edges
+   disappear into the artwork. Keep a semantic wrapper plus a pre fallback. */
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface [class*="_markdown"]
+  :is(
+    [data-code-block],
+    [class*="_codeBlock_"],
+    [class*="code-block"],
+    figure:has(> pre),
+    div:has(> pre)
+  ) {
+  overflow: hidden;
+  border: 1px solid rgb(var(--ds-accent-rgb) / .42) !important;
+  border-radius: 14px !important;
+  background: rgb(var(--ds-panel-rgb) / .76) !important;
+  box-shadow:
+    0 10px 28px rgb(var(--ds-bg-rgb) / .24),
+    inset 0 1px rgb(var(--ds-text-rgb) / .08) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface [class*="_markdown"] pre {
+  border: 1px solid rgb(var(--ds-accent-rgb) / .42) !important;
+  border-radius: 14px !important;
+  background: rgb(var(--ds-panel-rgb) / .76) !important;
+  box-shadow: 0 10px 28px rgb(var(--ds-bg-rgb) / .24) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface [class*="_markdown"]
+  :is(
+    [data-code-block],
+    [class*="_codeBlock_"],
+    [class*="code-block"],
+    figure:has(> pre),
+    div:has(> pre)
+  ) > pre {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface [class*="_markdown"]
+  :is(
+    [data-code-block],
+    [class*="_codeBlock_"],
+    [class*="code-block"],
+    figure:has(> pre),
+    div:has(> pre)
+  ) button {
+  color: rgb(var(--ds-muted-rgb) / .96) !important;
+}
+
+/* Keep plugin install actions on the preset's gold accent instead of the
+   native white fog surface. */
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface:has(#plugins-page-search)
+  button[class~="bg-token-bg-fog"][class~="text-token-button-tertiary-foreground"][class~="h-token-button-composer"] {
+  background: var(--ds-accent) !important;
+  border-color: rgb(var(--ds-accent-rgb) / .72) !important;
+  color: var(--ds-on-accent) !important;
+  box-shadow: 0 5px 14px rgb(var(--ds-bg-rgb) / .24) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface:has(#plugins-page-search)
+  button[class~="bg-token-bg-fog"][class~="text-token-button-tertiary-foreground"][class~="h-token-button-composer"]:enabled:hover {
+  background: var(--ds-accent-soft) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface:has(#plugins-page-search)
+  button[class~="bg-token-bg-fog"][class~="text-token-button-tertiary-foreground"][class~="h-token-button-composer"]:disabled {
+  opacity: .62 !important;
 }
 
 html.codex-dream-skin[data-dream-shell="light"] main.main-surface:not(.dream-skin-home-shell) [role="main"] {
@@ -1027,6 +1181,41 @@ html.codex-dream-skin[data-dream-art-wide="true"] main.main-surface
   background: rgb(var(--ds-accent-rgb) / .08) !important;
   color: var(--ds-text) !important;
   box-shadow: 0 3px 12px rgb(var(--ds-bg-rgb) / .12) !important;
+}
+
+/* The labeled project bar is absolutely positioned and taller than Codex's
+   reserved gap. Give Gothic's detailed artwork complete card edges and keep
+   the first suggestion from covering the bottom border. */
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  .dream-skin-home div:has(> div > div > .composer-surface-chrome):has(> div > div > .dream-skin-home-utility) {
+  margin-bottom: 72px !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  .dream-skin-home:has(.dream-skin-home-utility) .composer-surface-chrome {
+  border-radius: 22px !important;
+  box-shadow:
+    0 10px 30px rgb(var(--ds-bg-rgb) / .22),
+    inset 0 0 0 1px rgb(var(--ds-accent-rgb) / .34),
+    inset 0 1px rgb(var(--ds-text-rgb) / .14) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  .dream-skin-home .dream-skin-home-utility {
+  margin-top: 8px !important;
+  border: 1px solid rgb(var(--ds-accent-rgb) / .34) !important;
+  border-radius: 18px !important;
+  box-shadow:
+    0 8px 22px rgb(var(--ds-bg-rgb) / .20),
+    inset 0 1px rgb(var(--ds-text-rgb) / .10) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  .dream-skin-home .group\/home-suggestions button.group\/home-suggestion-list-item {
+  border: 1px solid rgb(var(--ds-accent-rgb) / .26) !important;
+  box-shadow:
+    0 8px 22px rgb(var(--ds-bg-rgb) / .18),
+    inset 0 0 0 1px rgb(var(--ds-accent-rgb) / .08) !important;
 }
 
 html.codex-dream-skin .ProseMirror {

--- a/macos/assets/dream-skin.css
+++ b/macos/assets/dream-skin.css
@@ -450,6 +450,38 @@ html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
   --wb-text-primary: var(--ds-text) !important;
   --wb-text-secondary: rgb(var(--ds-muted-rgb) / .92) !important;
   --wb-text-tertiary: rgb(var(--ds-muted-rgb) / .74) !important;
+  --color-token-main-surface-primary: rgb(var(--ds-panel-rgb) / .90);
+  --color-token-border-default: rgb(var(--ds-accent-rgb) / .34);
+  background: rgb(var(--ds-panel-rgb) / .90) !important;
+  color: var(--ds-text) !important;
+  border: 1px solid rgb(var(--ds-accent-rgb) / .38) !important;
+  box-shadow:
+    0 12px 32px rgb(var(--ds-bg-rgb) / .30),
+    inset 0 1px rgb(var(--ds-text-rgb) / .10) !important;
+  text-shadow: none !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface [data-oai-writing-block-surface] * {
+  text-shadow: none !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface [data-oai-writing-block-surface] button {
+  color: rgb(var(--ds-muted-rgb) / .96) !important;
+  border-color: rgb(var(--ds-accent-rgb) / .30) !important;
+  background: rgb(var(--ds-accent-rgb) / .08) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface [data-oai-writing-block-surface] button:hover {
+  color: var(--ds-text) !important;
+  background: rgb(var(--ds-accent-rgb) / .14) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  main.main-surface [data-oai-writing-block-surface] button * {
+  color: currentColor !important;
 }
 
 html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]

--- a/macos/assets/dream-skin.css
+++ b/macos/assets/dream-skin.css
@@ -1292,6 +1292,54 @@ html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
   color: currentColor !important;
 }
 
+/* The composer's context picker is its own floating surface and keeps the
+   native light dropdown tokens whether opened from plus or by typing @. */
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  [data-codex-composer-root]
+  [data-composer-overlay-floating-ui="true"] > div:has([data-list-navigation-item="true"]) {
+  --color-token-dropdown-background: rgb(var(--ds-panel-rgb) / .94);
+  --color-token-foreground: var(--ds-text);
+  --color-token-description-foreground: rgb(var(--ds-muted-rgb) / .88);
+  --color-token-list-hover-background: rgb(var(--ds-accent-rgb) / .14);
+  background: rgb(var(--ds-panel-rgb) / .94) !important;
+  color: var(--ds-text) !important;
+  border-color: rgb(var(--ds-accent-rgb) / .38) !important;
+  box-shadow:
+    0 18px 48px rgb(var(--ds-bg-rgb) / .42),
+    inset 0 1px rgb(var(--ds-text-rgb) / .10) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  [data-codex-composer-root]
+  [data-composer-overlay-floating-ui="true"] [class*="bg-token-dropdown-background/"] {
+  background: rgb(var(--ds-panel-rgb) / .96) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  [data-codex-composer-root]
+  [data-composer-overlay-floating-ui="true"] [class*="bg-token-dropdown-background/"][class~="sticky"] {
+  color: var(--ds-accent) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  [data-codex-composer-root]
+  [data-composer-overlay-floating-ui="true"] [data-list-navigation-item="true"] {
+  color: var(--ds-text) !important;
+  opacity: 1 !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  [data-codex-composer-root]
+  [data-composer-overlay-floating-ui="true"] [data-list-navigation-item="true"][aria-selected="true"] {
+  background: rgb(var(--ds-accent-rgb) / .18) !important;
+}
+
+html.codex-dream-skin[data-dream-theme-id="preset-gothic-void-crusade"]
+  [data-codex-composer-root]
+  [data-composer-overlay-floating-ui="true"] [class~="text-token-description-foreground"] {
+  color: rgb(var(--ds-muted-rgb) / .88) !important;
+}
+
 html.codex-dream-skin .ProseMirror {
   color: var(--ds-text) !important;
   caret-color: var(--ds-accent) !important;

--- a/macos/assets/renderer-inject.js
+++ b/macos/assets/renderer-inject.js
@@ -4,6 +4,7 @@
   const STYLE_ID = "codex-dream-skin-style";
   const CHROME_ID = "codex-dream-skin-chrome";
   const SHELL_ATTR = "data-dream-shell";
+  const THEME_ATTR = "data-dream-theme-id";
   const ART_ATTRS = [
     "data-dream-art-wide", "data-dream-art-safe", "data-dream-task-mode",
     "data-dream-art-safe-area", "data-dream-art-task-mode", "data-dream-art-aspect",
@@ -549,6 +550,7 @@
     ensureStyle(root);
     const shell = resolvedShell();
     setAttribute(root, SHELL_ATTR, shell);
+    setAttribute(root, THEME_ATTR, THEME.id || "unknown");
     setStyleProperty(root, "--dream-skin-art", `url("${artUrl}")`);
     applyTheme(root, shell);
     applyArtMetadata(root);
@@ -650,6 +652,7 @@
     window[DISABLED_KEY] = true;
     document.documentElement?.classList.remove("codex-dream-skin");
     document.documentElement?.removeAttribute(SHELL_ATTR);
+    document.documentElement?.removeAttribute(THEME_ATTR);
     for (const name of ART_ATTRS) document.documentElement?.removeAttribute(name);
     document.documentElement?.style.removeProperty("--dream-skin-art");
     for (const name of THEME_VARIABLES) document.documentElement?.style.removeProperty(name);

--- a/macos/assets/renderer-inject.js
+++ b/macos/assets/renderer-inject.js
@@ -568,7 +568,8 @@
     const home = homeIndicator?.closest('[role="main"]') ||
       [...document.querySelectorAll('[role="main"]')].find((candidate) =>
         candidate.querySelector('[data-feature="game-source"]') &&
-        candidate.querySelector('.group\\\\/home-suggestions')) || null;
+        (candidate.querySelector('.group\\\\/home-suggestions') ||
+          candidate.querySelector('[data-codex-composer-root]'))) || null;
     for (const candidate of document.querySelectorAll('[role="main"].dream-skin-home')) {
       if (candidate !== home) candidate.classList.remove("dream-skin-home");
     }

--- a/macos/tests/renderer-inject.test.mjs
+++ b/macos/tests/renderer-inject.test.mjs
@@ -131,6 +131,16 @@ assert.match(
 );
 assert.match(
   css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,180}\[data-oai-writing-block-surface\][\s\S]{0,340}background:\s*rgb\(var\(--ds-panel-rgb\) \/ \.90\) !important;[\s\S]{0,140}border:\s*1px solid rgb\(var\(--ds-accent-rgb\) \/ \.38\) !important;/,
+  "Gothic reusable content blocks must replace the native high-brightness surface.",
+);
+assert.match(
+  css,
+  /\[data-oai-writing-block-surface\] button\s*\{[\s\S]{0,160}color:\s*rgb\(var\(--ds-muted-rgb\) \/ \.96\) !important;[\s\S]{0,160}background:\s*rgb\(var\(--ds-accent-rgb\) \/ \.08\) !important;/,
+  "Gothic reusable content block controls must remain readable without bright native button fills.",
+);
+assert.match(
+  css,
   /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,220}:has\(#plugins-page-search\)[\s\S]{0,260}button\[class~="bg-token-bg-fog"\][\s\S]{0,260}background:\s*var\(--ds-accent\) !important;[\s\S]{0,180}color:\s*var\(--ds-on-accent\) !important;/,
   "Gothic plugin install buttons must use the preset accent and a contrast-safe foreground.",
 );

--- a/macos/tests/renderer-inject.test.mjs
+++ b/macos/tests/renderer-inject.test.mjs
@@ -85,6 +85,10 @@ assert.match(
   /\[class\*="_homeUtilityBar_"\][\s\S]{0,500}dream-skin-home-utility/,
   "The renderer should give the current native home utility bar a stable theme class.",
 );
+assert.ok(
+  template.includes("candidate.querySelector('[data-codex-composer-root]')"),
+  "Typed home routes must retain their stable theme class after native suggestions disappear.",
+);
 assert.match(
   css,
   /\.dream-skin-home:has\(\.dream-skin-home-utility\)[\s\S]{0,120}\.composer-surface-chrome\s*\{[\s\S]{0,180}border-radius:\s*0 0 22px 22px !important;/,
@@ -144,6 +148,21 @@ assert.match(
   css,
   /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,180}\.dream-skin-home \.dream-skin-home-utility[\s\S]{0,180}border:\s*1px solid rgb\(var\(--ds-accent-rgb\) \/ \.34\) !important;[\s\S]{0,100}border-radius:\s*18px !important;/,
   "Gothic's home project picker must retain a complete, visible border on all four sides.",
+);
+assert.match(
+  css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,220}\[role="main"\]:has\(\[data-feature="game-source"\]\) \[class\*="_homeUtilityBar_"\][\s\S]{0,180}background:\s*rgb\(var\(--ds-panel-rgb\) \/ \.92\) !important;[\s\S]{0,220}border:\s*1px solid rgb\(var\(--ds-accent-rgb\) \/ \.34\) !important;/,
+  "Gothic's typed-home project bar must not flash the native white utility surface.",
+);
+assert.match(
+  css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,220}rounded-3xl[\s\S]{0,120}thread-summary-panel-item-button[\s\S]{0,320}background:\s*rgb\(var\(--ds-panel-rgb\) \/ \.94\) !important;[\s\S]{0,160}border:\s*1px solid rgb\(var\(--ds-accent-rgb\) \/ \.36\) !important;/,
+  "Gothic's thread summary panel must use a readable preset surface and complete border.",
+);
+assert.match(
+  css,
+  /thread-summary-panel-section-actions[\s\S]{0,100}text-token-conversation-summary-trailing[\s\S]{0,140}color:\s*rgb\(var\(--ds-muted-rgb\) \/ \.82\) !important;/,
+  "Gothic's summary actions and trailing labels must remain readable over the dark panel.",
 );
 assert.match(
   css,

--- a/macos/tests/renderer-inject.test.mjs
+++ b/macos/tests/renderer-inject.test.mjs
@@ -107,6 +107,51 @@ assert.match(
 );
 assert.match(
   css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,180}main\.main-surface\s*\{[\s\S]{0,260}--vscode-foreground:\s*var\(--ds-text\);[\s\S]{0,300}--color-token-text-primary:\s*var\(--ds-text\);/,
+  "Gothic conversation timelines must bridge native light-shell text variables to the preset palette.",
+);
+assert.match(
+  css,
+  /--color-token-conversation-body:\s*rgb\(var\(--ds-muted-rgb\) \/ \.90\);/,
+  "Gothic collapsed activity headers must not inherit the native light-shell conversation-body token.",
+);
+assert.match(
+  css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,260}\[class\*="!text-token-conversation-body"\] \*:not\(button\)[\s\S]{0,120}color:\s*rgb\(var\(--ds-muted-rgb\) \/ \.90\) !important;/,
+  "Generated important conversation-body descendants must remain readable in Gothic activity rows.",
+);
+assert.match(
+  css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,180}\[data-oai-writing-block-surface\][\s\S]{0,160}--wb-text-primary:\s*var\(--ds-text\) !important;/,
+  "Gothic writing and command surfaces must not retain an inline light-theme text color.",
+);
+assert.match(
+  css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,220}:has\(#plugins-page-search\)[\s\S]{0,260}button\[class~="bg-token-bg-fog"\][\s\S]{0,260}background:\s*var\(--ds-accent\) !important;[\s\S]{0,180}color:\s*var\(--ds-on-accent\) !important;/,
+  "Gothic plugin install buttons must use the preset accent and a contrast-safe foreground.",
+);
+assert.match(
+  css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,220}data-app-action-sidebar-thread-active="true"[\s\S]{0,180}--vscode-foreground:\s*var\(--ds-text\) !important;/,
+  "Gothic selected thread titles must override the stale native VS Code foreground token.",
+);
+assert.match(
+  css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,180}> div > div > \.composer-surface-chrome\):has\(> div > div > \.dream-skin-home-utility\)[\s\S]{0,100}margin-bottom:\s*72px !important;/,
+  "Gothic's taller labeled project bar must reserve enough layout space to avoid overlapping home suggestions.",
+);
+assert.match(
+  css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,180}\.dream-skin-home \.dream-skin-home-utility[\s\S]{0,180}border:\s*1px solid rgb\(var\(--ds-accent-rgb\) \/ \.34\) !important;[\s\S]{0,100}border-radius:\s*18px !important;/,
+  "Gothic's home project picker must retain a complete, visible border on all four sides.",
+);
+assert.match(
+  css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,280}\[class\*="_markdown"\][\s\S]{0,260}div:has\(> pre\)[\s\S]{0,180}border:\s*1px solid rgb\(var\(--ds-accent-rgb\) \/ \.42\) !important;[\s\S]{0,160}background:\s*rgb\(var\(--ds-panel-rgb\) \/ \.76\) !important;/,
+  "Gothic fenced code blocks must retain a complete contrast-safe border and surface over the wallpaper.",
+);
+assert.match(
+  css,
   /\.composer-surface-chrome p\.placeholder::after\s*\{[\s\S]{0,120}color:\s*rgb\(var\(--ds-muted-rgb\) \/ \.82\) !important;[\s\S]{0,80}opacity:\s*1 !important;/,
   "Composer placeholder text must not inherit a stale native color with double opacity.",
 );
@@ -357,6 +402,7 @@ const defaults = createFixture({
 const defaultResult = vm.runInNewContext(defaults.payload, defaults.context);
 assert.equal(defaultResult.installed, true);
 assert.equal(defaults.attributes.get("data-dream-shell"), "light");
+assert.equal(defaults.attributes.get("data-dream-theme-id"), "default-contract");
 assert.equal(defaults.attributes.get("data-dream-art-safe-area"), "center");
 assert.equal(defaults.attributes.get("data-dream-art-task-mode"), "ambient");
 assert.equal(defaults.attributes.get("data-dream-art-ready"), "false");
@@ -537,6 +583,7 @@ assert.equal(banner.attributes.get("data-dream-task-mode"), "banner");
 assert.equal(explicit.window.__CODEX_DREAM_SKIN_STATE__.cleanup(), true);
 assert.equal(explicit.root.classList.contains("codex-dream-skin"), false);
 assert.equal(explicit.attributes.has("data-dream-shell"), false);
+assert.equal(explicit.attributes.has("data-dream-theme-id"), false);
 assert.equal(explicit.attributes.has("data-dream-art-safe-area"), false);
 assert.equal(explicit.attributes.has("data-dream-art-task-mode"), false);
 assert.equal(explicit.rootStyle.values.has("--dream-art-position"), false);

--- a/macos/tests/renderer-inject.test.mjs
+++ b/macos/tests/renderer-inject.test.mjs
@@ -166,6 +166,16 @@ assert.match(
 );
 assert.match(
   css,
+  /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,180}data-codex-composer-root[\s\S]{0,180}data-composer-overlay-floating-ui="true"[\s\S]{0,180}data-list-navigation-item="true"[\s\S]{0,340}background:\s*rgb\(var\(--ds-panel-rgb\) \/ \.94\) !important;[\s\S]{0,160}border-color:\s*rgb\(var\(--ds-accent-rgb\) \/ \.38\) !important;/,
+  "Gothic's plus and @ context picker must replace the native white dropdown surface.",
+);
+assert.match(
+  css,
+  /data-composer-overlay-floating-ui="true"[\s\S]{0,180}data-list-navigation-item="true"\]\[aria-selected="true"\][\s\S]{0,140}background:\s*rgb\(var\(--ds-accent-rgb\) \/ \.18\) !important;/,
+  "Gothic's selected add-context row must remain distinct on the dark menu surface.",
+);
+assert.match(
+  css,
   /data-dream-theme-id="preset-gothic-void-crusade"[\s\S]{0,280}\[class\*="_markdown"\][\s\S]{0,260}div:has\(> pre\)[\s\S]{0,180}border:\s*1px solid rgb\(var\(--ds-accent-rgb\) \/ \.42\) !important;[\s\S]{0,160}background:\s*rgb\(var\(--ds-panel-rgb\) \/ \.76\) !important;/,
   "Gothic fenced code blocks must retain a complete contrast-safe border and surface over the wallpaper.",
 );


### PR DESCRIPTION
## 这次改了啥

Gothic Void Crusade 这张背景本身比较暗，但 Codex 有些页面还在沿用浅色外观下的深色文字，所以会出现“背景黑、字也黑”的情况。这次主要把这些容易看不清的地方补齐了：

- 插件页的标题、描述和搜索提示改成主题自己的文字颜色，“安装”按钮改成金色强调色。
- 左侧选中的会话改成金色半透明底，标题不会再黑成一团。
- 会话里的读文件、跑命令、编辑文件、思考/压缩上下文等状态文字和图标都提亮了。
- 代码块补回半透明深色底、完整边框、圆角和复制按钮颜色。
- 首页项目选择区补回四条边框，并拉开它和第一条建议之间的距离，不会再互相盖住。
- 首页输入内容后，下面的项目/插件栏现在会继续保持 Gothic 深色卡片样式，不会突然变成一条白底浅字的区域。
- 会话右上角的“输出 / 来源”摘要面板也换成了半透明深色底、金色边框和可读文字，“查看全部”等次要信息不会再淡到看不见。
- 首页和普通会话里的上下文选择菜单也适配了主题：不管点“＋”还是输入 `@`，添加项、插件列表和选中行都会使用深色金边样式，不再弹出一大片白底浅字。
- 带“添加到任务”和复制按钮的内容块也压低了亮度：纯白底换成深色半透明面板，去掉文字发光，按钮改成轻微金色底。

这些规则全部挂在 `data-dream-theme-id="preset-gothic-void-crusade"` 下面，只对 Gothic Void Crusade 生效，切换其他预设或自定义皮肤时不会继承这套特殊样式。

## 为什么会这样

主要有五个原因：

1. Codex 的部分新页面、会话时间线和摘要浮层会直接使用原生 token。皮肤把界面切成暗色背景后，这些 token 仍可能是浅色外观里的深色值或白色面板。
2. 首页项目栏源码里原本去掉了底边，而且它是绝对定位的；加上标题空间后高度超过了原生预留区域，第一条建议会压到项目栏上。
3. 首页输入文字以后，原生建议列表会消失，旧的首页识别逻辑也跟着失效，于是项目栏丢掉了主题标记，又退回原生白色样式。
4. 输入框的上下文选择器是独立浮层，点击“＋”和输入 `@` 都会走这套结构；它自己的下拉背景变量之前没有接入皮肤，所以首页和会话里都会变白。
5. 可复用内容块之前只覆盖了文字变量，没有覆盖组件自己的白色表面，所以在暗色壁纸上会像一块过曝的白板。

这次在运行时给根节点加了当前主题 ID，CSS 就可以精确区分是哪套皮肤；同时让首页在输入状态下继续被正确识别，再只修正 Gothic 的颜色和布局。

## 验证

- `npm test` 通过。
- 本地运行版实测：会话时间线文字使用 `rgba(181, 163, 134, 0.9)`，不再沿用深灰 token。
- 首页项目栏四边都是 `1px`，项目栏与第一条建议之间保留 `16px` 间距。
- 输入文字后首页主题标记仍在，项目栏是 `rgba(23, 21, 19, 0.92)`，四边保持 `1px`。
- 摘要面板是 `rgba(23, 21, 19, 0.94)`，四边保持 `1px`；标题、来源和“查看全部”均使用 Gothic 金色系文字。
- “＋”和 `@` 两种入口都实测通过：上下文面板是 `rgba(23, 21, 19, 0.94)`，标题是金色，选中行是金色半透明底，四边均为 `1px`。
- 可复用内容块是 `rgba(23, 21, 19, 0.9)`，四边均为 `1px`，文字无额外阴影；“添加到任务”和复制按钮使用 8% 金色底。
- 代码块外层四边都是 `1px`，并有主题面板背景和 `14px` 圆角。
