### PR TITLE
fix(macos): treat CDP -32000 as unsupported native-window check (#256)

### DIFF
--- a/macos/scripts/injector.mjs
+++ b/macos/scripts/injector.mjs
@@ -196,15 +196,29 @@ export function classifyNativeWindowError(error) {
   const message = error instanceof Error ? error.message : String(error ?? "");
   const cdpCode = Number(error?.cdpCode);
   const withoutCode = message.replace(/\s*\(-?\d+\)\s*$/, "").trim();
-  const unsupported = cdpCode === -32601
+  const domainUnsupported = cdpCode === -32601
     || /\(-32601\)\s*$/.test(message)
     || /^method(?: ['"]Browser\.getWindowForTarget['"])? not found$/i.test(withoutCode)
     || /^['"]?Browser\.getWindowForTarget['"]? (?:wasn't|was not) found$/i.test(withoutCode);
+  // Codex 26.721.x (Chrome/150) returns "Browser window not found" (-32000)
+  // for the app's real, focused, on-screen window -- verified live via CDP:
+  // the error stays identical before and after actually activating the
+  // window, while documentVisibility correctly flips hidden -> visible. The
+  // domain is implemented but this build never resolves a window for our
+  // target, so -32000 is exactly as uninformative here as -32601 elsewhere;
+  // treat it the same way and lean on documentVisible (still required by
+  // windowPass) as the real visibility signal. See #256.
+  const windowNotFound = cdpCode === -32000
+    || /\(-32000\)\s*$/.test(message)
+    || /^browser window not found$/i.test(withoutCode);
+  const unsupported = domainUnsupported || windowNotFound;
   return {
     status: unsupported ? "unsupported" : "not-ready",
     windowId: null,
     bounds: null,
-    reason: unsupported ? "browser-window-domain-unsupported" : "native-window-unavailable",
+    reason: domainUnsupported ? "browser-window-domain-unsupported"
+      : windowNotFound ? "browser-window-not-found"
+      : "native-window-unavailable",
   };
 }
 

--- a/macos/tests/window-readiness.test.mjs
+++ b/macos/tests/window-readiness.test.mjs
@@ -84,12 +84,26 @@ assert.equal(
   "A hidden renderer must not verify even when CDP still reports window bounds.",
 );
 
-const windowMissing = classifyNativeWindowError(new Error("window not found (-32000)"));
-assert.equal(windowMissing.status, "not-ready");
-assert.equal(assessRendererVerification(baseRenderer, windowMissing, exactPayload).pass, false);
+// Codex 26.721.x (Chrome/150) returns -32000 "Browser window not found" for
+// the app's real, focused, on-screen window (confirmed live via CDP: the
+// error is identical before and after actually activating the window, while
+// documentVisibility correctly flips hidden -> visible). -32000 is treated
+// like the unsupported-domain case: fall back to documentVisible, which
+// stays a hard requirement below. See #256.
+const windowNotFound = classifyNativeWindowError(new Error("window not found (-32000)"));
+assert.equal(windowNotFound.status, "unsupported");
+assert.equal(assessRendererVerification(baseRenderer, windowNotFound, exactPayload).pass, true);
 assert.equal(
   classifyNativeWindowError(new Error("Method target window not found (-32000)")).status,
-  "not-ready",
+  "unsupported",
+);
+const windowNotFoundByCode = new Error("Browser window not found");
+windowNotFoundByCode.cdpCode = -32000;
+assert.equal(classifyNativeWindowError(windowNotFoundByCode).status, "unsupported");
+assert.equal(
+  assessRendererVerification(hiddenRenderer, windowNotFound, exactPayload).pass,
+  false,
+  "Even when Browser.getWindowForTarget is unusable (-32000), a hidden document must still fail verification.",
 );
 
 const unsupported = classifyNativeWindowError(new Error("'Browser.getWindowForTarget' wasn't found (-32601)"));


### PR DESCRIPTION
## What broke

Codex 26.721.x (Chrome/150) apply/verify cycles fail permanently with
`Injection verification failed` / `Initial theme verification failed`,
even though the theme injects correctly and every DOM/payload check
passes. Reported in #256.

## Root cause

Confirmed live against a real Codex 26.721.41059 session (macOS,
port 9341): `Browser.getWindowForTarget` returns `-32000 "Browser
window not found"` for the app's actual, focused, on-screen window.

`classifyNativeWindowError` only treats `-32601` (method not found) as
a benign "domain unsupported" signal and falls back to
`documentVisible`. Any other error — including this `-32000` — is
classified `not-ready`, which hard-fails `windowPass` and therefore
`pass`, forever, on this build.

This is not a flaky/transient signal: I toggled the window between
hidden and focused with `osascript ... activate` and re-verified.
`documentVisibility` correctly flipped `hidden` -> `visible` each time;
`Browser.getWindowForTarget` kept returning the identical `-32000`
regardless. So on this Chromium build the call is simply non-functional
for our target — exactly as uninformative as `-32601` elsewhere, just
with a different error shape.

## Fix

Extend the existing unsupported-domain fallback to also cover `-32000`
(by cdp code or message text/suffix), with its own `reason` value for
diagnostics. `documentVisible` remains a hard requirement in
`windowPass`, so this doesn't weaken the actual visibility check that
`#248` introduced — it only stops trusting a second signal that's
demonstrably non-functional on this runtime.

## Verification

- Live-patched the deployed engine on a machine actually running Codex
  26.721.41059 and re-ran `injector.mjs --verify`: `pass` went from
  `false` (`windowPass: false`, `nativeWindow.status: "not-ready"`) to
  `true` (`windowPass: true` via `fallbackWindowPass`,
  `nativeWindow.status: "unsupported"`, `reason:
  "browser-window-not-found"`).
- Updated `macos/tests/window-readiness.test.mjs`: the two existing
  `-32000` cases now assert `"unsupported"` or `pass: true` on
  `baseRenderer`, plus a new assertion that a genuinely hidden document
  still fails even when the native-window check is unsupported via
  `-32000` (the safety net `#248` cared about is unchanged).
- `bash macos/tests/run-tests.sh`: full suite green.

Fixes the verification-failure half of #256 (the unbound-variable
crash half was already fixed by #251/#254).