### PR TITLE
feat(brand): adopt DreamSkin site mark across app/menu bar/installer icons

### DIFF
--- a/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
+++ b/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
@@ -106,12 +106,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     menu.autoenablesItems = false
     statusItem.menu = menu
     guard let button = statusItem.button else { return }
-    let configuration = NSImage.SymbolConfiguration(pointSize: 15, weight: .semibold)
-    button.image = NSImage(
-      systemSymbolName: "paintpalette.fill",
-      accessibilityDescription: "Codex Dream Skin"
-    )?.withSymbolConfiguration(configuration)
-    button.image?.isTemplate = true
+    // 菜单栏模板剪影：与 dreamskin.cc favicon 同源的品牌 mark
+    // （圆角方描边 + 墨色对角半区）。模板图仅黑 + 透明，青点在
+    // 此尺寸下省略，避免糊成噪点。
+    let mark = NSImage(size: NSSize(width: 18, height: 18), flipped: true) { rect in
+      let inset = rect.insetBy(dx: 1, dy: 1)
+      let rounded = NSBezierPath(roundedRect: inset, xRadius: 5.2, yRadius: 5.2)
+      NSColor.black.setStroke()
+      rounded.lineWidth = 1.4
+      rounded.stroke()
+      NSGraphicsContext.current?.saveGraphicsState()
+      rounded.addClip()
+      let diagonal = NSBezierPath()
+      diagonal.move(to: NSPoint(x: inset.minX, y: inset.maxY))
+      diagonal.line(to: NSPoint(x: inset.maxX, y: inset.minY))
+      diagonal.line(to: NSPoint(x: inset.maxX, y: inset.maxY))
+      diagonal.close()
+      NSColor.black.setFill()
+      diagonal.fill()
+      NSGraphicsContext.current?.restoreGraphicsState()
+      return true
+    }
+    mark.isTemplate = true
+    mark.accessibilityDescription = "Codex Dream Skin"
+    button.image = mark
     button.toolTip = "Codex Dream Skin"
     rebuildMenu()
   }

--- a/macos/menubar-app/Tools/generate-icon.swift
+++ b/macos/menubar-app/Tools/generate-icon.swift
@@ -30,44 +30,36 @@ guard let context = NSGraphicsContext(bitmapImageRep: bitmap) else {
 }
 NSGraphicsContext.current = context
 
-let canvas = NSRect(x: 48, y: 48, width: 928, height: 928)
-let background = NSBezierPath(roundedRect: canvas, xRadius: 220, yRadius: 220)
-let gradient = NSGradient(colors: [
-  NSColor(calibratedRed: 0.18, green: 0.28, blue: 0.72, alpha: 1),
-  NSColor(calibratedRed: 0.53, green: 0.25, blue: 0.76, alpha: 1),
-  NSColor(calibratedRed: 0.95, green: 0.37, blue: 0.48, alpha: 1)
-])!
-gradient.draw(in: background, angle: -42)
+// DreamSkin 品牌 mark，与 dreamskin.cc 的 favicon 同源：白底圆角方 +
+// 发丝描边 + 墨色对角三角 + 青色圆点。坐标取自 32 栅格 favicon ×32
+//（AppKit 坐标系原点在左下，Y 轴与 SVG 相反，已做镜像换算）。
+let canvas = NSRect(x: 64, y: 64, width: 896, height: 896)
+let cornerRadius: CGFloat = 288
+let background = NSBezierPath(roundedRect: canvas, xRadius: cornerRadius, yRadius: cornerRadius)
+let paper = NSColor(calibratedRed: 0.992, green: 0.992, blue: 0.988, alpha: 1) // #fdfdfc
+let ink = NSColor(calibratedRed: 0.090, green: 0.094, blue: 0.110, alpha: 1) // #17181c
+let teal = NSColor(calibratedRed: 0.176, green: 0.882, blue: 0.761, alpha: 1) // #2de1c2
 
