### PR TITLE
fix(macos): brace $code to stop unbound-variable crash in menu bar apply alert

### DIFF
--- a/macos/scripts/apply-from-menubar-macos.sh
+++ b/macos/scripts/apply-from-menubar-macos.sh
@@ -122,6 +122,6 @@ if [ "$code" -eq 0 ]; then
 fi
 
 detail="$(/usr/bin/tail -n 5 "$LOG_OUT" 2>/dev/null | /usr/bin/tr '\n' ' ' | /usr/bin/cut -c1-350)"
-alert "应用失败（$code）。$detail"
+alert "应用失败（${code}）。$detail"
 progress "应用失败"
 exit "$code"

--- a/macos/tests/shell-braced-vars-before-cjk.test.mjs
+++ b/macos/tests/shell-braced-vars-before-cjk.test.mjs
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// A bare $var immediately followed by full-width CJK punctuation (no braces)
+// can make bash misparse the variable name boundary under a UTF-8 locale
+// with `set -u` active, raising "unbound variable" even though the variable
+// is assigned — masking the real error behind a bogus one. Reproduced with
+// the real common-macos.sh under LANG=en_US.UTF-8: `$code）` crashes,
+// `${code}）` does not (#251). Require braces whenever a bare $var expansion
+// directly abuts CJK punctuation.
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const scriptDirs = ["scripts", "menubar"];
+const cjkPunctuation = "）。，：；！？」』】";
+const bareVarBeforeCjk = new RegExp(`\\$[A-Za-z_][A-Za-z0-9_]*[${cjkPunctuation}]`, "g");
+
+const listShFiles = (dir) => {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...listShFiles(path));
+    else if (entry.name.endsWith(".sh")) files.push(path);
+  }
+  return files;
+};
+
+const files = scriptDirs.flatMap((dir) => listShFiles(join(root, dir)));
+assert.ok(files.length > 0, "expected to find at least one shell script to scan");
+
+for (const file of files) {
+  test(`no bare $var immediately before CJK punctuation in ${file.slice(root.length + 1)}`, () => {
+    const source = readFileSync(file, "utf8");
+    const findings = [...source.matchAll(bareVarBeforeCjk)].map((match) => match[0]);
+    assert.deepEqual(findings, [], `bare $var before CJK punctuation found in ${file}`);
+  });
+}


### PR DESCRIPTION
## What changed

`apply-from-menubar-macos.sh` sources `common-macos.sh`'s `set -euo pipefail`, which leaves `-u` (nounset) active even after the script's own later `set +e`. The failure-path alert referenced a bare `$code` immediately followed by a full-width right parenthesis (`$code）`, no braces). Under a UTF-8 locale, bash misparses that as a different, never-assigned identifier and aborts with "unbound variable" instead of showing the real failure — even though `code=$?` had assigned it correctly a few lines earlier.

- `macos/scripts/apply-from-menubar-macos.sh`: brace it — `${code}）`.
- `macos/tests/shell-braced-vars-before-cjk.test.mjs`: new repo-wide static regression test (mirrors the existing no-nested-`:has()` CSS guard) that fails on any bare `$var` immediately followed by CJK punctuation in a shell script.

## Why

Fixes #251. This bug fires on *every* failure of `start-dream-skin-macos.sh --restart-existing` triggered from the menu bar, for any underlying reason — it was masking the real error behind a bogus "unbound variable" crash instead of showing the user what actually went wrong.

## Validation

- Reproduced against the real `common-macos.sh` under `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8`: bare `$code）` crashes, `${code}）` does not.
- New static test passes across all 26 shell scripts in `macos/scripts` + `macos/menubar`.
- Full macOS + Windows JS test suites pass on Node 22 (58/58), matching CI's Node version.
- `bash -n` syntax check passes.