### PR TITLE
feat(macos): add bounded synthetic audio push proof

### DIFF
--- a/macos/assets/renderer-inject.js
+++ b/macos/assets/renderer-inject.js
@@ -3,6 +3,7 @@
   const DISABLED_KEY = "__CODEX_DREAM_SKIN_DISABLED__";
   const STYLE_ID = "codex-dream-skin-style";
   const CHROME_ID = "codex-dream-skin-chrome";
+  const AUDIO_CANVAS_ID = "codex-dream-skin-audio";
   const SHELL_ATTR = "data-dream-shell";
   const ART_ATTRS = [
     "data-dream-art-wide", "data-dream-art-safe", "data-dream-task-mode",
@@ -64,6 +65,7 @@
     return URL.createObjectURL(new Blob([bytes], { type: mime }));
   })();
 
+  try { previous?.audio?.stop?.(); } catch {}
   if (previous?.observer) previous.observer.disconnect();
   if (previous?.rootObserver) previous.rootObserver.disconnect();
   if (previous?.resizeObserver) previous.resizeObserver.disconnect();
@@ -644,10 +646,199 @@
     if (route) syncRouteState(shell, { layout });
   };
 
+  const createAudioController = () => {
+    const allowedFrameKeys = new Set([
+      "type", "protocolVersion", "sequence", "monotonicMs", "rms", "peak",
+      "bass", "mid", "treble", "beat", "bands",
+    ]);
+    let canvas = null;
+    let context = null;
+    let latest = null;
+    let scheduledFrame = null;
+    let scheduledTimer = null;
+    let fps = 30;
+    let lastAcceptedSequence = 0;
+    const audioMetrics = {
+      received: 0,
+      accepted: 0,
+      rejected: 0,
+      drawn: 0,
+      renderDropped: 0,
+      lastAcceptedSequence: null,
+      lastDrawnSequence: null,
+      queueLatencyTotalMs: 0,
+      queueLatencyMaxMs: 0,
+    };
+
+    const canvasCount = () => {
+      if (typeof document.querySelectorAll === "function") {
+        return document.querySelectorAll(`#${AUDIO_CANVAS_ID}`).length;
+      }
+      return document.getElementById(AUDIO_CANVAS_ID) ? 1 : 0;
+    };
+
+    const ensureCanvas = () => {
+      if (canvas && canvas.isConnected !== false && document.getElementById(AUDIO_CANVAS_ID) === canvas) {
+        return true;
+      }
+      document.getElementById(AUDIO_CANVAS_ID)?.remove();
+      const next = document.createElement("canvas");
+      next.id = AUDIO_CANVAS_ID;
+      next.setAttribute("aria-hidden", "true");
+      next.tabIndex = -1;
+      next.style.setProperty("position", "fixed");
+      next.style.setProperty("inset", "0");
+      next.style.setProperty("width", "100%");
+      next.style.setProperty("height", "100%");
+      next.style.setProperty("z-index", "0");
+      next.style.setProperty("pointer-events", "none");
+      next.style.setProperty("user-select", "none");
+      next.style.setProperty("contain", "strict");
+      next.style.setProperty("opacity", "0.22");
+      const host = document.querySelector("main.main-surface") || document.body;
+      if (typeof host?.prepend === "function") host.prepend(next);
+      else host?.appendChild?.(next);
+      const nextContext = next.getContext?.("2d", { alpha: true });
+      if (!nextContext) {
+        next.remove();
+        return false;
+      }
+      canvas = next;
+      context = nextContext;
+      return true;
+    };
+
+    const validUnit = (value) => Number.isFinite(value) && value >= 0 && value <= 1;
+    const isValidFrame = (frame) => frame && typeof frame === "object" && !Array.isArray(frame)
+      && Object.keys(frame).every((key) => allowedFrameKeys.has(key))
+      && frame.type === "features" && frame.protocolVersion === 1
+      && Number.isSafeInteger(frame.sequence) && frame.sequence > lastAcceptedSequence
+      && Number.isFinite(frame.monotonicMs) && frame.monotonicMs >= 0
+      && validUnit(frame.rms) && validUnit(frame.peak) && validUnit(frame.bass)
+      && validUnit(frame.mid) && validUnit(frame.treble) && typeof frame.beat === "boolean"
+      && Array.isArray(frame.bands) && frame.bands.length === 64
+      && frame.bands.every(validUnit);
+
+    const resizeCanvas = () => {
+      const width = typeof innerWidth === "number" && innerWidth > 0 ? innerWidth : 320;
+      const height = typeof innerHeight === "number" && innerHeight > 0 ? innerHeight : 180;
+      const scale = Math.min(
+        1.5,
+        typeof devicePixelRatio === "number" && devicePixelRatio > 0 ? devicePixelRatio : 1,
+      );
+      const nextWidth = Math.min(1600, Math.max(1, Math.round(width * scale)));
+      const nextHeight = Math.min(1000, Math.max(1, Math.round(height * scale)));
+      if (canvas.width !== nextWidth) canvas.width = nextWidth;
+      if (canvas.height !== nextHeight) canvas.height = nextHeight;
+    };
+
+    const drawLatest = () => {
+      scheduledFrame = null;
+      scheduledTimer = null;
+      const record = latest;
+      latest = null;
+      if (!record || !canvas || !context) return;
+      resizeCanvas();
+      context.clearRect(0, 0, canvas.width, canvas.height);
+      const width = canvas.width / record.frame.bands.length;
+      const baseHeight = canvas.height * (0.08 + record.frame.rms * 0.18);
+      for (let index = 0; index < record.frame.bands.length; index += 1) {
+        const value = record.frame.bands[index];
+        const shaped = Math.min(1, value * 0.72 + record.frame.bass * 0.18 + record.frame.peak * 0.1);
+        const height = Math.max(1, baseHeight + shaped * canvas.height * 0.72);
+        context.fillStyle = index % 2 === 0 ? "#f5c84c" : "#7b5cff";
+        context.fillRect(
+          index * width,
+          canvas.height - height,
+          Math.max(1, width - 1),
+          height,
+        );
+      }
+      const queueLatencyMs = Math.max(0, now() - record.receivedAt);
+      audioMetrics.drawn += 1;
+      audioMetrics.lastDrawnSequence = record.frame.sequence;
+      audioMetrics.queueLatencyTotalMs += queueLatencyMs;
+      audioMetrics.queueLatencyMaxMs = Math.max(audioMetrics.queueLatencyMaxMs, queueLatencyMs);
+    };
+
+    const scheduleDraw = () => {
+      if (scheduledFrame !== null || scheduledTimer !== null) return;
+      if (typeof requestAnimationFrame === "function") {
+        scheduledFrame = requestAnimationFrame(drawLatest);
+      } else {
+        scheduledTimer = setTimeout(drawLatest, Math.round(1000 / fps));
+      }
+    };
+
+    const push = (frame, config = {}) => {
+      audioMetrics.received += 1;
+      if (config?.fps !== undefined && ![10, 20, 30].includes(config.fps)) {
+        audioMetrics.rejected += 1;
+        return { accepted: false, sequence: frame?.sequence ?? null, reason: "fps" };
+      }
+      if (!isValidFrame(frame)) {
+        audioMetrics.rejected += 1;
+        return { accepted: false, sequence: frame?.sequence ?? null, reason: "frame" };
+      }
+      fps = config?.fps ?? fps;
+      if (!ensureCanvas()) {
+        audioMetrics.rejected += 1;
+        return { accepted: false, sequence: frame.sequence, reason: "canvas" };
+      }
+      const replaced = Boolean(latest);
+      if (replaced) audioMetrics.renderDropped += 1;
+      latest = { frame, receivedAt: now() };
+      lastAcceptedSequence = frame.sequence;
+      audioMetrics.accepted += 1;
+      audioMetrics.lastAcceptedSequence = frame.sequence;
+      scheduleDraw();
+      return { accepted: true, sequence: frame.sequence, replaced };
+    };
+
+    const snapshot = () => ({
+      active: Boolean(canvas),
+      fps,
+      metrics: {
+        ...audioMetrics,
+        queueLatencyMeanMs: audioMetrics.drawn
+          ? audioMetrics.queueLatencyTotalMs / audioMetrics.drawn : null,
+      },
+      canvas: canvas ? {
+        count: canvasCount(),
+        ariaHidden: canvas.getAttribute?.("aria-hidden") ?? null,
+        tabIndex: canvas.tabIndex,
+        pointerEvents: typeof getComputedStyle === "function"
+          ? getComputedStyle(canvas).pointerEvents : canvas.style.getPropertyValue("pointer-events"),
+        contain: canvas.style.getPropertyValue("contain"),
+      } : null,
+    });
+
+    const stop = () => {
+      if (scheduledFrame !== null && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(scheduledFrame);
+      }
+      if (scheduledTimer !== null) clearTimeout(scheduledTimer);
+      scheduledFrame = null;
+      scheduledTimer = null;
+      latest = null;
+      lastAcceptedSequence = 0;
+      canvas?.remove();
+      document.getElementById(AUDIO_CANVAS_ID)?.remove();
+      canvas = null;
+      context = null;
+      return true;
+    };
+
+    return { push, snapshot, stop };
+  };
+
+  const audio = createAudioController();
+
   const cleanup = () => {
     const state = window[STATE_KEY];
     if (state?.installToken !== installToken) return false;
     window[DISABLED_KEY] = true;
+    state.audio?.stop?.();
     document.documentElement?.classList.remove("codex-dream-skin");
     document.documentElement?.removeAttribute(SHELL_ATTR);
     for (const name of ART_ATTRS) document.documentElement?.removeAttribute(name);
@@ -735,6 +926,7 @@
     analysis: artAnalysis,
     artMetadata: ART_METADATA,
     metrics,
+    audio,
     version: VERSION,
     themeId: THEME.id || "custom",
     revision: PAYLOAD_REVISION,

--- a/macos/references/qa-inventory.md
+++ b/macos/references/qa-inventory.md
@@ -21,6 +21,7 @@
 - Port collision selection and saved-port reuse.
 - PID reuse protection through PID, start time, executable, script path, and command-line matching.
 - Live verification after `Page.reload` returns version `1.2.0` and `pass: true`.
+- Synthetic audio diagnostics validate strict 64-band feature frames at 10/20/30 FPS, latest-frame backpressure, one inaccessible pointer-transparent canvas, CDP target reattachment, and zero canvas/process/profile residue without requesting audio permission.
 - Strict home verification requires a visible wallpaper composition region of at least 320×160, composer, sidebar, non-interactive decoration, and no horizontal overflow. Suggestion cards and the standalone project button are optional only when the current Codex host does not render them.
 
 ## Visual checks

--- a/macos/references/runtime-notes.md
+++ b/macos/references/runtime-notes.md
@@ -9,6 +9,7 @@
 - Accept CDP only when the listener belongs to the discovered Codex main process or one of its legitimate descendants, the WebSocket URL is loopback-only, and an `app://` renderer exposes expected native shell markers.
 - Treat loopback CDP as locally privileged but unauthenticated. Keep the themed session limited to trusted local use and close the port through a full Restore when finished.
 - Poll page targets and reinject after document loads. A debounced mutation observer plus a low-frequency safety timer handles in-page route changes.
+- `--synthetic-audio --audio-fps 10|20|30` is an opt-in watch-mode diagnostic. It pushes deterministic normalized feature frames through the existing CDP session with one in-flight frame and one replaceable pending frame; it never opens an audio device, requests permission, or carries raw samples.
 - Record injector PID, start time, executable, script path, app identity, selected port, and theme directory. Refuse to stop a PID when any required identity differs.
 - Store mutable data under `~/Library/Application Support/CodexDreamSkinStudio`; keep the installed program under `~/.codex/codex-dream-skin-studio`.
 - Back up and restore only `appearanceTheme` and `appearanceDarkCodeThemeId`. Leave `appearanceDarkChromeTheme` and unrelated TOML content untouched.

--- a/macos/scripts/injector.mjs
+++ b/macos/scripts/injector.mjs
@@ -19,6 +19,12 @@ const OPERATION_UI_HOST_ID = "chatgpt-dream-skin-operation";
 const OPERATION_UI_REGISTRY_KEY = "__CHATGPT_DREAM_SKIN_OPERATION_UI__";
 const OPERATION_KINDS = new Set(["apply", "pause", "switch"]);
 const OPERATION_UI_STATES = new Set(["success", "error", "cancelled"]);
+const AUDIO_FPS_VALUES = new Set([10, 20, 30]);
+const MAX_AUDIO_PUSH_RECEIPTS = 32;
+const AUDIO_FRAME_KEYS = new Set([
+  "type", "protocolVersion", "sequence", "monotonicMs", "rms", "peak",
+  "bass", "mid", "treble", "beat", "bands",
+]);
 const OPERATION_UI_CSS = `
   :host {
     all: initial;
@@ -143,6 +149,9 @@ function parseArgs(argv) {
     operationUiState: null,
     operationMessage: null,
     operationToken: null,
+    syntheticAudio: false,
+    audioFps: 30,
+    audioFpsExplicit: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -163,6 +172,11 @@ function parseArgs(argv) {
     else if (arg === "--operation-ui-state") options.operationUiState = argv[++i];
     else if (arg === "--operation-message") options.operationMessage = argv[++i];
     else if (arg === "--operation-token") options.operationToken = argv[++i];
+    else if (arg === "--synthetic-audio") options.syntheticAudio = true;
+    else if (arg === "--audio-fps") {
+      options.audioFps = Number(argv[++i]);
+      options.audioFpsExplicit = true;
+    }
     else if (arg === "--reload") options.reload = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
@@ -188,7 +202,22 @@ function parseArgs(argv) {
       throw new Error("Finish operation requires a single-line --operation-message up to 240 characters");
     }
   }
+  options.audioFps = normalizeAudioFps(options.audioFps);
+  if (options.audioFpsExplicit && !options.syntheticAudio) {
+    throw new Error("--audio-fps requires --synthetic-audio");
+  }
+  if (options.syntheticAudio && options.mode !== "watch") {
+    throw new Error("--synthetic-audio is available only in watch mode");
+  }
   return options;
+}
+
+export function normalizeAudioFps(value) {
+  const fps = Number(value);
+  if (!Number.isInteger(fps) || !AUDIO_FPS_VALUES.has(fps)) {
+    throw new Error("Audio FPS must be 10, 20, or 30");
+  }
+  return fps;
 }
 
 function validatedDebuggerUrl(target, port) {
@@ -638,6 +667,217 @@ async function applyToSession(session, payload) {
   return session.evaluate(payload);
 }
 
+export function normalizeAudioFeatureFrame(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("Audio feature frame must be an object");
+  }
+  if (Object.keys(input).some((key) => !AUDIO_FRAME_KEYS.has(key))) {
+    throw new Error("Audio feature frame contains an unsupported field");
+  }
+  const unit = (value, name) => {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new Error(`Audio feature ${name} must be finite and normalized`);
+    }
+    return value;
+  };
+  if (input.type !== "features" || input.protocolVersion !== 1) {
+    throw new Error("Audio feature frame must use protocol version 1");
+  }
+  if (!Number.isSafeInteger(input.sequence) || input.sequence < 1) {
+    throw new Error("Audio feature sequence must be a positive safe integer");
+  }
+  if (!Number.isFinite(input.monotonicMs) || input.monotonicMs < 0) {
+    throw new Error("Audio feature monotonicMs must be finite and non-negative");
+  }
+  if (typeof input.beat !== "boolean") {
+    throw new Error("Audio feature beat must be boolean");
+  }
+  if (!Array.isArray(input.bands) || input.bands.length !== 64) {
+    throw new Error("Audio feature frame must contain exactly 64 bands");
+  }
+  return {
+    type: "features",
+    protocolVersion: 1,
+    sequence: input.sequence,
+    monotonicMs: input.monotonicMs,
+    rms: unit(input.rms, "rms"),
+    peak: unit(input.peak, "peak"),
+    bass: unit(input.bass, "bass"),
+    mid: unit(input.mid, "mid"),
+    treble: unit(input.treble, "treble"),
+    beat: input.beat,
+    bands: input.bands.map((value, index) => unit(value, `bands[${index}]`)),
+  };
+}
+
+export function createDeterministicAudioFrame(sequence, fps = 30) {
+  const normalizedFps = normalizeAudioFps(fps);
+  if (!Number.isSafeInteger(sequence) || sequence < 1) {
+    throw new Error("Synthetic audio sequence must be a positive safe integer");
+  }
+  const wave = (index) => Number((
+    (Math.sin((sequence + index) * 0.31) + 1) * 0.32
+    + (Math.cos((sequence * 0.17) + (index * 0.11)) + 1) * 0.18
+  ).toFixed(6));
+  const rms = Number((0.2 + ((sequence % 12) / 24)).toFixed(6));
+  return normalizeAudioFeatureFrame({
+    type: "features",
+    protocolVersion: 1,
+    sequence,
+    monotonicMs: Number((((sequence - 1) * 1000) / normalizedFps).toFixed(3)),
+    rms,
+    peak: Number(Math.min(1, rms + 0.16).toFixed(6)),
+    bass: Number((0.25 + (sequence % 5) * 0.1).toFixed(6)),
+    mid: Number((0.3 + (sequence % 4) * 0.08).toFixed(6)),
+    treble: Number((0.2 + (sequence % 3) * 0.09).toFixed(6)),
+    beat: sequence % 10 === 0,
+    bands: Array.from({ length: 64 }, (_, index) => wave(index)),
+  });
+}
+
+export class LatestFrameDispatcher {
+  constructor(send, clock = () => performance.now()) {
+    if (typeof send !== "function" || typeof clock !== "function") {
+      throw new Error("LatestFrameDispatcher requires send and clock functions");
+    }
+    this.send = send;
+    this.clock = clock;
+    this.closed = false;
+    this.inFlight = null;
+    this.pending = null;
+    this.lastOfferedSequence = 0;
+    this.waiters = new Set();
+    this.metrics = {
+      sent: 0,
+      dispatched: 0,
+      accepted: 0,
+      transportDropped: 0,
+      failed: 0,
+      maxBuffered: 0,
+      lastSentSequence: null,
+      lastAcceptedSequence: null,
+      roundTripTotalMs: 0,
+      roundTripMinMs: null,
+      roundTripMaxMs: 0,
+    };
+  }
+
+  offer(input) {
+    if (this.closed) throw new Error("Audio frame dispatcher is closed");
+    const frame = normalizeAudioFeatureFrame(input);
+    if (frame.sequence <= this.lastOfferedSequence) {
+      throw new Error("Audio feature sequence must increase strictly");
+    }
+    this.lastOfferedSequence = frame.sequence;
+    this.metrics.sent += 1;
+    this.metrics.lastSentSequence = frame.sequence;
+    const record = { frame };
+    if (this.inFlight) {
+      if (this.pending) this.metrics.transportDropped += 1;
+      this.pending = record;
+      this.metrics.maxBuffered = Math.max(this.metrics.maxBuffered, 1);
+      return { queued: true, sequence: frame.sequence };
+    }
+    this.dispatch(record);
+    return { queued: false, sequence: frame.sequence };
+  }
+
+  dispatch(record) {
+    record.dispatchedAt = this.clock();
+    this.inFlight = record;
+    this.metrics.dispatched += 1;
+    Promise.resolve()
+      .then(() => this.send(record.frame))
+      .then((ack) => {
+        if (ack?.accepted !== true || ack.sequence !== record.frame.sequence) {
+          throw new Error("Renderer rejected the audio feature frame");
+        }
+        const roundTripMs = Math.max(0, this.clock() - record.dispatchedAt);
+        this.metrics.accepted += 1;
+        this.metrics.lastAcceptedSequence = record.frame.sequence;
+        this.metrics.roundTripTotalMs += roundTripMs;
+        this.metrics.roundTripMinMs = this.metrics.roundTripMinMs === null
+          ? roundTripMs : Math.min(this.metrics.roundTripMinMs, roundTripMs);
+        this.metrics.roundTripMaxMs = Math.max(this.metrics.roundTripMaxMs, roundTripMs);
+      })
+      .catch(() => {
+        this.metrics.failed += 1;
+      })
+      .finally(() => {
+        this.inFlight = null;
+        const next = this.pending;
+        this.pending = null;
+        if (!this.closed && next) this.dispatch(next);
+        else this.resolveWaitersIfDrained();
+      });
+  }
+
+  resolveWaitersIfDrained() {
+    if (this.inFlight || this.pending) return;
+    for (const resolve of this.waiters) resolve();
+    this.waiters.clear();
+  }
+
+  async drain() {
+    if (!this.inFlight && !this.pending) return this.snapshot();
+    await new Promise((resolve) => this.waiters.add(resolve));
+    return this.snapshot();
+  }
+
+  async close() {
+    if (!this.closed) {
+      this.closed = true;
+      if (this.pending) {
+        this.metrics.transportDropped += 1;
+        this.pending = null;
+      }
+      this.resolveWaitersIfDrained();
+    }
+    return this.drain();
+  }
+
+  snapshot() {
+    const roundTripMeanMs = this.metrics.accepted
+      ? this.metrics.roundTripTotalMs / this.metrics.accepted : null;
+    return {
+      sent: this.metrics.sent,
+      dispatched: this.metrics.dispatched,
+      accepted: this.metrics.accepted,
+      transportDropped: this.metrics.transportDropped,
+      failed: this.metrics.failed,
+      maxBuffered: this.metrics.maxBuffered,
+      lastSentSequence: this.metrics.lastSentSequence,
+      lastAcceptedSequence: this.metrics.lastAcceptedSequence,
+      roundTripMs: {
+        min: this.metrics.roundTripMinMs,
+        mean: roundTripMeanMs,
+        max: this.metrics.roundTripMaxMs,
+      },
+      closed: this.closed,
+    };
+  }
+}
+
+export function audioPushExpression(input, fps = 30) {
+  const frame = normalizeAudioFeatureFrame(input);
+  const normalizedFps = normalizeAudioFps(fps);
+  return `(() => {
+    const audio = window.__CODEX_DREAM_SKIN_STATE__?.audio;
+    if (!audio?.push) return { accepted: false, sequence: ${frame.sequence}, reason: "unavailable" };
+    return audio.push(${JSON.stringify(frame)}, { fps: ${normalizedFps} });
+  })()`;
+}
+
+function audioStopExpression() {
+  return `(() => {
+    const audio = window.__CODEX_DREAM_SKIN_STATE__?.audio;
+    if (!audio?.stop) return { available: false, before: null, after: null };
+    const before = audio.snapshot();
+    audio.stop();
+    return { available: true, before, after: audio.snapshot() };
+  })()`;
+}
+
 function nextOperationToken() {
   operationSequence += 1;
   return `${process.pid}:${Date.now()}:${operationSequence}`;
@@ -809,6 +1049,7 @@ async function removeFromSession(session) {
     document.documentElement?.style.removeProperty('--dream-skin-art');
     document.getElementById('codex-dream-skin-style')?.remove();
     document.getElementById('codex-dream-skin-chrome')?.remove();
+    document.getElementById('codex-dream-skin-audio')?.remove();
     delete window.__CODEX_DREAM_SKIN_STATE__;
     return true;
   })()`);
