### PR TITLE
fix(theme): pin Codex appearanceTheme to fixed-appearance themes and remap dropdown tokens

### DIFF
--- a/macos/assets/dream-skin.css
+++ b/macos/assets/dream-skin.css
@@ -103,6 +103,25 @@ html[data-dream-skin="active"][data-dream-shell="light"] {
   --ds-task-immersive-far: rgb(var(--ds-panel-rgb) / .66);
 }
 
+/* Native token surfaces (dropdown/popover) resolve from Codex's own
+   appearanceTheme, not the skin; when that disagrees with data-dream-shell the
+   popover keeps the opposite palette (#233). Remap the dropdown token family to
+   skin variables so those surfaces inherit the theme in both shells. */
+html[data-dream-skin="active"] {
+  --color-token-dropdown-background: var(--ds-panel);
+}
+
+html[data-dream-skin="active"] [class~="bg-token-dropdown-background"] {
+  color: var(--ds-text);
+  --color-token-foreground: var(--ds-text);
+  --color-token-text-secondary: var(--ds-muted);
+  --color-token-muted-foreground: var(--ds-muted);
+  --color-token-description-foreground: var(--ds-muted);
+  --color-token-list-hover-background: rgb(var(--ds-panel-2-rgb) / .9);
+  --color-token-border: var(--ds-line);
+  --color-token-border-default: var(--ds-line);
+}
+
 html[data-dream-skin="active"]:is([data-dream-art-safe="left"], [data-dream-art-safe-area="left"]) {
   --ds-safe-side: left;
   --ds-art-position: 100% var(--ds-focus-y);

--- a/macos/scripts/common-macos.sh
+++ b/macos/scripts/common-macos.sh
@@ -350,6 +350,22 @@ codex_is_running() {
   [ -n "$(codex_main_pids)" ]
 }
 
+active_theme_appearance() {
+  "$NODE" -e '
+const fs = require("node:fs");
+let appearance = "auto";
+try { appearance = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).appearance; } catch {}
+process.stdout.write(appearance === "light" || appearance === "dark" ? appearance : "auto");
+' "$THEME_DIR/theme.json"
+}
+
+# Pin Codex appearanceTheme to the staged theme's declared appearance (or put
+# the user's original line back for auto themes). Callers must only run this
+# while Codex is closed; config writes race the app's own saves otherwise.
+sync_appearance_pin() {
+  "$NODE" "$SCRIPT_DIR/theme-config.mjs" install "$CONFIG_PATH" "$THEME_BACKUP_PATH" "$(active_theme_appearance)"
+}
+
 process_started_at() {
   /bin/ps -p "$1" -o lstart= 2>/dev/null | /usr/bin/awk '{$1=$1; print}'
 }

--- a/macos/scripts/install-dream-skin-macos.sh
+++ b/macos/scripts/install-dream-skin-macos.sh
@@ -97,7 +97,7 @@ if [ ! -f "$THEME_DIR/theme.json" ]; then
 fi
 [ -f "$CONFIG_PATH" ] || fail "Codex config not found: $CONFIG_PATH. Launch Codex once, close it, and rerun the installer."
 "$NODE" "$INJECTOR" --check-payload --theme-dir "$THEME_DIR" >/dev/null
-"$NODE" "$SCRIPT_DIR/theme-config.mjs" install "$CONFIG_PATH" "$THEME_BACKUP_PATH"
+sync_appearance_pin
 
 shell_quote() {
   "$NODE" -e 'process.stdout.write(JSON.stringify(process.argv[1]))' "$1"

--- a/macos/scripts/install-dream-skin-macos.sh
+++ b/macos/scripts/install-dream-skin-macos.sh
@@ -94,6 +94,18 @@ codex_is_running && fail "Close Codex before installation so config.toml cannot 
 seed_bundled_presets
 if [ ! -f "$THEME_DIR/theme.json" ]; then
   "$SCRIPT_DIR/switch-theme-macos.sh" --id preset-gothic-void-crusade --no-apply >/dev/null
+else
+  # Re-stage official presets so metadata upgrades (e.g. the #183 appearance
+  # pin) reach an active copy staged by an older engine.
+  ACTIVE_THEME_ID="$("$NODE" -e '
+const fs = require("node:fs");
+let id = "";
+try { id = String(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).id ?? ""); } catch {}
+process.stdout.write(/^preset-[A-Za-z0-9_-]{1,72}$/.test(id) ? id : "");
+' "$THEME_DIR/theme.json")"
+  if [ -n "$ACTIVE_THEME_ID" ] && [ -d "$STATE_ROOT/themes/$ACTIVE_THEME_ID" ]; then
+    "$SCRIPT_DIR/switch-theme-macos.sh" --id "$ACTIVE_THEME_ID" --no-apply >/dev/null
+  fi
 fi
 [ -f "$CONFIG_PATH" ] || fail "Codex config not found: $CONFIG_PATH. Launch Codex once, close it, and rerun the installer."
 "$NODE" "$INJECTOR" --check-payload --theme-dir "$THEME_DIR" >/dev/null

