### PR TITLE
修复 payload 注入、Windows 换肤失效、日志隐私泄露与回归防线缺口

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,24 @@ jobs:
             printf 'The macOS runtime must parse state without python3 or eval.\n' >&2
             exit 1
           fi
+          if grep -n -E 'target\.(title|url)' \
+            macos/scripts/injector.mjs windows/scripts/injector.mjs >/dev/null; then
+            printf 'Injector logs and results must not record page titles or URLs; keep only target IDs and structural markers.\n' >&2
+            exit 1
+          fi
+          if grep -n -E '(document\.title|location\.href)' \
+            macos/scripts/injector.mjs windows/scripts/injector.mjs >/dev/null; then
+            printf 'Injector renderer probes must not read the page title or URL back to the host.\n' >&2
+            exit 1
+          fi
+          for injector in macos/scripts/injector.mjs; do
+            if grep -n -E '\.replace\("__DREAM_SKIN_[A-Z0-9_]+_JSON__", [^(]' \
+              "$injector" >/dev/null; then
+              printf '%s: payload placeholders must use function replacements so a theme name containing $ cannot corrupt the payload.\n' \
+                "$injector" >&2
+              exit 1
+            fi
+          done
 
       - name: Check version consistency
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
             printf 'Injector renderer probes must not read the page title or URL back to the host.\n' >&2
             exit 1
           fi
-          for injector in macos/scripts/injector.mjs; do
+          for injector in macos/scripts/injector.mjs windows/scripts/injector.mjs; do
             if grep -n -E '\.replace\("__DREAM_SKIN_[A-Z0-9_]+_JSON__", [^(]' \
               "$injector" >/dev/null; then
               printf '%s: payload placeholders must use function replacements so a theme name containing $ cannot corrupt the payload.\n' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,14 @@
 name: Release
 
+# This workflow deliberately does NOT gate on `workflow_run: [CI]`.  The guard
+# job below decides whether a main push is a real version bump by diffing
+# macos/VERSION against `github.event.before`, and a `workflow_run` payload
+# carries no `before` field.  Chaining CI would therefore disable the gate that
+# AGENTS.md requires against rebuilding or overwriting a Release when the
+# version did not change, and would break the idempotent `workflow_dispatch`
+# retry of a single tag.  The checks CI performs are instead repeated by the
+# `regressions` job below, run against the exact release commit rather than
+# whatever CI last happened to observe.
 on:
   push:
     branches:
@@ -164,9 +173,98 @@ jobs:
             echo "should_release=$should_release"
           } >> "$GITHUB_OUTPUT"
 
