### PR TITLE
Fix community apply cancelling every time due to a focus race

### DIFF
--- a/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
+++ b/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
@@ -813,6 +813,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       )
       return
     }
+    reactivateCodexBeforeTransaction()
     updateCommunityStage("正在保存当前主题、应用新主题并验证渲染…")
     ScriptRunner.run(
       script: transactionScript,
@@ -1281,6 +1282,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
   private func activateForUserInteraction() {
     NSApp.activate(ignoringOtherApps: true)
+  }
+
+  /// DreamSkin is an LSUIElement with no Dock icon or regular window, so
+  /// macOS does not automatically return focus to Codex once this app's own
+  /// alert closes. Without this, `document.visibilityState` in the Codex
+  /// renderer stays "hidden" for the confirm dialog's caller, so the
+  /// rollback-snapshot verification in captureActiveThemeThenApplyImported
+  /// spuriously fails and cancels every community apply even though the
+  /// visible theme content is correct.
+  private func reactivateCodexBeforeTransaction() {
+    NSRunningApplication.runningApplications(withBundleIdentifier: "com.openai.codex")
+      .first?.activate(options: [.activateIgnoringOtherApps])
   }
 
   private func showInfo(title: String, message: String) {


### PR DESCRIPTION
## Summary
- One-click community apply (`dreamskin://apply?version=...`) was reliably cancelling before switching themes, every single time, with: "The rollback snapshot does not exactly match the current visible renderer; community apply was cancelled before switching themes."
- Root cause: DreamSkin is an `LSUIElement` (menu-bar only, no Dock icon, no regular window). Once its own confirmation `NSAlert` closes, macOS never automatically hands keyboard/window focus back to Codex. `document.visibilityState` in the Codex renderer then stays `"hidden"` for the entire life of `captureActiveThemeThenApplyImported`'s rollback-snapshot verification (12s timeout, ~24 retries at 500ms), so it spuriously fails and safely cancels — even though the actual theme content is completely correct.
- Fix: reactivate Codex (`NSRunningApplication.activate`) immediately before starting the rollback-protected transaction script, mirroring the existing `activateForUserInteraction()` pattern already used to bring DreamSkin's own alerts to front.

## Evidence
Reproduced live end-to-end against production (real upload → admin approval → real `dreamskin://` deep link → real v1.5.4 client) 5 times in a row, always failing identically. Confirmed root cause by manually re-running `injector.mjs --verify` against the *exact preserved* rollback snapshot from a failed attempt (`recovery/community-2132c229-.../active-before`) — it passed instantly once Codex was manually reactivated first, proving the snapshot/theme content was never the actual problem.

## Test plan
- [ ] CI (`swift test --package-path macos/menubar-app`) — this machine only has Xcode Command Line Tools (Swift 5.10), not a full Xcode with the Swift 6.0.3 SDK this package requires, so I could not build locally. Relying on macOS CI runner.
- [ ] Re-run the same live end-to-end deep-link test against a build containing this fix to confirm the switch actually completes.