--- a/macos/scripts/restore-dream-skin-macos.sh
+++ b/macos/scripts/restore-dream-skin-macos.sh
@@ -30,7 +30,10 @@ if [ "$UNINSTALL" = "true" ] && [ ! -e "$STATE_PATH" ] &&
   fi
   backup_appearance="$(/usr/bin/plutil -extract values.appearanceTheme raw -o - "$THEME_BACKUP_PATH" 2>/dev/null || true)"
   backup_dark_code="$(/usr/bin/plutil -extract values.appearanceDarkCodeThemeId raw -o - "$THEME_BACKUP_PATH" 2>/dev/null || true)"
-  if [ "$backup_appearance" = "null" ] && [ "$backup_dark_code" = "null" ]; then
+  # Install may have pinned appearanceTheme even when the backup recorded no
+  # original line; a pinned config still needs the full restore below.
+  if [ "$backup_appearance" = "null" ] && [ "$backup_dark_code" = "null" ] &&
+      ! /usr/bin/grep -E -q '^[[:space:]]*appearanceTheme[[:space:]]*=' "$CONFIG_PATH" 2>/dev/null; then
     /bin/rm -f "$THEME_BACKUP_PATH"
     printf 'The install created no config overrides; safe engine-only cleanup.\n'
     exit 0

--- a/macos/scripts/start-dream-skin-macos.sh
+++ b/macos/scripts/start-dream-skin-macos.sh
@@ -96,6 +96,11 @@ fi
 
 INJECTOR_PID=""
 if [ "$DEBUG_READY" = "false" ]; then
+  # Codex is closed on this path (never started, or stopped just above), so it
+  # is safe to sync the appearanceTheme pin to the staged theme before launch.
+  # Best-effort: a config we refuse to rewrite should not block starting.
+  sync_appearance_pin >/dev/null \
+    || printf 'Warning: could not sync Codex appearanceTheme to the active theme; native menus may keep the previous appearance.\n' >&2
   PORT="$(select_available_port "$PORT")"
   printf 'Launching ChatGPT with skin debug port %s…\n' "$PORT" >&2
   launch_codex_with_cdp "$PORT"

