### PR TITLE
fix(menubar): saved themes list empty when home dir casing differs from disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,5 +198,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: CodexDreamSkin-dmg
-          path: release/*.dmg
+          path: macos/release/*.dmg
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,3 +193,10 @@ jobs:
 
       - name: Compile and verify the universal DMG
         run: ./macos/scripts/build-dmg.sh --skip-tests
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: CodexDreamSkin-dmg
+          path: release/*.dmg
+          retention-days: 7

--- a/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
+++ b/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
@@ -241,28 +241,47 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   }
 
   private func savedThemes() -> [ThemeOption] {
-    guard let entries = try? fileManager.contentsOfDirectory(
-      at: themesURL,
-      includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
-      options: [.skipsHiddenFiles]
-    ) else {
+    let entries: [URL]
+    do {
+      entries = try fileManager.contentsOfDirectory(
+        at: themesURL,
+        includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+        options: [.skipsHiddenFiles]
+      )
+    } catch {
+      NSLog(
+        "[DreamSkin] savedThemes: list %@ failed: %@",
+        themesURL.path, String(describing: error)
+      )
       return []
     }
     let safeRoot = themesURL.standardizedFileURL.path + "/"
-    return entries.compactMap { directory in
+    var rejected: [String: Int] = [:]
+    let options: [ThemeOption] = entries.compactMap { directory in
       let id = directory.lastPathComponent
-      guard id.range(of: #"^[A-Za-z0-9_-]{1,80}$"#, options: .regularExpression) != nil,
-            let values = try? directory.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+      guard id.range(of: #"^[A-Za-z0-9_-]{1,80}$"#, options: .regularExpression) != nil else {
+        rejected["name", default: 0] += 1
+        return nil
+      }
+      guard let values = try? directory.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
             values.isDirectory == true,
-            values.isSymbolicLink != true,
-            directory.standardizedFileURL.path.hasPrefix(safeRoot) else {
+            values.isSymbolicLink != true else {
+        rejected["kind", default: 0] += 1
+        return nil
+      }
+      guard directory.standardizedFileURL.path.hasPrefix(safeRoot) else {
+        rejected["root", default: 0] += 1
         return nil
       }
       let configURL = directory.appendingPathComponent("theme.json")
       guard let data = try? Data(contentsOf: configURL, options: [.mappedIfSafe]),
-            data.count <= 1_048_576,
-            let object = try? JSONSerialization.jsonObject(with: data),
+            data.count <= 1_048_576 else {
+        rejected["read", default: 0] += 1
+        return nil
+      }
+      guard let object = try? JSONSerialization.jsonObject(with: data),
             let value = object as? [String: Any] else {
+        rejected["json", default: 0] += 1
         return nil
       }
       let rawName = value["name"] as? String ?? id
@@ -270,6 +289,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }.sorted {
       $0.name.localizedStandardCompare($1.name) == .orderedAscending
     }
+    // 空列表或有拒收时落一条统一日志：`log show --predicate 'process ==
+    // "CodexDreamSkinMenuBar"'` 可直接定位是哪一层过滤把主题吃掉了。
+    if options.isEmpty || !rejected.isEmpty {
+      NSLog(
+        "[DreamSkin] savedThemes: %d entries -> %d themes at %@ rejected=%@",
+        entries.count, options.count, themesURL.path, String(describing: rejected)
+      )
+    }
+    return options
   }
 
   private func cleanMenuText(_ source: String) -> String {

--- a/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
+++ b/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
@@ -255,7 +255,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       )
       return []
     }
-    let safeRoot = themesURL.standardizedFileURL.path + "/"
+    // 包含性判断必须用 canonicalPath：用户记录的 home 大小写可能与磁盘目录
+    // 不一致（如 NFSHomeDirectory=/Users/Fei、磁盘实际为 /Users/fei），
+    // 字符串前缀比较会把全部主题误拒成 rejected["root"]。
+    let canonicalRoot =
+      (((try? themesURL.resourceValues(forKeys: [.canonicalPathKey]))?.canonicalPath)
+        ?? themesURL.standardizedFileURL.path) + "/"
     var rejected: [String: Int] = [:]
     let options: [ThemeOption] = entries.compactMap { directory in
       let id = directory.lastPathComponent
@@ -269,7 +274,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         rejected["kind", default: 0] += 1
         return nil
       }
-      guard directory.standardizedFileURL.path.hasPrefix(safeRoot) else {
+      let entryPath =
+        ((try? directory.resourceValues(forKeys: [.canonicalPathKey]))?.canonicalPath)
+          ?? directory.standardizedFileURL.path
+      guard entryPath.hasPrefix(canonicalRoot) else {
         rejected["root", default: 0] += 1
         return nil
       }


### PR DESCRIPTION
已保存的主题在真机上显示为空（磁盘上有 13 个合规主题目录，外部复刻同逻辑可列出）。本 PR：1) savedThemes 加分层拒收计数与读目录错误日志（仅在异常时打一条，正常路径零噪音）；2) CI 上传 DMG 构建产物便于直接下载复测。定位后按日志结论出修复。