@@ -819,6 +1060,7 @@ async function verifyRemovedSession(session) {
     !document.documentElement.classList.contains('codex-dream-skin') &&
     !document.getElementById('codex-dream-skin-style') &&
     !document.getElementById('codex-dream-skin-chrome') &&
+    !document.getElementById('codex-dream-skin-audio') &&
     !window.__CODEX_DREAM_SKIN_STATE__
   )()`);
 }
@@ -905,6 +1147,7 @@ async function verifySession(session, expectedThemeId = null, expectedRevision =
         result.suggestionLabelColorsMatch
       ))
     );
+    result.audio = window.__CODEX_DREAM_SKIN_STATE__?.audio?.snapshot?.() ?? null;
     result.pass = Boolean(basePass && homePass && payloadPass);
     result.expectedThemeId = expectedThemeId;
     result.expectedRevision = expectedRevision;
@@ -1272,6 +1515,10 @@ async function runWatch(options) {
   let controlOnly = false;
   let mutationEpoch = 0;
   let activeTargetSetups = 0;
+  let syntheticAudioTimer = null;
+  let syntheticAudioSequence = 0;
+  let latestSyntheticFrame = null;
+  const audioPushReceipts = [];
   const targetSetupWaiters = new Set();
   let wakeControlWait = null;
   const wakeControlLoop = () => {
@@ -1362,6 +1609,55 @@ async function runWatch(options) {
     return results.every(Boolean);
   };
 
+  const stopAudioForRecord = async (record) => {
+    if (!options.syntheticAudio || record.audioStopped) return null;
+    record.audioStopped = true;
+    const dispatcher = record.audioDispatcher;
+    record.audioDispatcher = null;
+    const transport = dispatcher
+      ? await dispatcher.close()
+      : null;
+    let renderer = null;
+    if (!record.session.closed) {
+      try {
+        renderer = await record.session.evaluate(audioStopExpression(), 2000);
+      } catch (error) {
+        renderer = { available: false, error: error.message };
+      }
+    }
+    const receipt = { targetId: record.targetId, transport, renderer };
+    if (audioPushReceipts.length === MAX_AUDIO_PUSH_RECEIPTS) audioPushReceipts.shift();
+    audioPushReceipts.push(receipt);
+    return receipt;
+  };
+
+  const createAudioDispatcher = (record) => {
+    record.audioStopped = false;
+    record.audioDispatcher = new LatestFrameDispatcher((frame) =>
+      record.session.evaluate(
+        audioPushExpression(frame, options.audioFps),
+        Math.max(250, Math.min(2000, options.timeoutMs)),
+      ));
+    if (latestSyntheticFrame) record.audioDispatcher.offer(latestSyntheticFrame);
+  };
+
+  const emitSyntheticAudioFrame = () => {
+    if (!options.syntheticAudio || stopping || controlOnly) return;
+    syntheticAudioSequence += 1;
+    latestSyntheticFrame = createDeterministicAudioFrame(
+      syntheticAudioSequence,
+      options.audioFps,
+    );
+    for (const record of sessions.values()) {
+      if (!record.audioDispatcher || record.session.closed) continue;
+      try {
+        record.audioDispatcher.offer(latestSyntheticFrame);
+      } catch (error) {
+        console.error(`[dream-skin] audio frame offer failed: ${error.message}`);
+      }
+    }
+  };
+
   const registerEarlyForRecord = async (record, payload, revision) => {
     const identifier = await registerEarly(record.session, payload, revision);
     if (identifier) record.earlyScriptIds.add(identifier);
@@ -1384,7 +1680,8 @@ async function runWatch(options) {
     return removeEarly(record, { strict });
   };
 
-  const releaseControlSessions = () => {
+  const releaseControlSessions = async () => {
+    await Promise.all([...sessions.values()].map((record) => stopAudioForRecord(record)));
     for (const record of sessions.values()) record.session.close();
     sessions.clear();
   };
@@ -1396,7 +1693,7 @@ async function runWatch(options) {
       token: operation.token,
       message: operation.message || "暂停失败，原皮肤已恢复",
     };
-    releaseControlSessions();
+    await releaseControlSessions();
     wakeControlLoop();
   };
 
@@ -1545,13 +1842,22 @@ async function runWatch(options) {
           invalidateEarly(record, { strict: true }))).catch((error) => {
           console.error(`[dream-skin] final pause invalidation failed: ${error.message}`);
         });
-        releaseControlSessions();
+        await releaseControlSessions();
       }
     }).catch((error) => {
       console.error(`[dream-skin] operation progress failed: ${error.message}`);
     });
     return operationSignalChain;
   });
+
+  if (options.syntheticAudio) {
+    emitSyntheticAudioFrame();
+    syntheticAudioTimer = setInterval(
+      emitSyntheticAudioFrame,
+      Math.round(1000 / options.audioFps),
+    );
+    console.log(`[dream-skin] synthetic audio enabled at ${options.audioFps} FPS`);
+  }
 
   try {
     while (!stopping) {
@@ -1570,11 +1876,11 @@ async function runWatch(options) {
         }));
         if (expiredOperation.status === "pausing") {
           controlOnly = true;
-          releaseControlSessions();
+          await releaseControlSessions();
         }
       }
       if (controlOnly && !activeOperation) {
-        releaseControlSessions();
+        await releaseControlSessions();
         await waitForControlOperation();
         continue;
       }
@@ -1593,7 +1899,7 @@ async function runWatch(options) {
       }
 
       if (controlOnly && !activeOperation) {
-        releaseControlSessions();
+        await releaseControlSessions();
         continue;
       }
 
@@ -1605,6 +1911,7 @@ async function runWatch(options) {
               record.session, "hide", record.operationToken, "loading", "",
             );
           }
+          await stopAudioForRecord(record);
           record.session.close();
           sessions.delete(id);
         }
@@ -1623,12 +1930,15 @@ async function runWatch(options) {
         try {
           session = await connectTarget(target, options.port);
           record = {
+            targetId: target.id,
             session,
             earlyScriptId: null,
             earlyScriptIds: new Set(),
             needsLoadFallback: false,
             operationToken: null,
             operationExternal: false,
+            audioDispatcher: null,
+            audioStopped: true,
           };
           connectionEpoch = mutationEpoch;
           sessions.set(target.id, record);
@@ -1718,6 +2028,7 @@ async function runWatch(options) {
             current.revision,
           );
           if (!verification?.pass) throw new Error("Initial theme verification failed");
+          if (options.syntheticAudio) createAudioDispatcher(record);
           if (recoveryOperation && !activeOperation
             && pauseRecovery?.token === recoveryOperation.token) {
             await presentOperationUi(
@@ -1753,7 +2064,10 @@ async function runWatch(options) {
               );
             }
           }
-          if (record) await removeEarly(record);
+          if (record) {
+            await stopAudioForRecord(record);
+            await removeEarly(record);
+          }
           session?.close();
           sessions.delete(target.id);
           console.error(`[dream-skin] inject failed for ${target.id}: ${error.message}`);
@@ -1770,6 +2084,7 @@ async function runWatch(options) {
       await new Promise((resolve) => setTimeout(resolve, pollDelay));
     }
   } finally {
+    if (syntheticAudioTimer) clearInterval(syntheticAudioTimer);
     if (reloadTimer) clearTimeout(reloadTimer);
     closePayloadWatchers();
     closeOperationWatcher();
@@ -1779,8 +2094,16 @@ async function runWatch(options) {
       record.operationToken && !record.operationExternal
         ? bestEffortOperationUi(record.session, "hide", record.operationToken, "loading", "")
         : Promise.resolve(false)));
+    await Promise.all([...sessions.values()].map((record) => stopAudioForRecord(record)));
     await Promise.all([...sessions.values()].map((record) => removeEarly(record)));
     for (const record of sessions.values()) record.session.close();
+    if (options.syntheticAudio) {
+      console.log(`[dream-skin] audio-push-receipt ${JSON.stringify({
+        fps: options.audioFps,
+        lastSyntheticSequence: syntheticAudioSequence,
+        targets: audioPushReceipts,
+      })}`);
+    }
   }
 }
 
@@ -1813,7 +2136,14 @@ if (path.resolve(process.argv[1] || "") === path.resolve(scriptPath)) {
       await runFinishOperation(options);
       await new Promise((resolve) => process.stdout.write("", resolve));
       process.exit(0);
-    } else if (options.mode === "watch") await runWatch(options);
+    } else if (options.mode === "watch") {
+      await runWatch(options);
+      await Promise.all([
+        new Promise((resolve) => process.stdout.write("", resolve)),
+        new Promise((resolve) => process.stderr.write("", resolve)),
+      ]);
+      process.exit(process.exitCode ?? 0);
+    }
     else await runOneShotAndExit(options);
   } catch (error) {
     console.error(`[dream-skin] ${error.stack || error.message}`);

--- a/macos/tests/injector-bootstrap.test.mjs
+++ b/macos/tests/injector-bootstrap.test.mjs
@@ -3,7 +3,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import vm from "node:vm";
 import { fileURLToPath } from "node:url";
-import { earlyPayloadFor } from "../scripts/injector.mjs";
+import {
+  LatestFrameDispatcher,
+  audioPushExpression,
+  createDeterministicAudioFrame,
+  earlyPayloadFor,
+  normalizeAudioFeatureFrame,
+  normalizeAudioFps,
+} from "../scripts/injector.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const injectorPath = path.resolve(here, "../scripts/injector.mjs");
@@ -81,5 +88,96 @@ assert.match(
   /const suggestionLabelColorsMatch = visibleSuggestionLabels\.every\([\s\S]{0,2500}visibleSuggestionLabels\.length >= result\.visibleCardCount[\s\S]{0,160}result\.suggestionLabelColorsMatch/,
   "Live verification must reject visible home suggestion labels that diverge from the themed card color.",
 );
+
+for (const fps of [10, 20, 30]) assert.equal(normalizeAudioFps(fps), fps);
+for (const invalid of [0, 15, 60, NaN, "30fps"]) {
+  assert.throws(() => normalizeAudioFps(invalid), /10, 20, or 30/);
+}
+
+const deterministic = createDeterministicAudioFrame(7, 30);
+assert.deepEqual(deterministic, createDeterministicAudioFrame(7, 30));
+assert.equal(deterministic.bands.length, 64);
+assert.ok(deterministic.bands.every((value) => Number.isFinite(value) && value >= 0 && value <= 1));
+assert.doesNotMatch(audioPushExpression(deterministic, 30), /samples|pcm|rawAudio/i);
+assert.throws(
+  () => normalizeAudioFeatureFrame({ ...deterministic, samples: [0.1] }),
+  /unsupported field/,
+);
+assert.throws(
+  () => normalizeAudioFeatureFrame({ ...deterministic, bands: deterministic.bands.slice(1) }),
+  /exactly 64 bands/,
+);
+assert.throws(
+  () => normalizeAudioFeatureFrame({ ...deterministic, rms: Number.POSITIVE_INFINITY }),
+  /finite and normalized/,
+);
+
+for (const fps of [10, 20, 30]) {
+  let clock = 0;
+  const sent = [];
+  const dispatcher = new LatestFrameDispatcher(async (frame) => {
+    sent.push(frame.sequence);
+    clock += 0.5;
+    return { accepted: true, sequence: frame.sequence };
+  }, () => clock);
+  for (let sequence = 1; sequence <= fps; sequence += 1) {
+    dispatcher.offer(createDeterministicAudioFrame(sequence, fps));
+    await dispatcher.drain();
+    clock += 1000 / fps;
+  }
+  const metrics = await dispatcher.close();
+  assert.equal(metrics.sent, fps);
+  assert.equal(metrics.accepted, fps);
+  assert.equal(metrics.transportDropped, 0);
+  assert.equal(metrics.failed, 0);
+  assert.equal(metrics.maxBuffered, 0);
+  assert.equal(metrics.lastAcceptedSequence, fps);
+  assert.deepEqual(sent, Array.from({ length: fps }, (_, index) => index + 1));
+}
+
+let overloadResolve;
+const overloadedSent = [];
+const overloaded = new LatestFrameDispatcher((frame) => {
+  overloadedSent.push(frame.sequence);
+  if (frame.sequence === 1) {
+    return new Promise((resolve) => { overloadResolve = resolve; });
+  }
+  return Promise.resolve({ accepted: true, sequence: frame.sequence });
+});
+overloaded.offer(createDeterministicAudioFrame(1));
+overloaded.offer(createDeterministicAudioFrame(2));
+overloaded.offer(createDeterministicAudioFrame(3));
+await Promise.resolve();
+overloadResolve({ accepted: true, sequence: 1 });
+const overloadMetrics = await overloaded.drain();
+assert.deepEqual(overloadedSent, [1, 3]);
+assert.equal(overloadMetrics.sent, 3);
+assert.equal(overloadMetrics.accepted, 2);
+assert.equal(overloadMetrics.transportDropped, 1);
+assert.equal(overloadMetrics.maxBuffered, 1);
+assert.equal(overloadMetrics.lastAcceptedSequence, 3);
+assert.throws(
+  () => overloaded.offer(createDeterministicAudioFrame(3)),
+  /increase strictly/,
+);
+
+let closingResolve;
+const closingSent = [];
+const closing = new LatestFrameDispatcher((frame) => {
+  closingSent.push(frame.sequence);
+  return new Promise((resolve) => { closingResolve = resolve; });
+});
+closing.offer(createDeterministicAudioFrame(1));
+closing.offer(createDeterministicAudioFrame(2));
+await Promise.resolve();
+const closingPromise = closing.close();
+closingResolve({ accepted: true, sequence: 1 });
+const closingMetrics = await closingPromise;
+assert.deepEqual(closingSent, [1]);
+assert.equal(closingMetrics.sent, 2);
+assert.equal(closingMetrics.accepted, 1);
+assert.equal(closingMetrics.transportDropped, 1);
+assert.equal(closingMetrics.maxBuffered, 1);
+assert.throws(() => closing.offer(createDeterministicAudioFrame(3)), /closed/);
 
 console.log("PASS: early injection is shell-guarded, generation-safe, and removed on shutdown.");

--- a/macos/tests/renderer-inject.test.mjs
+++ b/macos/tests/renderer-inject.test.mjs
@@ -159,6 +159,7 @@ function createFixture(theme, {
   nativeShell = "light",
   analysisFixture = null,
   analysisCache = null,
+  animationFrame = false,
 } = {}) {
   let fixtureShell = nativeShell;
   const nodes = new Map();
@@ -167,7 +168,9 @@ function createFixture(theme, {
   const observers = [];
   const resizeObservers = [];
   const timers = new Map();
+  const animationFrames = new Map();
   let nextTimer = 1;
+  let nextFrame = 1;
   let nextBlob = 1;
   const rootStyle = createStyleDeclaration();
   const root = {
@@ -176,6 +179,7 @@ function createFixture(theme, {
     style: rootStyle,
     appendChild(node) {
       node.parentElement = root;
+      node.isConnected = true;
       if (node.id) nodes.set(node.id, node);
     },
     getAttribute(name) { return attributes.get(name) ?? null; },
@@ -186,6 +190,7 @@ function createFixture(theme, {
     className: "",
     appendChild(node) {
       node.parentElement = body;
+      node.isConnected = true;
       if (node.id) nodes.set(node.id, node);
     },
     getAttribute(name) { return bodyAttributes.get(name) ?? null; },
@@ -194,40 +199,54 @@ function createFixture(theme, {
   const shellBox = { left: 280, top: 36, width: 1000, height: 764 };
   const shellMain = {
     classList: createClassList(),
+    prepend(node) {
+      node.parentElement = shellMain;
+      node.isConnected = true;
+      if (node.id) nodes.set(node.id, node);
+    },
     getBoundingClientRect() {
       return { ...shellBox };
     },
   };
 
   const createElement = (tagName) => {
-    if (tagName === "canvas" && analysisFixture) {
-      return {
-        width: 0,
-        height: 0,
-        getContext() {
-          return {
-            drawImage() {},
-            getImageData() { return { data: analysisFixture.pixels }; },
-          };
-        },
-      };
-    }
     const childNodes = new Map();
+    const elementAttributes = new Map();
     const element = {
       id: "",
       dataset: {},
       style: createStyleDeclaration(),
       classList: createClassList(),
       parentElement: null,
+      isConnected: false,
+      tabIndex: 0,
       textContent: "",
       innerHTML: "",
-      setAttribute() {},
+      setAttribute(name, value) { elementAttributes.set(name, String(value)); },
+      getAttribute(name) { return elementAttributes.get(name) ?? null; },
       querySelector(selector) {
         if (!childNodes.has(selector)) childNodes.set(selector, { textContent: "" });
         return childNodes.get(selector);
       },
-      remove() { if (element.id) nodes.delete(element.id); },
+      remove() {
+        element.isConnected = false;
+        if (element.id) nodes.delete(element.id);
+      },
     };
+    if (tagName === "canvas") {
+      element.width = 0;
+      element.height = 0;
+      element.drawCalls = 0;
+      element.getContext = () => ({
+        clearRect() {},
+        drawImage() {},
+        fillRect() { element.drawCalls += 1; },
+        getImageData() {
+          return { data: analysisFixture?.pixels ?? new Uint8ClampedArray(0) };
+        },
+        fillStyle: "",
+      });
+    }
     return element;
   };
 
@@ -241,7 +260,13 @@ function createFixture(theme, {
       if (selector === "main.main-surface" || selector === "main") return shellMain;
       return null;
     },
-    querySelectorAll() { return []; },
+    querySelectorAll(selector) {
+      if (selector.startsWith("#")) {
+        const node = nodes.get(selector.slice(1));
+        return node ? [node] : [];
+      }
+      return [];
+    },
   };
   const mediaQuery = {
     matches: false,
@@ -292,12 +317,13 @@ function createFixture(theme, {
     Blob,
     Uint8Array,
     atob,
-    getComputedStyle() {
+    getComputedStyle(node) {
       const skinShell = root.classList.contains("codex-dream-skin")
         ? (attributes.get("data-dream-shell") || "dark") : fixtureShell;
       return {
         colorScheme: skinShell,
         backgroundColor: fixtureShell === "dark" ? "rgb(24, 24, 27)" : "rgb(250, 250, 250)",
+        pointerEvents: node?.style?.getPropertyValue?.("pointer-events") || "auto",
       };
     },
     setInterval: () => 1,
@@ -309,7 +335,18 @@ function createFixture(theme, {
     },
     clearTimeout(id) { timers.delete(id); },
     cancelAnimationFrame() {},
+    innerWidth: 1280,
+    innerHeight: 800,
+    devicePixelRatio: 1,
   };
+  if (animationFrame) {
+    context.requestAnimationFrame = (callback) => {
+      const id = nextFrame++;
+      animationFrames.set(id, callback);
+      return id;
+    };
+    context.cancelAnimationFrame = (id) => { animationFrames.delete(id); };
+  }
   const payloadFor = (nextTheme, cssText = ".fixture { color: blue; }") => template
     .replace("__DREAM_SKIN_CSS_JSON__", JSON.stringify(cssText))
     .replace("__DREAM_SKIN_ART_JSON__", JSON.stringify("data:image/png;base64,AA=="))
@@ -327,13 +364,20 @@ function createFixture(theme, {
       timer.callback();
     }
   };
+  const flushAnimationFrames = () => {
+    const pending = [...animationFrames.entries()];
+    animationFrames.clear();
+    for (const [, callback] of pending) callback(16.667);
+  };
 
   return {
+    animationFrames,
     attributes,
     body,
     bodyAttributes,
     context,
     flushTimers,
+    flushAnimationFrames,
     nodes,
     observers,
     payload: payloadFor(theme),
@@ -533,6 +577,100 @@ vm.runInNewContext(banner.payload, banner.context);
 assert.equal(banner.attributes.get("data-dream-art-wide"), "true");
 assert.equal(banner.attributes.get("data-dream-art-task-mode"), "banner");
 assert.equal(banner.attributes.get("data-dream-task-mode"), "banner");
+
+const audioFrame = (sequence, overrides = {}) => ({
+  type: "features",
+  protocolVersion: 1,
+  sequence,
+  monotonicMs: (sequence - 1) * (1000 / 30),
+  rms: 0.4,
+  peak: 0.6,
+  bass: 0.5,
+  mid: 0.4,
+  treble: 0.3,
+  beat: false,
+  bands: Array.from({ length: 64 }, (_, index) => ((sequence + index) % 20) / 20),
+  ...overrides,
+});
+
+const audioFixture = createFixture({
+  id: "audio-push-contract",
+  appearance: "dark",
+  art: { safeArea: "none", taskMode: "ambient" },
+}, { animationFrame: true });
+vm.runInNewContext(audioFixture.payload, audioFixture.context);
+const firstAudioState = audioFixture.window.__CODEX_DREAM_SKIN_STATE__;
+assert.equal(firstAudioState.audio.snapshot().active, false);
+assert.equal(audioFixture.nodes.has("codex-dream-skin-audio"), false);
+
+const firstPush = firstAudioState.audio.push(audioFrame(1), { fps: 30 });
+assert.equal(firstPush.accepted, true);
+assert.equal(firstPush.sequence, 1);
+assert.equal(firstPush.replaced, false);
+const secondPush = firstAudioState.audio.push(audioFrame(2), { fps: 30 });
+assert.equal(secondPush.accepted, true);
+assert.equal(secondPush.sequence, 2);
+assert.equal(secondPush.replaced, true);
+const thirdPush = firstAudioState.audio.push(audioFrame(3), { fps: 30 });
+assert.equal(thirdPush.accepted, true);
+assert.equal(thirdPush.sequence, 3);
+assert.equal(thirdPush.replaced, true);
+assert.equal(audioFixture.animationFrames.size, 1, "Audio pushes must share one scheduled animation frame.");
+const audioCanvas = audioFixture.nodes.get("codex-dream-skin-audio");
+assert.ok(audioCanvas, `Audio canvas missing; fixture nodes: ${[...audioFixture.nodes.keys()].join(", ")}`);
+assert.equal(audioCanvas.getAttribute("aria-hidden"), "true");
+assert.equal(audioCanvas.tabIndex, -1);
+assert.equal(audioCanvas.style.getPropertyValue("pointer-events"), "none");
+assert.equal(audioCanvas.style.getPropertyValue("contain"), "strict");
+assert.equal(audioFixture.context.document.querySelectorAll("#codex-dream-skin-audio").length, 1);
+audioFixture.flushAnimationFrames();
+const coalesced = firstAudioState.audio.snapshot();
+assert.equal(coalesced.metrics.accepted, 3);
+assert.equal(coalesced.metrics.drawn, 1);
+assert.equal(coalesced.metrics.renderDropped, 2);
+assert.equal(coalesced.metrics.lastDrawnSequence, 3);
+assert.equal(coalesced.canvas.count, 1);
+assert.equal(coalesced.canvas.pointerEvents, "none");
+assert.equal(coalesced.canvas.contain, "strict");
+
+for (const invalid of [
+  audioFrame(4, { bands: [0.2] }),
+  audioFrame(4, { rms: Number.NaN }),
+  audioFrame(4, { peak: Number.POSITIVE_INFINITY }),
+  audioFrame(4, { bass: 1.1 }),
+  audioFrame(4, { beat: "yes" }),
+  audioFrame(2),
+]) {
+  assert.equal(firstAudioState.audio.push(invalid, { fps: 30 }).accepted, false);
+}
+const rejected = firstAudioState.audio.snapshot();
+assert.equal(rejected.metrics.rejected, 6);
+assert.equal(rejected.metrics.accepted, 3);
+assert.equal(audioFixture.animationFrames.size, 0);
+
+firstAudioState.audio.push(audioFrame(4), { fps: 30 });
+assert.equal(audioFixture.animationFrames.size, 1);
+vm.runInNewContext(audioFixture.payloadFor({
+  id: "audio-push-reinstalled",
+  appearance: "dark",
+  art: { safeArea: "none", taskMode: "ambient" },
+}), audioFixture.context);
+const secondAudioState = audioFixture.window.__CODEX_DREAM_SKIN_STATE__;
+assert.equal(firstAudioState.audio.snapshot().active, false);
+assert.equal(audioFixture.animationFrames.size, 0, "Reinjection must cancel the old audio frame.");
+assert.equal(audioFixture.nodes.has("codex-dream-skin-audio"), false);
+assert.equal(firstAudioState.cleanup(), false, "Old cleanup must not remove a newer renderer generation.");
+
+secondAudioState.audio.push(audioFrame(1), { fps: 10 });
+assert.equal(audioFixture.nodes.has("codex-dream-skin-audio"), true);
+assert.equal(audioFixture.animationFrames.size, 1);
+assert.equal(secondAudioState.audio.stop(), true);
+assert.equal(secondAudioState.audio.snapshot().active, false);
+assert.equal(audioFixture.animationFrames.size, 0);
+assert.equal(audioFixture.nodes.has("codex-dream-skin-audio"), false);
+assert.equal(secondAudioState.cleanup(), true);
+assert.equal(audioFixture.window.__CODEX_DREAM_SKIN_STATE__, undefined);
+assert.equal(audioFixture.nodes.has("codex-dream-skin-audio"), false);
 
 assert.equal(explicit.window.__CODEX_DREAM_SKIN_STATE__.cleanup(), true);
 assert.equal(explicit.root.classList.contains("codex-dream-skin"), false);


### PR DESCRIPTION
## Summary

- Add an opt-in watch-mode synthetic audio diagnostic at 10, 20, or 30 FPS.
- Validate strict protocol-v1 aggregate feature frames with exactly 64 normalized bands.
- Push through the existing verified CDP session with one in-flight frame plus one replaceable pending frame.
- Add a lazy yellow/purple Canvas2D renderer with one pointer-transparent, accessibility-hidden canvas and one latest-frame render slot.
- Clean up dispatcher, frame callback, canvas, early scripts, and renderer state on target loss, reinjection, pause, and watcher exit.
- Expose bounded transport/render receipts through the existing verifier and document the diagnostic boundary.

## Boundaries

- No real audio capture, Swift helper, ScreenCaptureKit, audio permission, loopback stream server, raw samples, or provider integration.
- No app bundle, app.asar, signature, installed theme, or regular Codex session modification.
- Normal watch behavior stays dormant unless `--synthetic-audio` is explicitly supplied.

## Verification

- `CODEX_DREAM_SKIN_SKIP_SIGNED_RUNTIME_TESTS=1 CODEX_DREAM_SKIN_SKIP_DOCTOR=1 ./macos/tests/run-tests.sh`
  - Pass; signed install/runtime-state and Doctor gates are explicitly skipped.
- Isolated signed-app runtime proof with one-time profiles and loopback CDP ports:
  - 10 FPS: pass, bounded latest-frame drops, watcher exit 0, canvas removed.
  - 20 FPS: pass, bounded latest-frame drops, watcher exit 0, canvas removed.
  - 30 FPS: pass across full isolated app/target recreation on the same profile and CDP port; accepted sequence advanced from 316 to 575 after reattach; watcher exit 0.
  - Every run preserved pre-existing Codex PID 77519 and removed its owned listener, processes, canvas, and profile.
- `/usr/bin/codesign --verify --deep --strict /Applications/ChatGPT.app`
  - Pass; identifier `com.openai.codex`, Team ID `2DC432GLL2`.
- `git diff --check`
  - Pass.
- Independent review
  - No remaining actionable findings after receipt bounding, teardown detachment, and stdout/stderr flush fixes.

## Known gates

- Local Doctor against the currently installed theme exits 2 because the installed renderer revision is intentionally older than this branch. No install or user-session restart was performed.
- A raw `Page.reload` on a fresh unauthenticated isolated profile does not reconstruct the native Codex shell, so lifecycle runtime evidence uses complete isolated app/target recreation. Same-document renderer reinjection and zero-leak cleanup remain covered by focused tests.