-NSColor(calibratedWhite: 0, alpha: 0.18).setFill()
-NSBezierPath(ovalIn: NSRect(x: 202, y: 176, width: 650, height: 650)).fill()
+paper.setFill()
+background.fill()
 
-NSColor(calibratedWhite: 1, alpha: 0.96).setFill()
-let palette = NSBezierPath()
-palette.appendOval(in: NSRect(x: 190, y: 210, width: 650, height: 650))
-palette.appendOval(in: NSRect(x: 568, y: 232, width: 210, height: 180))
-palette.windingRule = .evenOdd
-palette.fill()
+NSGraphicsContext.current?.saveGraphicsState()
+background.addClip()
+ink.setFill()
+let diagonal = NSBezierPath()
+diagonal.move(to: NSPoint(x: 64, y: 64))
+diagonal.line(to: NSPoint(x: 960, y: 960))
+diagonal.line(to: NSPoint(x: 960, y: 64))
+diagonal.close()
+diagonal.fill()
+NSGraphicsContext.current?.restoreGraphicsState()
 
-let colors: [(NSColor, NSRect)] = [
-  (NSColor(calibratedRed: 0.20, green: 0.45, blue: 0.96, alpha: 1), NSRect(x: 330, y: 620, width: 112, height: 112)),
-  (NSColor(calibratedRed: 0.28, green: 0.76, blue: 0.62, alpha: 1), NSRect(x: 480, y: 670, width: 112, height: 112)),
-  (NSColor(calibratedRed: 0.98, green: 0.71, blue: 0.23, alpha: 1), NSRect(x: 635, y: 596, width: 112, height: 112)),
-  (NSColor(calibratedRed: 0.95, green: 0.34, blue: 0.45, alpha: 1), NSRect(x: 286, y: 450, width: 112, height: 112))
-]
-for (color, rect) in colors {
-  color.setFill()
-  NSBezierPath(ovalIn: rect).fill()
-}
+ink.withAlphaComponent(0.14).setStroke()
+background.lineWidth = 32
+background.stroke()
 
-let brush = NSBezierPath(roundedRect: NSRect(x: 485, y: 182, width: 90, height: 390), xRadius: 45, yRadius: 45)
-var transform = AffineTransform()
-transform.translate(x: 530, y: 377)
-transform.rotate(byDegrees: -34)
-transform.translate(x: -530, y: -377)
-brush.transform(using: transform)
-NSColor(calibratedRed: 0.18, green: 0.20, blue: 0.30, alpha: 0.94).setFill()
-brush.fill()
+teal.setFill()
+NSBezierPath(ovalIn: NSRect(x: 656, y: 656, width: 160, height: 160)).fill()
 
 context.flushGraphics()
 NSGraphicsContext.restoreGraphicsState()