+  regressions:
+    name: Portable release regressions
+    needs: guard
+    if: needs.guard.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release candidate
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.guard.outputs.release_sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js for portable regressions
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Check shell syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r file; do
+            bash -n "$file"
+          done < <(
+            find macos -type f \( -name '*.sh' -o -name '*.command' \) \
+              ! -path '*/release/*' -print
+          )
+
+      - name: Check Node.js syntax on both platforms
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r file; do
+            node --check "$file" >/dev/null
+          done < <(
+            find macos windows -type f \( -name '*.mjs' -o -name '*.js' \) -print
+          )
+
+      # macos/tests/run-tests.sh already re-checks the macOS runtime assertions
+      # (legacy identifiers, app.asar mutation, python3/eval), so only the
+      # Windows execution-policy boundary is repeated here: the PowerShell
+      # suites assert it on named files, not across the whole tree.
+      - name: Check Windows execution-policy boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -R -n --include='*.ps1' --include='*.iss' \
+            -F -- '-ExecutionPolicy Bypass' windows/scripts windows/installer >/dev/null; then
+            printf 'Windows runtime or installer code bypasses the PowerShell execution policy.\n' >&2
+            exit 1
+          fi
+
+      - name: Check Windows PowerShell source encoding
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          function visit(directory) {
+            for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+              const file = path.join(directory, entry.name);
+              if (entry.isDirectory()) visit(file);
+              if (!entry.isFile() || path.extname(file) !== ".ps1") continue;
+              const bytes = fs.readFileSync(file);
+              const hasBom = bytes.subarray(0, 3).equals(Buffer.from([0xef, 0xbb, 0xbf]));
+              const content = hasBom ? bytes.subarray(3) : bytes;
+              if (content.some((byte) => byte >= 0x80) && !hasBom) {
+                throw new Error(`${file}: non-ASCII PowerShell 5.1 source requires a UTF-8 BOM`);
+              }
+            }
+          }
+
+          visit("windows");
+          NODE
+
+      # The platform runners execute run-tests.sh / run-tests.ps1, which only
+      # reference a subset of the *.test.mjs suites by name.  These globs are
+      # the only thing that reaches every portable regression, so they must run
+      # against the release commit before its tag exists.
+      - name: Run portable Node.js regressions
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --test macos/tests/*.test.mjs
+          node --test windows/tests/*.test.mjs
+          node macos/scripts/injector.mjs --check-payload >/dev/null
+          node windows/scripts/injector.mjs --check-payload >/dev/null
+
   create-tag:
     name: Create release tag
-    needs: guard
+    needs: [guard, regressions]
     if: needs.guard.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -283,12 +381,17 @@ jobs:
         env:
           VERSION: ${{ needs.guard.outputs.version }}
         run: |
-          & powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
-            -File .\windows\tests\run-tests.ps1
-          if ($LASTEXITCODE -ne 0) { throw "Windows regressions failed with exit code $LASTEXITCODE." }
-          & powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
-            -File .\windows\tests\installer-static.tests.ps1
-          if ($LASTEXITCODE -ne 0) { throw "Installer static checks failed with exit code $LASTEXITCODE." }
+          # Users run the shipped scripts under whichever shell their machine
+          # has, so both hosts must pass before the artifact is built.  Only
+          # Windows PowerShell 5.1 was exercised here previously.
+          foreach ($shell in @('powershell.exe', 'pwsh.exe')) {
+            & $shell -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
+              -File .\windows\tests\run-tests.ps1
+            if ($LASTEXITCODE -ne 0) { throw "Windows regressions failed under $shell with exit code $LASTEXITCODE." }
+            & $shell -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
+              -File .\windows\tests\installer-static.tests.ps1
+            if ($LASTEXITCODE -ne 0) { throw "Installer static checks failed under $shell with exit code $LASTEXITCODE." }
+          }
           $output = Join-Path $env:RUNNER_TEMP 'codex-dream-skin-release'
           New-Item -ItemType Directory -Path $output -Force | Out-Null
           & powershell.exe -NoProfile -ExecutionPolicy RemoteSigned `

--- a/macos/scripts/build-dmg.sh
+++ b/macos/scripts/build-dmg.sh
@@ -62,6 +62,17 @@ MOUNTED_APP="$MOUNT/Codex Dream Skin.app"
 [ -f "$MOUNTED_APP/Contents/Resources/LICENSE.txt" ] \
   && [ -f "$MOUNTED_APP/Contents/Resources/NOTICE.md" ] \
   || { printf 'Mounted app is missing license notices.\n' >&2; exit 1; }
+# The shipped DMG is the only artifact users ever see, so the icon contract is
+# verified here as well as at generation time: a trap that swallowed the icon
+# builder's exit code once shipped an iconless DMG (#220).
+MOUNTED_ICON_NAME="$(/usr/bin/plutil -extract CFBundleIconFile raw -o - \
+  "$MOUNTED_APP/Contents/Info.plist" 2>/dev/null)" \
+  || { printf 'Mounted app does not declare CFBundleIconFile.\n' >&2; exit 1; }
+[ -n "$MOUNTED_ICON_NAME" ] \
+  || { printf 'Mounted app declares an empty CFBundleIconFile.\n' >&2; exit 1; }
+MOUNTED_ICON="$MOUNTED_APP/Contents/Resources/${MOUNTED_ICON_NAME%.icns}.icns"
+[ -s "$MOUNTED_ICON" ] \
+  || { printf 'Mounted app icon is missing or empty: %s\n' "$MOUNTED_ICON" >&2; exit 1; }
 [ -f "$MOUNTED_APP/Contents/Resources/engine/presets/preset-gothic-void-crusade/theme.json" ] \
   || { printf 'Mounted app is missing the public release preset.\n' >&2; exit 1; }
 [ ! -e "$MOUNTED_APP/Contents/Resources/engine/presets/preset-arina-hashimoto" ] \

--- a/macos/scripts/injector.mjs
+++ b/macos/scripts/injector.mjs
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+import { Script } from "node:vm";
 import { readImageMetadata } from "./image-metadata.mjs";
 import {
   normalizeThemeColor,
@@ -505,8 +506,6 @@ async function probeSession(session) {
     const settings = Boolean(document.querySelector(${selectorLiteral("appearance-radio")})) ||
       Boolean(document.querySelector(${stableTestidLiteral("theme-preview")}));
     return {
-      title: document.title,
-      href: location.href,
       markers,
       codex: location.protocol === 'app:' &&
         ((markers.shell && markers.sidebar) || settings || markers.main),
@@ -770,7 +769,7 @@ function invalidateStaticPayloadAssets() {
   staticPayloadAssets = null;
 }
 
-async function loadPayload(themeDir) {
+export async function loadPayload(themeDir) {
   const startedAt = performance.now();
   const [staticAssets, loaded] = await Promise.all([
     loadStaticPayloadAssets(),
@@ -797,13 +796,18 @@ async function loadPayload(themeDir) {
     .update(JSON.stringify(theme))
     .digest("hex")
     .slice(0, 20);
+  // Every replacement value must be supplied as a function. A plain string
+  // replacement would still interpret `$$`, `$&`, `` $` `` and `$'` inside the
+  // JSON, so a theme name that legitimately contains `$` could silently corrupt
+  // or truncate the payload. Function replacements are inserted verbatim.
   const payload = template
-    .replace("__DREAM_SKIN_CSS_JSON__", JSON.stringify(combinedCss))
-    .replace("__DREAM_SKIN_ART_JSON__", JSON.stringify(artDataUrl))
-    .replace("__DREAM_SKIN_THEME_JSON__", JSON.stringify(theme))
-    .replace("__DREAM_SKIN_VERSION_JSON__", JSON.stringify(SKIN_VERSION))
-    .replace("__DREAM_SKIN_STYLE_REVISION_JSON__", JSON.stringify(styleRevision))
-    .replace("__DREAM_SKIN_PAYLOAD_REVISION_JSON__", JSON.stringify(revision));
+    .replace("__DREAM_SKIN_CSS_JSON__", () => JSON.stringify(combinedCss))
+    .replace("__DREAM_SKIN_ART_JSON__", () => JSON.stringify(artDataUrl))
+    .replace("__DREAM_SKIN_THEME_JSON__", () => JSON.stringify(theme))
+    .replace("__DREAM_SKIN_VERSION_JSON__", () => JSON.stringify(SKIN_VERSION))
+    .replace("__DREAM_SKIN_STYLE_REVISION_JSON__", () => JSON.stringify(styleRevision))
+    .replace("__DREAM_SKIN_PAYLOAD_REVISION_JSON__", () => JSON.stringify(revision));
+  assertPayloadIntegrity(payload);
   return {
     imageBytes: art.length,
     payload,
@@ -815,6 +819,27 @@ async function loadPayload(themeDir) {
       staticCacheHit: staticAssets.cacheHit,
     },
   };
+}
+
+// Fail closed before a payload can reach the renderer. Theme display fields are
+// attacker-influenced text, so template substitution is verified structurally
+// instead of trusting any single sanitiser:
+//   1. no placeholder token may survive substitution;
+//   2. the payload must still parse as the standalone expression that
+//      Runtime.evaluate would receive.
+// The second assertion is deliberately generic: it catches any corruption of
+// the template, not only the `$` replacement patterns that motivated it.
+// `new Script` compiles without running the payload, so nothing executes here.
+export function assertPayloadIntegrity(payload) {
+  if (/__DREAM_SKIN_[A-Z0-9_]+_JSON__/.test(payload)) {
+    throw new Error("Payload placeholders were not fully replaced");
+  }
+  try {
+    new Script(payload, { filename: "dream-skin-payload.js" });
+  } catch (error) {
+    throw new Error(`Payload is not a parsable renderer script: ${error.message}`);
+  }
+  return true;
 }
 
 async function applyToSession(session, payload) {
@@ -1289,7 +1314,7 @@ async function runOneShot(options) {
           loaded?.theme.id ?? null,
           loaded?.revision ?? null,
         );
-      results.push({ targetId: target.id, title: target.title, url: target.url, probe, result });
+      results.push({ targetId: target.id, markers: probe?.markers, result });
       if (operationToken) {
         const passed = options.mode === "remove" ? result === true : result?.pass;
         await presentOperationUi(
@@ -1320,9 +1345,7 @@ async function runOneShot(options) {
       }
       results.push({
         targetId: target.id,
-        title: target.title,
-        url: target.url,
-        probe,
+        markers: probe?.markers,
         error: error.message,
         result: null,
       });
@@ -1974,7 +1997,7 @@ async function runWatch(options) {
               session, record.operationToken, "success", `已应用「${current.theme.name}」`,
             );
           }
-          console.log(`[dream-skin] injected verified ChatGPT target ${target.id} (${target.title || target.url})`);
+          console.log(`[dream-skin] injected verified ChatGPT target ${target.id}`);
         } catch (error) {
           const recoveryStillCurrent = recoveryOperation && !activeOperation
             && pauseRecovery?.token === recoveryOperation.token;
@@ -2036,9 +2059,14 @@ if (path.resolve(process.argv[1] || "") === path.resolve(scriptPath)) {
     const options = parseArgs(process.argv.slice(2));
     if (options.mode === "check") {
       const loaded = await loadPayload(options.themeDir);
+      // loadPayload already fails closed, but every installer, importer and
+      // theme switch gates on this command, so the guard is re-asserted at the
+      // CLI boundary rather than being an internal implementation detail.
+      assertPayloadIntegrity(loaded.payload);
       console.log(JSON.stringify({
         pass: true,
         version: SKIN_VERSION,
+        payloadIntegrity: "verified",
         themeId: loaded.theme.id,
         themeName: loaded.theme.name,
         imageBytes: loaded.imageBytes,

--- a/macos/tests/bounded-community-http.test.mjs
+++ b/macos/tests/bounded-community-http.test.mjs
@@ -22,6 +22,7 @@ function sdkPath() {
   if (existsSync(known)) return known;
   return execFileSync("/usr/bin/xcrun", ["--sdk", "macosx", "--show-sdk-path"], {
     encoding: "utf8",
+    timeout: 60_000,
   }).trim();
 }
 
@@ -79,13 +80,15 @@ test("bounded community HTTP client", {
   const binary = path.join(temporary, "bounded-community-http-test");
   try {
     const arch = process.arch === "arm64" ? "arm64" : "x86_64";
+    // No timeout here means a contended CI runner can hang the whole suite
+    // instead of failing it, and this test now gates tag creation.
     execFileSync("/usr/bin/swiftc", [
       "-sdk", sdkPath(),
       "-target", `${arch}-apple-macosx13.0`,
       source,
       harness,
       "-o", binary,
-    ], { stdio: "pipe" });
+    ], { stdio: "pipe", timeout: 180_000 });
     await new Promise((resolve, reject) => {
       server.once("error", reject);
       server.listen(0, "127.0.0.1", resolve);

--- a/macos/tests/payload-template-integrity.test.mjs
+++ b/macos/tests/payload-template-integrity.test.mjs
@@ -1,0 +1,235 @@
+// Regression guard for payload template substitution.
+//
+// `String.prototype.replace` interprets `$$`, `$&`, "$`" and `$'` in a string
+// replacement even when the replacement is not a regular expression result.
+// Theme display fields such as `name` are attacker-influenced text that legally
+// contains `$`, so building the renderer payload with string replacements let a
+// crafted theme corrupt, truncate or silently rewrite the injected script.
+// These tests drive the real `loadPayload` build path — not a reimplementation —
+// and assert that every `$` construct survives byte-for-byte.
+
+import assert from "node:assert/strict";
+import { deflateSync } from "node:zlib";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+import { assertPayloadIntegrity, loadPayload } from "../scripts/injector.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const macosRoot = path.resolve(here, "..");
+const templatePath = path.join(macosRoot, "assets", "renderer-inject.js");
+const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-dream-skin-payload-"));
+
+let crcTable = null;
+function crc32(buffer) {
+  if (!crcTable) {
+    crcTable = new Int32Array(256);
+    for (let n = 0; n < 256; n += 1) {
+      let value = n;
+      for (let bit = 0; bit < 8; bit += 1) {
+        value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+      }
+      crcTable[n] = value;
+    }
+  }
+  let crc = -1;
+  for (const byte of buffer) crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  return (crc ^ -1) >>> 0;
+}
+
+function pngChunk(type, body) {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(body.length);
+  const typed = Buffer.concat([Buffer.from(type, "ascii"), body]);
+  const checksum = Buffer.alloc(4);
+  checksum.writeUInt32BE(crc32(typed));
+  return Buffer.concat([length, typed, checksum]);
+}
+
+// A minimal but genuinely decodable PNG so loadPayload's image metadata and
+// magic-number checks exercise their real code paths.
+function tinyPng(width = 4, height = 4) {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = 2;
+  const scanlines = Buffer.concat(Array.from({ length: height }, () => Buffer.concat([
+    Buffer.from([0]),
+    Buffer.alloc(width * 3, 0x40),
+  ])));
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk("IHDR", header),
+    pngChunk("IDAT", deflateSync(scanlines)),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+let themeSequence = 0;
+async function makeThemeDir(overrides) {
+  themeSequence += 1;
+  const directory = path.join(tempRoot, `theme-${themeSequence}`);
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(path.join(directory, "background.png"), tinyPng());
+  const theme = {
+    schemaVersion: 1,
+    id: `payload-case-${themeSequence}`,
+    name: "Dream Skin",
+    image: "background.png",
+    ...overrides,
+  };
+  await fs.writeFile(path.join(directory, "theme.json"), `${JSON.stringify(theme, null, 2)}\n`, "utf8");
+  return { directory, theme };
+}
+
+// The payload is an IIFE. Injecting a `return` as the first statement of its
+// body recovers exactly the arguments the renderer would have received, without
+// running any renderer logic. If substitution corrupted the payload the values
+// recovered here diverge from the theme on disk.
+function readPayloadArguments(payload) {
+  const marker = "((cssText, artDataUrl, themeConfig) => {";
+  const at = payload.indexOf(marker);
+  assert.notEqual(at, -1, "payload must keep the canonical renderer IIFE signature");
+  const probe = `${payload.slice(0, at + marker.length)}
+return { cssText, artDataUrl, themeConfig };
+${payload.slice(at + marker.length)}`;
+  return vm.runInNewContext(probe, Object.create(null), { timeout: 10_000 });
+}
+
+const dollarConstructs = {
+  "trailing-match ($')": "$'",
+  "preceding-match ($`)": "$`",
+  "whole-match ($&)": "$&",
+  "escaped-dollar ($$)": "$$",
+  "combined ($$$&)": "$$$&",
+  "combined (all four)": "$`$'$&$$",
+  "embedded in prose": "Neon $& Chrome $$ 主题 $' 夜色 $` 版",
+  "leading and trailing": "$$Aurora$&",
+};
+
+test("payload substitution preserves $ constructs in theme display text", async () => {
+  for (const [label, name] of Object.entries(dollarConstructs)) {
+    const { directory, theme } = await makeThemeDir({ name, statusText: name, quote: name });
+    const loaded = await loadPayload(directory);
+
+    assert.equal(
+      loaded.theme.name,
+      name,
+      `${label}: loadTheme must keep the theme name verbatim`,
+    );
+    assert.ok(
+      !/__DREAM_SKIN_[A-Z0-9_]+_JSON__/.test(loaded.payload),
+      `${label}: no placeholder token may survive substitution`,
+    );
+    assert.doesNotThrow(
+      () => new vm.Script(loaded.payload),
+      `${label}: payload must stay parsable`,
+    );
+
+    const captured = readPayloadArguments(loaded.payload);
+    assert.equal(
+      captured.themeConfig.name,
+      name,
+      `${label}: the renderer must observe the exact theme name`,
+    );
+    assert.equal(captured.themeConfig.statusText, name, `${label}: statusText must be verbatim`);
+    assert.equal(captured.themeConfig.quote, name, `${label}: quote must be verbatim`);
+    assert.equal(captured.themeConfig.id, theme.id, `${label}: theme id must be verbatim`);
+    assert.equal(
+      typeof captured.cssText === "string" && captured.cssText.length > 0,
+      true,
+      `${label}: CSS must still be substituted`,
+    );
+    assert.ok(
+      captured.artDataUrl.startsWith("data:image/png;base64,"),
+      `${label}: art data URL must still be substituted`,
+    );
+  }
+});
+
+test("a benign theme name is unaffected by the substitution fix", async () => {
+  const name = "Aurora Terminal 极光";
+  const { directory } = await makeThemeDir({ name });
+  const loaded = await loadPayload(directory);
+  const captured = readPayloadArguments(loaded.payload);
+  assert.equal(captured.themeConfig.name, name);
+  assert.ok(!/__DREAM_SKIN_[A-Z0-9_]+_JSON__/.test(loaded.payload));
+  assert.doesNotThrow(() => new vm.Script(loaded.payload));
+});
+
+test("payload byte length does not drift with $ constructs", async () => {
+  // Corruption showed up as a payload that grew by the whole template or lost
+  // bytes. Identical-length names must produce identical-length payloads.
+  const baseline = await makeThemeDir({ name: "AAAA" });
+  const dollars = await makeThemeDir({ name: "$$$$" });
+  const [baselineLoaded, dollarLoaded] = await Promise.all([
+    loadPayload(baseline.directory),
+    loadPayload(dollars.directory),
+  ]);
+  assert.equal(
+    Buffer.byteLength(dollarLoaded.payload),
+    Buffer.byteLength(baselineLoaded.payload),
+    "a four-character name of dollar signs must not change the payload size",
+  );
+});
+
+test("assertPayloadIntegrity rejects unresolved placeholders and unparsable payloads", async () => {
+  const template = await fs.readFile(templatePath, "utf8");
+  assert.throws(
+    () => assertPayloadIntegrity(template),
+    /placeholders were not fully replaced/,
+    "the raw template still carries placeholder tokens",
+  );
+  assert.throws(
+    () => assertPayloadIntegrity("((a) => { return a; )("),
+    /not a parsable renderer script/,
+    "a syntactically broken payload must fail closed",
+  );
+
+  const { directory } = await makeThemeDir({ name: "Integrity" });
+  const loaded = await loadPayload(directory);
+  assert.equal(assertPayloadIntegrity(loaded.payload), true);
+});
+
+test("assertPayloadIntegrity only parses and never executes the payload", () => {
+  const sentinel = "__dream_skin_payload_integrity_side_effect__";
+  delete globalThis[sentinel];
+  assertPayloadIntegrity(`globalThis[${JSON.stringify(sentinel)}] = true;`);
+  assert.equal(
+    Object.hasOwn(globalThis, sentinel),
+    false,
+    "the integrity guard must compile without running the payload",
+  );
+});
+
+test("the macOS injector builds payloads with function replacements only", async () => {
+  const source = await fs.readFile(path.join(macosRoot, "scripts", "injector.mjs"), "utf8");
+  const callPattern = /\.replace\(\s*"(__DREAM_SKIN_[A-Z0-9_]+_JSON__)"\s*,/g;
+  const seen = [];
+  for (const match of source.matchAll(callPattern)) {
+    const rest = source.slice(match.index + match[0].length).trimStart();
+    seen.push(match[1]);
+    assert.ok(
+      rest.startsWith("() =>"),
+      `${match[1]} must use a function replacement so $ patterns stay literal, saw: ${
+        JSON.stringify(rest.slice(0, 40))
+      }`,
+    );
+  }
+  assert.deepEqual(seen, [
+    "__DREAM_SKIN_CSS_JSON__",
+    "__DREAM_SKIN_ART_JSON__",
+    "__DREAM_SKIN_THEME_JSON__",
+    "__DREAM_SKIN_VERSION_JSON__",
+    "__DREAM_SKIN_STYLE_REVISION_JSON__",
+    "__DREAM_SKIN_PAYLOAD_REVISION_JSON__",
+  ], "all six payload placeholders must still be substituted");
+});
+
+test.after(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -12,6 +12,10 @@ while IFS= read -r file; do /bin/bash -n "$file"; done < <(
 while IFS= read -r file; do "$NODE" --check "$file" >/dev/null; done < <(
   /usr/bin/find "$ROOT/scripts" "$ROOT/assets" "$ROOT/presets" -type f \( -name '*.mjs' -o -name '*.js' \) -print
 )
+# `bash -n` accepts a bare $var abutting full-width CJK punctuation, but the
+# same source aborts at runtime under a UTF-8 locale with `set -u` and masks
+# the real failure behind a bogus "unbound variable" (#251).
+"$NODE" "$ROOT/tests/shell-braced-vars-before-cjk.test.mjs"
 
 if /usr/bin/grep -R -n -E 'dream-skin-skin|DREAM_SKIN_SKIN|1\.0\.0-rc2' \
   "$ROOT/scripts" "$ROOT/assets" >/dev/null; then
@@ -161,6 +165,10 @@ if /usr/bin/grep -E -q 'home-suggestion-list-item|\.dream-skin-home|\.dream-home
   printf 'Canonical CSS still contains retired marker classes or fossil selectors.\n' >&2
   exit 1
 fi
+# Nesting :has() inside :has() makes Chromium drop the whole rule, so the CSS
+# still parses but ships as silently dead styling; v1.3.1 lost the full-window
+# home and every task-route ambient background that way (#221).
+"$NODE" "$ROOT/tests/runtime-css-nested-has.test.mjs"
 
 "$NODE" "$ROOT/scripts/injector.mjs" --check-payload >/dev/null
 "$NODE" "$ROOT/tests/image-metadata.test.mjs"
@@ -1072,5 +1080,5 @@ else
   DOCTOR_RESULT="passed"
 fi
 
-printf 'PASS: syntax, payload, bundled presets, preset seeding, runtime-state safety, custom-theme, config round-trips, HOME recovery, signature, switch-theme signed runtime %s, runtime-state integration %s, and Doctor %s.\n' \
+printf 'PASS: syntax, CJK-adjacent shell expansions, nested :has() CSS, payload, bundled presets, preset seeding, runtime-state safety, custom-theme, config round-trips, HOME recovery, signature, switch-theme signed runtime %s, runtime-state integration %s, and Doctor %s.\n' \
   "$SWITCH_RUNTIME_RESULT" "$RUNTIME_STATE_RESULT" "$DOCTOR_RESULT"

--- a/windows/scripts/injector.mjs
+++ b/windows/scripts/injector.mjs
@@ -300,8 +300,14 @@ class CdpSession {
       if (!waiter) return;
       clearTimeout(waiter.timeout);
       this.pending.delete(message.id);
-      if (message.error) waiter.reject(new Error(`${message.error.message} (${message.error.code})`));
-      else waiter.resolve(message.result);
+      if (message.error) {
+        // Keep the numeric CDP code on the rejection: classifyNativeWindowError
+        // reads it directly instead of re-parsing the human-readable message,
+        // which Codex builds are free to reword at any time.
+        const error = new Error(`${message.error.message} (${message.error.code})`);
+        error.cdpCode = message.error.code;
+        waiter.reject(error);
+      } else waiter.resolve(message.result);
       return;
     }
     for (const listener of this.listeners.get(message.method) ?? []) listener(message.params ?? {});
@@ -619,7 +625,7 @@ export async function loadTheme(themeDir) {
   };
 }
 
-async function loadPayload(themeDir = path.join(root, "assets"), candidateTheme = null) {
+export async function loadPayload(themeDir = path.join(root, "assets"), candidateTheme = null) {
   const loadedTheme = candidateTheme ?? await loadTheme(themeDir);
   const [css, template] = await Promise.all([
     fs.readFile(path.join(root, "assets", "dream-skin.css"), "utf8"),
@@ -640,13 +646,32 @@ async function loadPayload(themeDir = path.join(root, "assets"), candidateTheme 
     .update(JSON.stringify(loadedTheme.theme))
     .digest("hex")
     .slice(0, 20);
+  // Every replacement uses a function so String.prototype.replace never
+  // interprets $$, $&, $` or $' inside the substituted JSON. Theme text is
+  // user-controlled (theme.json legitimately allows "$"), and a literal-string
+  // replacement would splice the template source back into the payload -- a
+  // stray "$`" produced a SyntaxError, while "$&"/"$$" silently corrupted the
+  // theme name.
   const payload = template
-    .replace("__DREAM_SKIN_CSS_JSON__", JSON.stringify(combinedCss))
-    .replace("__DREAM_SKIN_ART_JSON__", JSON.stringify(artDataUrl))
-    .replace("__DREAM_SKIN_THEME_JSON__", JSON.stringify(loadedTheme.theme))
-    .replace("__DREAM_SKIN_VERSION_JSON__", JSON.stringify(SKIN_VERSION))
-    .replace("__DREAM_SKIN_STYLE_REVISION_JSON__", JSON.stringify(styleRevision))
-    .replace("__DREAM_SKIN_PAYLOAD_REVISION_JSON__", JSON.stringify(revision));
+    .replace("__DREAM_SKIN_CSS_JSON__", () => JSON.stringify(combinedCss))
+    .replace("__DREAM_SKIN_ART_JSON__", () => JSON.stringify(artDataUrl))
+    .replace("__DREAM_SKIN_THEME_JSON__", () => JSON.stringify(loadedTheme.theme))
+    .replace("__DREAM_SKIN_VERSION_JSON__", () => JSON.stringify(SKIN_VERSION))
+    .replace("__DREAM_SKIN_STYLE_REVISION_JSON__", () => JSON.stringify(styleRevision))
+    .replace("__DREAM_SKIN_PAYLOAD_REVISION_JSON__", () => JSON.stringify(revision));
+  // Defence in depth for every caller, not just --check-payload: a template
+  // splice leaves an unreplaced placeholder token behind and usually breaks the
+  // syntax outright, so refuse to hand a corrupted script to the renderer.
+  if (/__DREAM_SKIN_[A-Z0-9_]+_JSON__/.test(payload)) {
+    throw new Error("Payload placeholders were not fully replaced");
+  }
+  try {
+    // Compile-only: this parses the payload and discards the result. It never
+    // runs the renderer script here.
+    new Function(payload);
+  } catch (error) {
+    throw new Error(`Payload failed to parse as JavaScript: ${error.message}`);
+  }
   const { imageBytes: _imageBytes, ...themeState } = loadedTheme;
   return { ...themeState, payload, revision };
 }
@@ -712,12 +737,31 @@ async function connectTarget(target, port) {
 }
 
 function unavailableNativeWindow(error) {
-  const detail = String(error?.message ?? "");
+  const message = String(error?.message ?? "");
+  const cdpCode = Number(error?.cdpCode);
+  const withoutCode = message.replace(/\s*\(-?\d+\)\s*$/, "").trim();
+  const domainUnsupported = cdpCode === -32601
+    || /\(-32601\)\s*$/.test(message)
+    || /^method(?: ['"]Browser\.getWindowForTarget['"])? not found$/i.test(withoutCode)
+    || /^['"]?Browser\.getWindowForTarget['"]? (?:wasn't|was not) found$/i.test(withoutCode);
+  // Codex 26.721.x (Chrome/150) answers -32000 "Browser window not found" for
+  // the app's real, focused, on-screen window -- verified live via CDP: the
+  // error is identical before and after actually activating the window, while
+  // documentVisibility correctly flips hidden -> visible. The domain exists but
+  // this build never resolves a window for our target, so -32000 is exactly as
+  // uninformative here as -32601 elsewhere. Treat both the same way and lean on
+  // documentVisible, which stays a hard requirement in windowPass below, as the
+  // real visibility signal. Matches macOS classifyNativeWindowError. See #256.
+  const windowNotFound = cdpCode === -32000
+    || /\(-32000\)\s*$/.test(message)
+    || /^browser window not found$/i.test(withoutCode)
+    || /^no window with given target found$/i.test(withoutCode);
   return {
     pass: false,
     bound: false,
-    reason: /\(-32601\)$/.test(detail)
-      ? "browser-window-api-unavailable"
+    unsupported: domainUnsupported || windowNotFound,
+    reason: domainUnsupported ? "browser-window-api-unavailable"
+      : windowNotFound ? "browser-window-not-found"
       : "target-window-unavailable",
   };
 }
@@ -1166,14 +1210,27 @@ export async function verifySession(
     const documentPass = result.documentVisibility === 'visible' && !result.documentHidden;
     const viewportPass = result.viewport.width >= ${MIN_RENDERER_VIEWPORT_WIDTH} &&
       result.viewport.height >= ${MIN_RENDERER_VIEWPORT_HEIGHT};
-    const windowPass = result.nativeWindow?.pass === true;
+    const nativeWindowPass = result.nativeWindow?.pass === true;
+    // Codex 26.721.x (Chrome/150) cannot resolve a native window for our target
+    // even when that window is real, focused and on-screen (-32000), and older
+    // builds omit the Browser domain outright (-32601). The injector classifies
+    // both as unsupported; in that case fall back to the renderer's own
+    // visibility evidence instead of failing every install. documentPass and
+    // viewportPass below stay hard requirements, so a genuinely hidden or
+    // collapsed window still fails closed. Mirrors the macOS
+    // assessRendererVerification fallbackWindowPass. See #256.
+    const fallbackWindowPass = result.nativeWindow?.unsupported === true;
+    const windowPass = nativeWindowPass || fallbackWindowPass;
     const expectedThemeId = ${JSON.stringify(expectedThemeId)};
     const expectedRevision = ${JSON.stringify(expectedRevision)};
     const payloadPass = (!expectedThemeId || result.themeId === expectedThemeId) &&
       (!expectedRevision || result.revision === expectedRevision);
     result.expectedThemeId = expectedThemeId;
     result.expectedRevision = expectedRevision;
-    result.readiness = { windowPass, documentPass, viewportPass, structurePass };
+    result.readiness = {
+      windowPass, documentPass, viewportPass, structurePass,
+      nativeWindowPass, fallbackWindowPass,
+    };
     result.pass = result.installed && result.version === result.expectedVersion &&
       result.stylePresent && result.businessClassPollution === 0 && windowPass &&
       documentPass && viewportPass && structurePass &&

--- a/windows/tests/injector-window-readiness.test.mjs
+++ b/windows/tests/injector-window-readiness.test.mjs
@@ -148,6 +148,8 @@ test("normal L1 renderer requires and records the exact target window binding", 
     documentPass: true,
     viewportPass: true,
     structurePass: true,
+    nativeWindowPass: true,
+    fallbackWindowPass: false,
   });
   assert.deepEqual(session.calls, [
     { method: "Browser.getWindowForTarget", params: { targetId: "page-main" } },
@@ -187,18 +189,86 @@ test("visible settings and home anchors are the only L0 structure exceptions", a
   assert.equal(noAnchor.result.readiness.structurePass, false);
 });
 
-test("missing or unsupported Browser window APIs fail closed", async () => {
-  const missing = await verify({
+// Regression for #256. The previous version of this test asserted that a
+// -32000 "no window with given target found" reply must fail verification, and
+// went further than macOS by demanding the same for -32601. Codex 26.721.x
+// (Chrome/150) answers -32000 for the app's real, focused, on-screen window --
+// confirmed live over CDP: the error is byte-identical before and after
+// actually activating the window, while documentVisibility correctly flips
+// hidden -> visible. Locking that in meant Windows could never verify on that
+// build, i.e. the assertion protected the bug. Both codes now mean "the Browser
+// window API told us nothing", and the renderer's own visibility evidence
+// decides. The fail-closed part that is real -- a hidden document -- is
+// asserted below and must stay.
+test("uninformative Browser window replies defer to the renderer, hidden documents still fail", async () => {
+  for (const [label, bindingError] of [
+    ["window-not-found", new Error("No window with given target found (-32000)")],
+    ["window-not-found-by-code", Object.assign(new Error("Browser window not found"), { cdpCode: -32000 })],
+    ["domain-unsupported", new Error("'Browser.getWindowForTarget' wasn't found (-32601)")],
+    ["domain-unsupported-by-code", Object.assign(new Error("Protocol method unavailable"), { cdpCode: -32601 })],
+    ["domain-unsupported-prose", new Error("Method not found (-32601)")],
+  ]) {
+    const visible = await verify({ bindingError });
+    assert.equal(visible.result.pass, true,
+      `${label}: a visible, laid-out renderer must still verify when CDP cannot resolve the native window.`);
+    assert.equal(visible.result.nativeWindow.unsupported, true, label);
+    assert.equal(visible.result.nativeWindow.pass, false, label);
+    assert.equal(visible.result.readiness.windowPass, true, label);
+    assert.equal(visible.result.readiness.nativeWindowPass, false, label);
+    assert.equal(visible.result.readiness.fallbackWindowPass, true, label);
+
+    const hidden = await verify({
+      bindingError,
+      dom: makeDomFixture({ visibilityState: "hidden", hidden: true }),
+    });
+    assert.equal(hidden.result.pass, false,
+      `${label}: a hidden document must fail even when the native window check is unusable.`);
+    assert.equal(hidden.result.readiness.documentPass, false, label);
+
+    const tiny = await verify({
+      bindingError,
+      dom: makeDomFixture({ viewportWidth: 319, viewportHeight: 239 }),
+    });
+    assert.equal(tiny.result.pass, false,
+      `${label}: an unreasonable viewport must fail even when the native window check is unusable.`);
+    assert.equal(tiny.result.readiness.viewportPass, false, label);
+
+    const noStructure = await verify({
+      bindingError,
+      dom: makeDomFixture({ shell: null, sidebar: null }),
+    });
+    assert.equal(noStructure.result.pass, false,
+      `${label}: a missing L1 shell must fail even when the native window check is unusable.`);
+    assert.equal(noStructure.result.readiness.structurePass, false, label);
+  }
+});
+
+test("distinguishable window reasons keep their labels", async () => {
+  const notFound = await verify({
     bindingError: new Error("No window with given target found (-32000)"),
   });
-  assert.equal(missing.result.pass, false);
-  assert.equal(missing.result.nativeWindow.reason, "target-window-unavailable");
+  assert.equal(notFound.result.nativeWindow.reason, "browser-window-not-found");
 
   const unsupported = await verify({
     bindingError: new Error("'Browser.getWindowForTarget' wasn't found (-32601)"),
   });
-  assert.equal(unsupported.result.pass, false);
   assert.equal(unsupported.result.nativeWindow.reason, "browser-window-api-unavailable");
+});
+
+test("unrecognized window transport failures still fail closed", async () => {
+  // Anything that is not a "the API cannot answer" signal -- a dropped socket,
+  // a timeout, an unclassified protocol code -- has no fallback and must fail.
+  for (const bindingError of [
+    new Error("CDP socket closed"),
+    new Error("CDP command timed out: Browser.getWindowForTarget"),
+    Object.assign(new Error("Internal error (-32603)"), { cdpCode: -32603 }),
+  ]) {
+    const result = await verify({ bindingError });
+    assert.equal(result.result.pass, false, bindingError.message);
+    assert.equal(result.result.nativeWindow.reason, "target-window-unavailable", bindingError.message);
+    assert.notEqual(result.result.nativeWindow.unsupported, true, bindingError.message);
+    assert.equal(result.result.readiness.windowPass, false, bindingError.message);
+  }
 
   const zeroWindowId = await verify({ windowId: 0 });
   assert.equal(zeroWindowId.result.pass, false);

--- a/windows/tests/payload-template-integrity.test.mjs
+++ b/windows/tests/payload-template-integrity.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { loadPayload } from "../scripts/injector.mjs";
+
+// Regression for the payload template substitution bug.
+//
+// loadPayload() used `template.replace(placeholder, JSON.stringify(value))`.
+// String.prototype.replace interprets `$$`, `$&`, "$`" and `$'` in the
+// replacement even when it is a plain string, so any `$` reaching a
+// substituted value rewrote the payload:
+//
+//   name       parses?  effect on the emitted payload
+//   ---------  -------  ------------------------------------------------
+//   "a$$b"     yes      silently becomes "a$b"
+//   "a$&b"     yes      silently becomes "a__DREAM_SKIN_THEME_JSON__b"
+//   "a$`b"     NO       splices the whole 38 KB template prefix back in
+//   "a$'b"     NO       splices the whole template suffix back in
+//
+// theme.json is user-supplied and normalizeThemeText deliberately allows `$`
+// (it is legitimate text), so this was reachable from any imported theme. The
+// fix passes a replacer function instead, which is never scanned for `$`
+// patterns. These tests drive the real loadPayload build path -- they must not
+// reimplement the substitution.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const assetsDir = path.resolve(here, "../assets");
+const templatePath = path.join(assetsDir, "renderer-inject.js");
+const template = await fs.readFile(templatePath, "utf8");
+
+// A distinctive, long-enough slice of the template. If a `$`-splice pastes the
+// template source back into the payload, this fragment shows up more than once.
+const TEMPLATE_FINGERPRINT = 'const STATE_KEY = "__CODEX_DREAM_SKIN_STATE__";';
+assert.equal(
+  template.split(TEMPLATE_FINGERPRINT).length - 1,
+  1,
+  "The fingerprint must occur exactly once in the template for the splice check to mean anything.",
+);
+
+const PLACEHOLDERS = [
+  "__DREAM_SKIN_CSS_JSON__",
+  "__DREAM_SKIN_ART_JSON__",
+  "__DREAM_SKIN_THEME_JSON__",
+  "__DREAM_SKIN_VERSION_JSON__",
+  "__DREAM_SKIN_STYLE_REVISION_JSON__",
+  "__DREAM_SKIN_PAYLOAD_REVISION_JSON__",
+];
+
+async function buildWith(themeFields) {
+  const themeDir = await fs.mkdtemp(path.join(os.tmpdir(), "dream-skin-payload-"));
+  try {
+    await fs.copyFile(
+      path.join(assetsDir, "dream-reference.jpg"),
+      path.join(themeDir, "dream-reference.jpg"),
+    );
+    await fs.writeFile(
+      path.join(themeDir, "theme.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        id: "payload-integrity-fixture",
+        image: "dream-reference.jpg",
+        appearance: "auto",
+        ...themeFields,
+      }),
+      "utf8",
+    );
+    return await loadPayload(themeDir);
+  } finally {
+    await fs.rm(themeDir, { recursive: true, force: true });
+  }
+}
+
+function assertIntactPayload(payload, label) {
+  // Ordered most-specific first: a template splice also leaves duplicated
+  // placeholders behind, so checking for the splice first reports the cause
+  // rather than the symptom.
+  assert.equal(
+    payload.split(TEMPLATE_FINGERPRINT).length - 1,
+    1,
+    `${label}: the template source was spliced back into the payload.`,
+  );
+  for (const placeholder of PLACEHOLDERS) {
+    assert.ok(
+      !payload.includes(placeholder),
+      `${label}: payload still contains the ${placeholder} placeholder.`,
+    );
+  }
+  // Compile-only parse. This never executes the renderer script.
+  assert.doesNotThrow(
+    () => new Function(payload),
+    `${label}: payload is not parseable JavaScript.`,
+  );
+}
+
+function extractThemeArgument(payload) {
+  // The renderer IIFE ends with (cssJson, artJson, themeJson); the theme object
+  // is the last argument, so read it back from the emitted payload rather than
+  // trusting what we passed in.
+  const tail = payload.slice(payload.lastIndexOf("})("));
+  const start = tail.indexOf('{"');
+  const end = tail.lastIndexOf("}");
+  assert.ok(start > 0 && end > start, "Could not locate the theme argument in the payload.");
+  return JSON.parse(tail.slice(start, end + 1));
+}
+
+const DOLLAR_NAMES = [
+  ["dollar-dollar", "a$$b"],
+  ["dollar-ampersand", "a$&b"],
+  ["dollar-backtick", "a$`b"],
+  ["dollar-apostrophe", "a$'b"],
+  ["dollar-group-refs", "a$1b$<name>c"],
+  ["combined", "N $` $& $$ $' $1 $<x>"],
+  ["leading-and-trailing", "$$$&$`$'"],
+];
+
+test("theme names containing $ substitution patterns cannot corrupt the payload", async () => {
+  for (const [label, name] of DOLLAR_NAMES) {
+    const loaded = await buildWith({ name });
+    assertIntactPayload(loaded.payload, label);
+    assert.equal(loaded.theme.name, name, `${label}: loadTheme must keep the name verbatim.`);
+    assert.equal(
+      extractThemeArgument(loaded.payload).name,
+      name,
+      `${label}: the theme name in the payload must be byte-for-byte identical to theme.json.`,
+    );
+  }
+});
+
+test("$ patterns in every user-visible theme string survive the build", async () => {
+  // theme.name is the shortest path to the bug, but the whole theme object goes
+  // through the same single substitution, so every field shares the hazard.
+  // No leading/trailing whitespace here: normalizeThemeText trims, which would
+  // make the round-trip assertions compare against the wrong expectation.
+  const fields = {
+    name: "name $`",
+    brandSubtitle: "brand $&",
+    tagline: "tagline $$",
+    projectPrefix: "prefix $'",
+    projectLabel: "label $1",
+    statusText: "status $<x>",
+    quote: "quote $` $& $$ $'",
+  };
+  const loaded = await buildWith(fields);
+  assertIntactPayload(loaded.payload, "all-fields");
+  const emitted = extractThemeArgument(loaded.payload);
+  for (const [key, value] of Object.entries(fields)) {
+    assert.equal(loaded.theme[key], value, `loadTheme mangled ${key}.`);
+    assert.equal(emitted[key], value, `The payload mangled ${key}.`);
+  }
+});
+
+test("an ordinary theme name is unaffected by the fix", async () => {
+  const name = "桥本有菜 Dream Skin";
+  const loaded = await buildWith({ name });
+  assertIntactPayload(loaded.payload, "ordinary");
+  assert.equal(extractThemeArgument(loaded.payload).name, name);
+
+  const shipped = await loadPayload();
+  assertIntactPayload(shipped.payload, "shipped-assets");
+  assert.equal(
+    extractThemeArgument(shipped.payload).name,
+    shipped.theme.name,
+    "The shipped theme must round-trip through the payload unchanged.",
+  );
+});
+
+test("the payload build refuses to emit a corrupted script", async () => {
+  // Guard the guard: prove that a payload carrying a leftover placeholder or a
+  // spliced-in template copy would actually be caught, so the checks above are
+  // not vacuous if the substitution regresses. These fixtures reproduce the
+  // pre-fix behaviour by passing JSON.stringify(...) as a literal replacement
+  // string, exactly as loadPayload used to.
+  const fillRest = (source) => source
+    .replace("__DREAM_SKIN_CSS_JSON__", () => '""')
+    .replace("__DREAM_SKIN_ART_JSON__", () => '""')
+    .replace("__DREAM_SKIN_VERSION_JSON__", () => '"0"')
+    .replace("__DREAM_SKIN_STYLE_REVISION_JSON__", () => '"0"')
+    .replace("__DREAM_SKIN_PAYLOAD_REVISION_JSON__", () => '"0"');
+
+  const spliced = fillRest(
+    template.replace("__DREAM_SKIN_THEME_JSON__", JSON.stringify({ name: "a$&b" })),
+  );
+  assert.throws(
+    () => assertIntactPayload(spliced, "self-check"),
+    /__DREAM_SKIN_THEME_JSON__ placeholder/,
+    "A $&-corrupted payload must be caught by the placeholder assertion.",
+  );
+
+  const backtick = fillRest(
+    template.replace("__DREAM_SKIN_THEME_JSON__", JSON.stringify({ name: "a$`b" })),
+  );
+  assert.throws(
+    () => assertIntactPayload(backtick, "self-check"),
+    /spliced back into the payload/,
+    "A $`-corrupted payload must be caught by the template-splice assertion.",
+  );
+
+  const apostrophe = fillRest(
+    template.replace("__DREAM_SKIN_THEME_JSON__", JSON.stringify({ name: "a$'b" })),
+  );
+  assert.throws(
+    () => assertIntactPayload(apostrophe, "self-check"),
+    /not parseable JavaScript/,
+    "A $'-corrupted payload must be caught by the parse assertion.",
+  );
+});


### PR DESCRIPTION
修复四组已确认缺陷,其中两条可由第三方主题远程触发。全部改动经实测验证,含反重言检查(注入回归确认断言会红)。

## 1. `$` 替换语义污染 payload(双端,可远程触发)

`String.prototype.replace` **即使替换值是字符串也会解释** `$$`、`$&`、`` $` ``、`$'`,而 `theme.name` 完全由导入的 theme.json 控制,`normalizeThemeText` 只查控制字符和长度、放行 `$`。

实测(真实 38 KB 模板):

| theme.name | payload 字节差 | 能解析 |
|---|---|---|
| `` $` `` | **+38755** | 否 SyntaxError |
| `$'` | −4 | 否 SyntaxError |
| `$&` | +19 | **是**(静默污染) |
| `$$` | −5 | **是**(静默污染) |

影响持久:`switch-theme-macos.sh:153` 把 theme.json 作为提交标记先落盘、之后才 apply,所以损坏的主题已经是活动主题,每次启动都读它。

修复:双端各六处改函数形式 `() => JSON.stringify(x)`。另加占位符扫描与解析断言作纵深防御 —— 但注意**两道守卫都拦不住 `$$`,只有函数替换本身能挡**。

未改 `normalizeThemeText` 拒绝 `$`:`$` 在主题名里是合法用户数据,已有社区主题在用。

## 2. Windows 在 Codex 26.721.x 上完全无法换肤

v1.5.4(#256)只修了 macOS。`Browser.getWindowForTarget` 在 Chrome/150 上对真实可见窗口也返回 `-32000`。Windows 只识别 `-32601` 且无 fallback,导致永久 `Injection verification failed`。

```
macOS   classifyNativeWindowError(-32000) → unsupported → fallback → 通过
Windows inspectTargetWindow(-32000)      → pass:false  → 无 fallback → 永久失败
```

**安全红线保住**:`documentPass && viewportPass && structurePass` 仍是独立硬性合取项,只豁免那个本就无信息量的原生窗口信号。

**同时反转了一条锁定 bug 的测试**:`injector-window-readiness.test.mjs:190` 原标题 "fail closed",断言 `-32000` 时 `pass === false`(连 `-32601` 也一并断言 false,比 macOS 更严)。它正在保护错误行为 —— 与 1.3.2 那次"断言锁定坏形态"同构(`macos/CHANGELOG.md:64-65`)。新测试净更严格:锁定 unsupported 语义的同时,断言 documentVisible/viewport/structure 在这些错误码下仍会失败。

## 3. macOS 把用户页面标题和 URL 写进长期日志(隐私)

`injector.mjs:1292/:1323/:1977` 输出 `target.title`/`target.url`,源头是 `probeSession` 的 `document.title`/`location.href`,经 `launchctl submit -o` 落进 `~/Library/Application Support/.../injector.log`。Codex 窗口标题含会话名和项目名。违反 AGENTS.md:73。

Windows 早已修复(`windows/CHANGELOG.md:142`),macOS 未跟进。本次对齐,并加 CI grep 防回归。

## 4. 回归防线三个缺口

- **孤儿测试**:`runtime-css-nested-has` 和 `shell-braced-vars-before-cjk`(#221/#251 的唯一防线)在 `run-tests.sh` 里引用次数为 0,本地跑不到。已接入,每条带注释说明删掉会失去什么。
- **Release 不跑 `node --test` 也不依赖 CI**:新增 `regressions` job 并让 `create-tag: needs: [guard, regressions]` —— 失败在 **tag 创建前**阻断,而非等构建阶段。
  未用 `workflow_run`:guard 依赖 `git show "$BEFORE_SHA:macos/VERSION"`,而该事件无 `before` 字段,挂上去会让"版本未变不得重复发布"的闸门失效(AGENTS.md:61)。理由已写入 release.yml 注释。**guard 逻辑与触发条件零改动。**
- **DMG 缺 icns 断言**:挂载验收查了版本/URL scheme/LICENSE/preset,独缺图标 —— 而 #220 根因正是缺图标的 DMG 照常出包。用退出码分支而非 `|| true`(`plutil` 把错误写 stdout,`|| true` 会把错误文本当图标名)。

## 验证

| 项 | 结果 |
|---|---|
| macOS `node --test` | 53/53 |
| Windows `node --test` | 17/17 |
| 双端 `--check-payload` | pass |
| `sync-runtime-assets --check` | exit 0 |
| shell / node 语法、`git diff --check` | 通过 |

**反重言检查**:注入五种回归(双端退回字符串替换、日志加回 title/url、probe 读 document.title),CI 断言全部正确变红;回退修复后新测试确实失败。

## 未在本地验证

- **全部 PowerShell 测试** — macOS 主机无 pwsh,交 CI
- **`build-dmg.sh` 完整运行** — 需签名环境;断言块已对 5 个 fixture bundle 逐分支执行验证
- **真实 Windows 上的 26.721.x** — `-32000` 修复依据 macOS 真机 CDP 抓包,Windows 侧未实机观察

## 已知遗留

`bounded-community-http.test.mjs` 有 flaky 嫌疑(一次未能复现的失败)。它**不是**端口竞争(`:91` 用 `listen(0)` 由内核分配),真实脆弱点是 `:82` 现场调 `swiftc` 编译 Swift harness。12 轮未复现。它现在位于能阻断发布的路径上,建议单独跟进加超时/重试。