--- a/macos/scripts/theme-config.mjs
+++ b/macos/scripts/theme-config.mjs
@@ -2,16 +2,22 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-const [mode, configPath, backupPath] = process.argv.slice(2);
-// Backup these keys so Restore can put them back. Do NOT force dark —
-// Dream Skin CSS auto-adapts to light/dark via data-dream-shell.
+const [mode, configPath, backupPath, appearanceArg] = process.argv.slice(2);
+// Backup these keys so Restore can put them back. When the active theme pins an
+// appearance (light|dark), install also pins Codex appearanceTheme to match —
+// native token surfaces (dropdown/popover, #233) follow appearanceTheme, not the
+// skin. "auto" themes restore the user's original line instead.
 const settings = new Map([
   ["appearanceTheme", null],
   ["appearanceDarkCodeThemeId", null],
 ]);
 
 if (!["install", "restore"].includes(mode) || !configPath || !backupPath) {
-  throw new Error("Usage: theme-config.mjs <install|restore> <config-path> <backup-path>");
+  throw new Error("Usage: theme-config.mjs <install|restore> <config-path> <backup-path> [appearance]");
+}
+const appearance = appearanceArg || "auto";
+if (!["auto", "light", "dark"].includes(appearance)) {
+  throw new Error(`Unsupported appearance "${appearanceArg}"; expected auto, light, or dark.`);
 }
 
 function desktopSection(content) {
@@ -260,20 +266,22 @@ async function main() {
       await atomicWrite(backupPath, `${JSON.stringify(backup, null, 2)}\n`, 0o600);
     }
 
-    // Only apply non-null settings. null means "backup only / leave user's appearance alone".
-    let body = section.body;
-    let changed = false;
-    for (const [key, line] of settings) {
-      if (line === null) continue;
-      body = replaceSetting(body, key, line);
-      changed = true;
-    }
-    if (changed) {
+    // Pin appearanceTheme while a fixed-appearance theme is active; "auto"
+    // writes the pre-install line back so the user's own choice returns.
+    const backup = JSON.parse(decodeStrictUtf8(await fs.readFile(backupPath), "Theme backup"));
+    validateBackup(backup);
+    const desired = appearance === "auto"
+      ? backup.values.appearanceTheme ?? null
+      : `appearanceTheme = "${appearance}"`;
+    const body = replaceSetting(section.body, "appearanceTheme", desired);
+    if (body !== section.body) {
       const updated = content.slice(0, section.bodyStart) + body + content.slice(section.bodyEnd);
       await assertConfigUnchanged(originalBytes, originalStat);
       await atomicWrite(configPath, updated, originalStat.mode & 0o777, originalBytes, originalStat);
     }
-    console.log("Saved base-theme backup; left Codex appearanceTheme unchanged (skin auto-adapts light/dark).");
+    console.log(appearance === "auto"
+      ? "Saved base-theme backup; left Codex appearanceTheme at the user's own value (auto theme adapts to either shell)."
+      : `Saved base-theme backup; pinned Codex appearanceTheme = "${appearance}" to match the theme (Restore puts the original back).`);
     return;
   }
 

--- a/runtime/dream-skin.css
+++ b/runtime/dream-skin.css
@@ -103,6 +103,25 @@ html[data-dream-skin="active"][data-dream-shell="light"] {
   --ds-task-immersive-far: rgb(var(--ds-panel-rgb) / .66);
 }
 
+/* Native token surfaces (dropdown/popover) resolve from Codex's own
+   appearanceTheme, not the skin; when that disagrees with data-dream-shell the
+   popover keeps the opposite palette (#233). Remap the dropdown token family to
+   skin variables so those surfaces inherit the theme in both shells. */
+html[data-dream-skin="active"] {
+  --color-token-dropdown-background: var(--ds-panel);
+}
+
+html[data-dream-skin="active"] [class~="bg-token-dropdown-background"] {
+  color: var(--ds-text);
+  --color-token-foreground: var(--ds-text);
+  --color-token-text-secondary: var(--ds-muted);
+  --color-token-muted-foreground: var(--ds-muted);
+  --color-token-description-foreground: var(--ds-muted);
+  --color-token-list-hover-background: rgb(var(--ds-panel-2-rgb) / .9);
+  --color-token-border: var(--ds-line);
+  --color-token-border-default: var(--ds-line);
+}
+
 html[data-dream-skin="active"]:is([data-dream-art-safe="left"], [data-dream-art-safe-area="left"]) {
   --ds-safe-side: left;
   --ds-art-position: 100% var(--ds-focus-y);

--- a/windows/assets/dream-skin.css
+++ b/windows/assets/dream-skin.css
@@ -103,6 +103,25 @@ html[data-dream-skin="active"][data-dream-shell="light"] {
   --ds-task-immersive-far: rgb(var(--ds-panel-rgb) / .66);
 }
 
+/* Native token surfaces (dropdown/popover) resolve from Codex's own
+   appearanceTheme, not the skin; when that disagrees with data-dream-shell the
+   popover keeps the opposite palette (#233). Remap the dropdown token family to
+   skin variables so those surfaces inherit the theme in both shells. */
+html[data-dream-skin="active"] {
+  --color-token-dropdown-background: var(--ds-panel);
+}
+
+html[data-dream-skin="active"] [class~="bg-token-dropdown-background"] {
+  color: var(--ds-text);
+  --color-token-foreground: var(--ds-text);
+  --color-token-text-secondary: var(--ds-muted);
+  --color-token-muted-foreground: var(--ds-muted);
+  --color-token-description-foreground: var(--ds-muted);
+  --color-token-list-hover-background: rgb(var(--ds-panel-2-rgb) / .9);
+  --color-token-border: var(--ds-line);
+  --color-token-border-default: var(--ds-line);
+}
+
 html[data-dream-skin="active"]:is([data-dream-art-safe="left"], [data-dream-art-safe-area="left"]) {
   --ds-safe-side: left;
   --ds-art-position: 100% var(--ds-focus-y);

--- a/windows/scripts/config-utf8.ps1
+++ b/windows/scripts/config-utf8.ps1
@@ -367,23 +367,37 @@ function Read-DreamSkinAppearanceMarker {
   } catch {
     throw "Dream Skin appearance marker is unreadable; config was preserved: $markerPath"
   }
-  if ($null -eq $marker -or $marker -is [string] -or $marker -is [array] -or
-    [int]$marker.schemaVersion -ne 1 -or $marker.appearanceThemeManaged -isnot [bool] -or
-    [bool]$marker.appearanceThemeManaged) {
+  if ($null -eq $marker -or $marker -is [string] -or $marker -is [array]) {
+    throw "Dream Skin appearance marker is invalid; config was preserved: $markerPath"
+  }
+  $schemaVersion = 0
+  try { $schemaVersion = [int]$marker.schemaVersion } catch { $schemaVersion = 0 }
+  # v1 markers are always unmanaged; v2 markers may pin appearanceTheme.
+  $validUnmanagedV1 = $schemaVersion -eq 1 -and $marker.appearanceThemeManaged -is [bool] -and
+    -not [bool]$marker.appearanceThemeManaged
+  $validV2 = $schemaVersion -eq 2 -and $marker.appearanceThemeManaged -is [bool]
+  if (-not ($validUnmanagedV1 -or $validV2)) {
     throw "Dream Skin appearance marker is invalid; config was preserved: $markerPath"
   }
   return $marker
 }
 
 function Write-DreamSkinAppearanceMarker {
-  param([Parameter(Mandatory = $true)][string]$BackupPath)
+  param(
+    [Parameter(Mandatory = $true)][string]$BackupPath,
+    [bool]$Managed = $false
+  )
   $markerPath = Get-DreamSkinAppearanceMarkerPath -BackupPath $BackupPath
   if (Get-Command Assert-DreamSkinNoReparseComponents -ErrorAction SilentlyContinue) {
     Assert-DreamSkinNoReparseComponents -Path $markerPath
   }
+  # Unmanaged markers keep the v1 shape older engines accept; managed pins use
+  # schemaVersion 2, which older engines conservatively refuse to act on.
+  $schemaVersion = 1
+  if ($Managed) { $schemaVersion = 2 }
   $marker = [ordered]@{
-    schemaVersion = 1
-    appearanceThemeManaged = $false
+    schemaVersion = $schemaVersion
+    appearanceThemeManaged = $Managed
   } | ConvertTo-Json
   Write-DreamSkinUtf8FileAtomically -Path $markerPath -Content ($marker + "`r`n")
 }
@@ -395,7 +409,10 @@ function Install-DreamSkinBaseTheme {
     [string]$ConfigPath,
 
     [Parameter(Mandatory = $true)]
-    [string]$BackupPath
+    [string]$BackupPath,
+
+    [ValidateSet('auto', 'light', 'dark')]
+    [string]$AppearanceTheme = 'auto'
   )
 
   if (-not (Test-Path -LiteralPath $ConfigPath)) { throw "Codex config not found: $ConfigPath" }
@@ -426,9 +443,14 @@ function Install-DreamSkinBaseTheme {
 
     $body = $desktop.Body
     $backupContent = $null
+    $pinnedAppearance = $AppearanceTheme -ne 'auto'
+    $managedByMarker = $null -ne $appearanceMarker -and [bool]$appearanceMarker.appearanceThemeManaged
     $legacyMigration = $null -eq $appearanceMarker -and (Test-Path -LiteralPath $BackupPath) -and
       (Test-DreamSkinLegacyManagedLightTrio -Content $content)
-    if ($legacyMigration) {
+    # Put the pre-install appearanceTheme back whenever we stop managing it:
+    # either migrating away from the legacy forced-light trio, or un-pinning
+    # after a fixed-appearance theme is replaced by an auto one.
+    if (-not $pinnedAppearance -and ($legacyMigration -or $managedByMarker)) {
       $backupContent = ConvertFrom-DreamSkinUtf8Bytes -Bytes ([System.IO.File]::ReadAllBytes($BackupPath)) -Path $BackupPath
       Assert-DreamSkinDesktopShapeSupported -Content $backupContent
       $backupDesktop = Get-DreamSkinDesktopSection -Content $backupContent
@@ -436,6 +458,12 @@ function Install-DreamSkinBaseTheme {
         Get-DreamSkinSectionSettingLine -Body $backupDesktop.Body -Key 'appearanceTheme'
       } else { $null }
       $body = Set-DreamSkinSectionSetting -Body $body -Key 'appearanceTheme' -Line $savedAppearance -NewLine $newLine
+    }
+    if ($pinnedAppearance) {
+      # Native token surfaces (dropdowns/popovers) follow appearanceTheme, so a
+      # fixed-appearance theme pins it to match; Restore puts the original back.
+      $body = Set-DreamSkinSectionSetting -Body $body -Key 'appearanceTheme' `
+        -Line ('appearanceTheme = "{0}"' -f $AppearanceTheme) -NewLine $newLine
     }
     $settings = [ordered]@{
       appearanceLightCodeThemeId = $script:DreamSkinManagedLightCodeTheme
@@ -452,7 +480,7 @@ function Install-DreamSkinBaseTheme {
       $content.Substring($desktop.BodyStart + $desktop.BodyLength)
     # Commit the metadata first. A config commit must never exist without the
     # marker that tells restore exactly which appearance keys we own.
-    Write-DreamSkinAppearanceMarker -BackupPath $BackupPath
+    Write-DreamSkinAppearanceMarker -BackupPath $BackupPath -Managed $pinnedAppearance
     Write-DreamSkinUtf8FileAtomically -Path $ConfigPath -Content $content -ExpectedBytes $originalBytes
     $writeCompleted = $true
   } catch {
@@ -515,8 +543,12 @@ function Restore-DreamSkinBaseTheme {
   $appearanceMarker = Read-DreamSkinAppearanceMarker -BackupPath $BackupPath
   $restoreLegacyAppearance = $null -eq $appearanceMarker -and
     (Test-DreamSkinLegacyManagedLightTrio -Content $currentContent)
+  $restoreManagedAppearance = $null -ne $appearanceMarker -and
+    [bool]$appearanceMarker.appearanceThemeManaged
   $restoreKeys = @('appearanceLightCodeThemeId', 'appearanceLightChromeTheme')
-  if ($restoreLegacyAppearance) { $restoreKeys = @('appearanceTheme') + $restoreKeys }
+  if ($restoreLegacyAppearance -or $restoreManagedAppearance) {
+    $restoreKeys = @('appearanceTheme') + $restoreKeys
+  }
   $hasNestedLightChromeTheme = Test-DreamSkinDesktopNestedTable `
     -Content $currentContent -Key 'appearanceLightChromeTheme'
   foreach ($key in $restoreKeys) {

--- a/windows/scripts/install-dream-skin.ps1
+++ b/windows/scripts/install-dream-skin.ps1
@@ -42,7 +42,8 @@ try {
   $null = Initialize-DreamSkinThemeStore -SkillRoot $engine.Root -StateRoot $StateRoot
   $ConfigPath = Join-Path $HOME '.codex\config.toml'
   $BackupPath = Join-Path $StateRoot 'config.before-dream-skin.toml'
-  Install-DreamSkinBaseTheme -ConfigPath $ConfigPath -BackupPath $BackupPath
+  Install-DreamSkinBaseTheme -ConfigPath $ConfigPath -BackupPath $BackupPath `
+    -AppearanceTheme (Get-DreamSkinActiveThemeAppearance -ThemeDirectory $themePaths.Active)
 
   if (-not $NoShortcuts) {
     $shell = New-Object -ComObject WScript.Shell

--- a/windows/scripts/start-dream-skin.ps1
+++ b/windows/scripts/start-dream-skin.ps1
@@ -114,6 +114,15 @@ try {
   $launchedWithCdp = $false
   try {
     if ($null -eq (Get-DreamSkinVerifiedCdpIdentity -Port $Port -Codex $codex)) {
+      # Codex is closed on this path; sync the appearanceTheme pin to the
+      # active theme before launching (config writes race the app while it runs).
+      try {
+        Install-DreamSkinBaseTheme -ConfigPath (Join-Path $HOME '.codex\config.toml') `
+          -BackupPath (Join-Path $StateRoot 'config.before-dream-skin.toml') `
+          -AppearanceTheme (Get-DreamSkinActiveThemeAppearance -ThemeDirectory $themePaths.Active)
+      } catch {
+        Write-Warning "Could not sync Codex appearanceTheme to the active theme: $($_.Exception.Message)"
+      }
       if (-not (Test-DreamSkinPortAvailable -Port $Port)) {
         if ($PortExplicit) { throw "Port $Port is already occupied by an unverified listener. Choose another port." }
         $Port = Select-DreamSkinPort -PreferredPort $Port

--- a/windows/scripts/theme-windows.ps1
+++ b/windows/scripts/theme-windows.ps1
@@ -235,16 +235,16 @@ function Initialize-DreamSkinThemeStore {
   $presetTheme = Join-Path $presetDirectory 'theme.json'
   Assert-DreamSkinNoReparseComponents -Path $presetDirectory
   Assert-DreamSkinNoReparseComponents -Path $presetTheme
-  if (-not (Test-Path -LiteralPath $presetTheme -PathType Leaf)) {
-    Ensure-DreamSkinManagedDirectory -Path $presetDirectory -Root $paths.Root
-    $presetImage = Join-Path $presetDirectory $assetImageName
-    Assert-DreamSkinNoReparseComponents -Path $presetImage
-    Copy-Item -LiteralPath $assetImage -Destination $presetImage -Force
-    Assert-DreamSkinNoReparseComponents -Path $presetImage
-    Assert-DreamSkinImageFile -Path $presetImage
-    Assert-DreamSkinNoReparseComponents -Path $presetTheme
-    Copy-Item -LiteralPath (Join-Path $assetRoot 'theme.json') -Destination $presetTheme -Force
-  }
+  # Refresh the saved copy on every run (matching macOS seeding) so preset
+  # metadata upgrades — e.g. the #183 appearance pin — reach existing installs.
+  Ensure-DreamSkinManagedDirectory -Path $presetDirectory -Root $paths.Root
+  $presetImage = Join-Path $presetDirectory $assetImageName
+  Assert-DreamSkinNoReparseComponents -Path $presetImage
+  Copy-Item -LiteralPath $assetImage -Destination $presetImage -Force
+  Assert-DreamSkinNoReparseComponents -Path $presetImage
+  Assert-DreamSkinImageFile -Path $presetImage
+  Assert-DreamSkinNoReparseComponents -Path $presetTheme
+  Copy-Item -LiteralPath (Join-Path $assetRoot 'theme.json') -Destination $presetTheme -Force
   # Bundled Gothic Void Crusade (same pack as macOS presets/).
   $gothicSource = Join-Path $SkillRoot 'presets\preset-gothic-void-crusade'
   $gothicDirectory = Join-Path $paths.Saved 'preset-gothic-void-crusade'
@@ -254,8 +254,7 @@ function Initialize-DreamSkinThemeStore {
   Assert-DreamSkinNoReparseComponents -Path $gothicDirectory
   Assert-DreamSkinNoReparseComponents -Path $gothicTheme
   if ((Test-Path -LiteralPath $gothicSourceTheme -PathType Leaf) -and
-    (Test-Path -LiteralPath $gothicSourceImage -PathType Leaf) -and
-    -not (Test-Path -LiteralPath $gothicTheme -PathType Leaf)) {
+    (Test-Path -LiteralPath $gothicSourceImage -PathType Leaf)) {
     Ensure-DreamSkinManagedDirectory -Path $gothicDirectory -Root $paths.Root
     $gothicImage = Join-Path $gothicDirectory 'background.jpg'
     Assert-DreamSkinNoReparseComponents -Path $gothicImage
@@ -265,6 +264,33 @@ function Initialize-DreamSkinThemeStore {
     Assert-DreamSkinImageFile -Path $gothicImage
     Assert-DreamSkinNoReparseComponents -Path $gothicTheme
     Copy-Item -LiteralPath $gothicSourceTheme -Destination $gothicTheme -Force
+  }
+  # Refresh the staged active copy of official presets too; otherwise metadata
+  # staged by an older engine (e.g. pre-#183 appearance "auto") keeps steering
+  # the appearanceTheme pin after upgrades.
+  if (Test-Path -LiteralPath $activeTheme -PathType Leaf) {
+    $activeId = ''
+    try {
+      $activeId = "$((Read-DreamSkinTheme -ThemeDirectory $paths.Active -SkipImageMetadata).Theme.id)"
+    } catch {}
+    $refreshSource = $null
+    if ($activeId -ceq $bundledPresetId) { $refreshSource = $assetRoot }
+    elseif ($activeId -ceq 'preset-gothic-void-crusade' -and
+      (Test-Path -LiteralPath $gothicSourceTheme -PathType Leaf)) { $refreshSource = $gothicSource }
+    if ($null -ne $refreshSource) {
+      $sourcePack = Read-DreamSkinTheme -ThemeDirectory $refreshSource
+      $sourceJson = Read-DreamSkinUtf8File -Path $sourcePack.ThemePath
+      $activeJson = Read-DreamSkinUtf8File -Path $activeTheme
+      if ($sourceJson -cne $activeJson) {
+        $sourceImageName = [System.IO.Path]::GetFileName($sourcePack.ImagePath)
+        $refreshedImage = Join-Path $paths.Active $sourceImageName
+        Assert-DreamSkinNoReparseComponents -Path $refreshedImage
+        Copy-Item -LiteralPath $sourcePack.ImagePath -Destination $refreshedImage -Force
+        Assert-DreamSkinNoReparseComponents -Path $refreshedImage
+        Assert-DreamSkinImageFile -Path $refreshedImage
+        Copy-Item -LiteralPath $sourcePack.ThemePath -Destination $activeTheme -Force
+      }
+    }
   }
   $null = Read-DreamSkinTheme -ThemeDirectory $paths.Active
   return $paths

--- a/windows/scripts/theme-windows.ps1
+++ b/windows/scripts/theme-windows.ps1
@@ -183,6 +183,15 @@ function Write-DreamSkinTheme {
   Write-DreamSkinUtf8FileAtomically -Path $themePath -Content ($json + "`r`n")
 }
 
+function Get-DreamSkinActiveThemeAppearance {
+  param([Parameter(Mandatory = $true)][string]$ThemeDirectory)
+  try {
+    $appearance = "$((Read-DreamSkinTheme -ThemeDirectory $ThemeDirectory).Theme.appearance)"
+    if ($appearance -in @('light', 'dark')) { return $appearance }
+  } catch {}
+  return 'auto'
+}
+
 function Initialize-DreamSkinThemeStore {
   param(
     [Parameter(Mandatory = $true)][string]$SkillRoot,


### PR DESCRIPTION
Fixes #233.

## Problem

The environment-info popover (and the native dropdown token family) colors from Codex's own `appearanceTheme`, not from the skin. With a dark theme active and the user's config at `system` → light, the popover renders the native light palette — the light-purple patch in #233. Verified live over loopback CDP: the popover's `--color-token-dropdown-background` comes from the app's `@layer theme` VS Code-token bridge (`var(--vscode-dropdown-background)`), which follows `appearanceTheme` and ignores `electron-light/dark` classes entirely.

## Fix — two complementary layers

**Config pin (root cause).** Install and the launch path of start now pin `appearanceTheme` to the active theme's declared `appearance` (`light`|`dark`); `auto` themes put the user's pre-install line back.
- macOS: `theme-config.mjs install` takes the appearance as a new argv (backward compatible — omitted means `auto`); `sync_appearance_pin` in `common-macos.sh` reads it from the staged `theme.json`. Runs only where Codex is closed (install guard / pre-launch), so config writes can't race the app's saves.
- Windows: `Install-DreamSkinBaseTheme -AppearanceTheme` pins the same way and records managed pins in a v2 appearance marker. v1 markers stay accepted; restore returns the pre-install line for legacy-trio, v1, and v2 states. Uninstall keeps the selective-restore path whenever a pin is present.

**CSS fallback (defense in depth).** The unified runtime CSS remaps `--color-token-dropdown-background` plus the dropdown foreground/hover/border tokens to `--ds-*` variables inside the skin scope — covers hand-edited configs, `system` flips while running, and future native surfaces. Unlayered author rules override the app's `@layer theme` without `!important`.

## Verification

- Live macOS deploy: popover token resolves to the theme panel `#171513` (was native `rgb(45,45,45)`); doctor passes end-to-end.
- Full macOS suite green (config roundtrips, switch-theme signed runtime, runtime-state integration, doctor).
- Windows: parse checks on all touched scripts; structural installer suite + node tests green; pin/unpin/restore roundtrip harness green on pwsh 7.6 (pin dark → marker v2; back to auto → user's line returns, marker v1; final restore → byte-identical config).
- `sync-runtime-assets.mjs --check` passes; macOS/Windows assets byte-identical.

macOS is verified on real hardware; Windows changes are structurally tested only — flagging for a quick manual pass on a real Windows box before release.