--- a/windows/installer/build-release.ps1
+++ b/windows/installer/build-release.ps1
@@ -164,29 +164,43 @@ function Write-DreamSkinIcon {
         $alphaRow = New-Object byte[] $size
         for ($column = 0; $column -lt $size; $column++) {
           $coverage = 0
-          $moonCoverage = 0
-          $starCoverage = 0
+          $darkCoverage = 0
+          $dotCoverage = 0
+          $edgeCoverage = 0
           foreach ($sampleY in @(0.125, 0.375, 0.625, 0.875)) {
             foreach ($sampleX in @(0.125, 0.375, 0.625, 0.875)) {
+              # DreamSkin 品牌 mark（与网站 favicon 同源）：白圆角方 +
+              # 墨色对角半区（x+y>=1）+ 青点 + 14% 发丝描边环。
               $x = ($column + $sampleX) / $size
               $y = ($row + $sampleY) / $size
-              $dx = [Math]::Max([Math]::Abs($x - 0.5) - 0.34, 0.0)
-              $dy = [Math]::Max([Math]::Abs($y - 0.5) - 0.34, 0.0)
-              if (($dx * $dx + $dy * $dy) -le (0.105 * 0.105)) { $coverage++ }
-
-              $outerMoon = (($x - 0.43) * ($x - 0.43) + ($y - 0.46) * ($y - 0.46)) -le (0.215 * 0.215)
-              $innerMoon = (($x - 0.52) * ($x - 0.52) + ($y - 0.39) * ($y - 0.39)) -le (0.185 * 0.185)
-              if ($outerMoon -and -not $innerMoon) { $moonCoverage++ }
-              if ([Math]::Abs($x - 0.69) + [Math]::Abs($y - 0.31) -le 0.065) { $starCoverage++ }
+              $dx = [Math]::Max([Math]::Abs($x - 0.5) - 0.16, 0.0)
+              $dy = [Math]::Max([Math]::Abs($y - 0.5) - 0.16, 0.0)
+              $edgeDistance = [Math]::Sqrt($dx * $dx + $dy * $dy)
+              if ($edgeDistance -le 0.285) {
+                $coverage++
+                if (($x + $y) -ge 1.0) { $darkCoverage++ }
+                $ddx = $x - 0.719
+                $ddy = $y - 0.281
+                if (($ddx * $ddx + $ddy * $ddy) -le (0.08 * 0.08)) { $dotCoverage++ }
+                if ($edgeDistance -gt (0.285 - [Math]::Max(0.028, 1.1 / $size))) { $edgeCoverage++ }
+              }
             }
           }
 
           $alpha = [int][Math]::Round(255.0 * $coverage / 16.0)
           $alphaRow[$column] = [byte]$alpha
-          $blend = [Math]::Max($moonCoverage, $starCoverage) / 16.0
-          $red = [int][Math]::Round((63 + 23 * (1.0 - $y)) * (1.0 - $blend) + 245 * $blend)
-          $green = [int][Math]::Round((48 + 70 * $x) * (1.0 - $blend) + 248 * $blend)
-          $blue = [int][Math]::Round((153 + 73 * $x) * (1.0 - $blend) + 255 * $blend)
+          $darkBlend = $darkCoverage / 16.0
+          $dotBlend = $dotCoverage / 16.0
+          $edgeBlend = 0.14 * ($edgeCoverage / 16.0)
+          $red = 253.0 * (1.0 - $darkBlend) + 23.0 * $darkBlend
+          $green = 253.0 * (1.0 - $darkBlend) + 24.0 * $darkBlend
+          $blue = 252.0 * (1.0 - $darkBlend) + 28.0 * $darkBlend
+          $red = $red * (1.0 - $dotBlend) + 45.0 * $dotBlend
+          $green = $green * (1.0 - $dotBlend) + 225.0 * $dotBlend
+          $blue = $blue * (1.0 - $dotBlend) + 194.0 * $dotBlend
+          $red = [int][Math]::Round($red * (1.0 - $edgeBlend) + 23.0 * $edgeBlend)
+          $green = [int][Math]::Round($green * (1.0 - $edgeBlend) + 24.0 * $edgeBlend)
+          $blue = [int][Math]::Round($blue * (1.0 - $edgeBlend) + 28.0 * $edgeBlend)
           $writer.Write([byte]$blue)
           $writer.Write([byte]$green)
           $writer.Write([byte]$red)

--- a/windows/installer/build-release.ps1
+++ b/windows/installer/build-release.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param(
   [string]$OutputDirectory,
   [string]$IsccPath,


### PR DESCRIPTION
三个图标管线统一换成 dreamskin.cc 的品牌 mark（favicon 同源：白圆角方 + 发丝边 + 墨色对角 + 青点）：macOS 1024 应用图标、菜单栏模板剪影（青点在 18px 模板下省略）、Windows ICO 光栅器（含 14% 描边环）。确定性测试为双跑对比，纯算术画稿天然满足。