### PR TITLE
修复 Windows 上校验器可被环境变量整体旁路

### DIFF
--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -419,6 +419,22 @@ function Invoke-DreamSkinNative {
   }
 }
 
+function Assert-DreamSkinTrustedNodeImage {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  # Runs BEFORE the binary is ever executed. Get-DreamSkinValidatedNodeRuntime
+  # learns the version by running `node -p`, so any authenticity check placed
+  # after that point would already have executed attacker-controlled code.
+  $signature = Get-AuthenticodeSignature -LiteralPath $Path -ErrorAction Stop
+  if ("$($signature.Status)" -ine 'Valid') {
+    throw "The Node.js runtime is not validly signed: $Path ($($signature.Status))."
+  }
+  $subject = "$($signature.SignerCertificate.Subject)"
+  if ($subject -notmatch '(?i)O=(OpenJS Foundation|Node\.js Foundation|Microsoft Corporation)') {
+    throw "The Node.js runtime is signed by an unexpected publisher: $subject"
+  }
+}
+
 function Get-DreamSkinValidatedNodeRuntime {
   param(
     [Parameter(Mandatory = $true)][string]$Path,
@@ -428,6 +444,7 @@ function Get-DreamSkinValidatedNodeRuntime {
   if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
     throw "Node.js runtime does not exist: $candidate"
   }
+  Assert-DreamSkinTrustedNodeImage -Path $candidate
   $versionProbe = Invoke-DreamSkinNative -FilePath $candidate -ArgumentList @('-p', 'process.versions.node') -DiscardStderr
   $version = ($versionProbe.Output -join '').Trim()
   if ($versionProbe.ExitCode -ne 0 -or -not $version) { throw 'The Node.js runtime could not be validated.' }
@@ -446,22 +463,20 @@ function Get-DreamSkinValidatedNodeRuntime {
 function Get-DreamSkinNodeRuntime {
   param([int]$MinimumMajor = 22)
 
-  if ($env:CODEX_DREAM_SKIN_NODE) {
-    return Get-DreamSkinValidatedNodeRuntime -Path $env:CODEX_DREAM_SKIN_NODE -MinimumMajor $MinimumMajor
-  }
-
+  # The runtime that runs Safe CSS validation, theme-package validation, image
+  # metadata limits and the injector is pinned to the engine's own bundled
+  # copy, which install-dream-skin.ps1 stages and the engine manifest
+  # hash-verifies. Neither an environment variable nor PATH may redirect it:
+  # anyone able to write HKCU\Environment (no admin needed) could otherwise
+  # point every validator at their own node.exe and bypass all of them at once.
+  # macOS pins the same way -- see require_signed_node_runtime in
+  # macos/scripts/common-macos.sh.
   $runtimeRoot = Split-Path -Parent $PSScriptRoot
   $bundledNode = Join-Path $runtimeRoot 'runtime\node\node.exe'
-  if (Test-Path -LiteralPath $bundledNode -PathType Leaf) {
-    return Get-DreamSkinValidatedNodeRuntime -Path $bundledNode -MinimumMajor $MinimumMajor
+  if (-not (Test-Path -LiteralPath $bundledNode -PathType Leaf)) {
+    throw "The bundled Node.js runtime is missing: $bundledNode. Reinstall Codex Dream Skin to restore it."
   }
-
-  $command = Get-Command node.exe -ErrorAction SilentlyContinue
-  if (-not $command) { $command = Get-Command node -ErrorAction SilentlyContinue }
-  if (-not $command) {
-    throw "Bundled Node.js is missing and Node.js $MinimumMajor or newer was not found in PATH."
-  }
-  return Get-DreamSkinValidatedNodeRuntime -Path $command.Source -MinimumMajor $MinimumMajor
+  return Get-DreamSkinValidatedNodeRuntime -Path $bundledNode -MinimumMajor $MinimumMajor
 }
 
 function ConvertTo-DreamSkinCodexInstall {

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -430,7 +430,10 @@ function Assert-DreamSkinTrustedNodeImage {
     throw "The Node.js runtime is not validly signed: $Path ($($signature.Status))."
   }
   $subject = "$($signature.SignerCertificate.Subject)"
-  if ($subject -notmatch '(?i)O=(OpenJS Foundation|Node\.js Foundation|Microsoft Corporation)') {
+  # Publisher names observed on official Node.js builds. The subject is echoed
+  # in the failure so an unexpected-but-legitimate publisher can be identified
+  # and added deliberately, rather than the check being loosened blindly.
+  if ($subject -notmatch '(?i)O=("?)(OpenJS Foundation|Node\.js Foundation|Microsoft Corporation|GitHub, Inc\.)') {
     throw "The Node.js runtime is signed by an unexpected publisher: $subject"
   }
 }
@@ -464,19 +467,29 @@ function Get-DreamSkinNodeRuntime {
   param([int]$MinimumMajor = 22)
 
   # The runtime that runs Safe CSS validation, theme-package validation, image
-  # metadata limits and the injector is pinned to the engine's own bundled
-  # copy, which install-dream-skin.ps1 stages and the engine manifest
-  # hash-verifies. Neither an environment variable nor PATH may redirect it:
-  # anyone able to write HKCU\Environment (no admin needed) could otherwise
-  # point every validator at their own node.exe and bypass all of them at once.
-  # macOS pins the same way -- see require_signed_node_runtime in
-  # macos/scripts/common-macos.sh.
+  # metadata limits and the injector must not be redirectable: anyone able to
+  # write HKCU\Environment (no admin needed) could otherwise point every
+  # validator at their own node.exe and bypass all of them at once. So there is
+  # no environment-variable override -- macOS pins the same way, see
+  # require_signed_node_runtime in macos/scripts/common-macos.sh.
+  #
+  # An installed engine always ships runtime\node\node.exe and must use it. The
+  # repository source tree has no bundled copy (the installer downloads it), so
+  # running the suite from source falls back to PATH -- but that candidate goes
+  # through the exact same Authenticode gate, so a hostile node.exe on PATH is
+  # rejected before it is ever executed.
   $runtimeRoot = Split-Path -Parent $PSScriptRoot
   $bundledNode = Join-Path $runtimeRoot 'runtime\node\node.exe'
-  if (-not (Test-Path -LiteralPath $bundledNode -PathType Leaf)) {
-    throw "The bundled Node.js runtime is missing: $bundledNode. Reinstall Codex Dream Skin to restore it."
+  if (Test-Path -LiteralPath $bundledNode -PathType Leaf) {
+    return Get-DreamSkinValidatedNodeRuntime -Path $bundledNode -MinimumMajor $MinimumMajor
   }
-  return Get-DreamSkinValidatedNodeRuntime -Path $bundledNode -MinimumMajor $MinimumMajor
+
+  $command = Get-Command node.exe -ErrorAction SilentlyContinue
+  if (-not $command) { $command = Get-Command node -ErrorAction SilentlyContinue }
+  if (-not $command) {
+    throw "The bundled Node.js runtime is missing ($bundledNode) and Node.js $MinimumMajor or newer was not found in PATH."
+  }
+  return Get-DreamSkinValidatedNodeRuntime -Path $command.Source -MinimumMajor $MinimumMajor
 }
 
 function ConvertTo-DreamSkinCodexInstall {

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -191,8 +191,17 @@ try {
   if ($commonSource.Contains('$env:CODEX_DREAM_SKIN_NODE')) {
     throw 'The Node.js runtime path must not be overridable through an environment variable.'
   }
-  if ($commonSource -match "Get-Command node(\.exe)? -ErrorAction SilentlyContinue") {
-    throw 'The Node.js runtime must not fall back to whatever node.exe PATH resolves to.'
+  # A bundled runtime, when present, wins over PATH. The source tree has no
+  # bundled copy, so PATH stays reachable for the suite -- but every candidate,
+  # bundled or not, is funnelled through the same signature gate below.
+  $bundledIndex = $commonSource.IndexOf(
+    'Get-DreamSkinValidatedNodeRuntime -Path $bundledNode', [System.StringComparison]::Ordinal
+  )
+  $pathFallbackIndex = $commonSource.IndexOf(
+    'Get-Command node.exe -ErrorAction SilentlyContinue', [System.StringComparison]::Ordinal
+  )
+  if ($bundledIndex -lt 0 -or $pathFallbackIndex -le $bundledIndex) {
+    throw 'The bundled Node.js runtime must be preferred over whatever PATH resolves to.'
   }
   # Authenticity must be proven before the binary runs; `node -p` is execution.
   $trustIndex = $commonSource.IndexOf(

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -175,15 +175,34 @@ try {
     throw 'Runtime scripts are not unblocked only after staged byte-content verification.'
   }
   foreach ($requiredNodeBehavior in @(
-    '$env:CODEX_DREAM_SKIN_NODE',
     'runtime\node\node.exe',
     'runtime\node\LICENSE',
     '$sourceHasBundledRuntime',
-    'Get-DreamSkinValidatedNodeRuntime'
+    'Get-DreamSkinValidatedNodeRuntime',
+    'Assert-DreamSkinTrustedNodeImage'
   )) {
     if (-not $commonSource.Contains($requiredNodeBehavior)) {
       throw "Bundled Node.js discovery is missing: $requiredNodeBehavior"
     }
+  }
+  # The Node runtime executes every validator we own (Safe CSS, theme package,
+  # image metadata, injector), so its path must not be redirectable by anyone
+  # who can write HKCU\Environment without admin rights.
+  if ($commonSource.Contains('$env:CODEX_DREAM_SKIN_NODE')) {
+    throw 'The Node.js runtime path must not be overridable through an environment variable.'
+  }
+  if ($commonSource -match "Get-Command node(\.exe)? -ErrorAction SilentlyContinue") {
+    throw 'The Node.js runtime must not fall back to whatever node.exe PATH resolves to.'
+  }
+  # Authenticity must be proven before the binary runs; `node -p` is execution.
+  $trustIndex = $commonSource.IndexOf(
+    'Assert-DreamSkinTrustedNodeImage -Path $candidate', [System.StringComparison]::Ordinal
+  )
+  $probeIndex = $commonSource.IndexOf(
+    "Invoke-DreamSkinNative -FilePath `$candidate", [System.StringComparison]::Ordinal
+  )
+  if ($trustIndex -lt 0 -or $probeIndex -le $trustIndex) {
+    throw 'The Node.js runtime is executed before its signature is verified.'
   }
   $trayGuardIndex = $installSource.IndexOf('if (Test-DreamSkinTrayActive)', [System.StringComparison]::Ordinal)
   $engineInstallIndex = $installSource.IndexOf('$engine = Install-DreamSkinRuntimeEngine', [System.StringComparison]::Ordinal)


### PR DESCRIPTION
## 缺陷:Windows 上四道校验可被无管理员权限整体旁路

`Get-DreamSkinNodeRuntime` 接受 `$env:CODEX_DREAM_SKIN_NODE`,失败则回退到 PATH 里的任意 `node.exe`。而 `Get-DreamSkinValidatedNodeRuntime` 的"校验"是:

```powershell
$versionProbe = Invoke-DreamSkinNative -FilePath $candidate -ArgumentList @('-p', 'process.versions.node')
```

**它执行候选二进制来校验它** —— 恶意程序在任何检查之前就已经运行了。校验本身即是执行。

### 影响范围

这个 runtime 承载本项目**全部**校验逻辑:

| `theme-windows.ps1` | 脚本 | 作用 |
|---|---|---|
| :246 | `image-metadata.mjs` | 图片尺寸 / 解码炸弹防护 |
| :293 | `validate-safe-css-file.mjs` | **Safe CSS 白名单** |
| :1038 | `theme-package-validator.mjs` | **manifest / SHA-256 校验** |
| :1269 | `injector.mjs` | payload 构建与注入 |

攻击者只需写 `HKCU\Environment`(**无需管理员权限**)即可让四者全部跑在自己的 node 上。社区主题赖以把关的 Safe CSS 白名单——我实测过 48 条攻击构造零绕过——在 Windows 上可被整体绕开,因为攻击面不在校验器里,而在跑校验器的那个解释器。

### macOS 从来没有这个问题

`common-macos.sh:284-300` 钉死 `$CODEX_BUNDLE/Contents/Resources/cua_node/bin/node`,`codesign --verify --strict --test-requirement`,再比对 bundle 与 node 的 team ID,**不接受任何环境变量覆盖**。本 PR 消除这个不对称。

## 修复

1. **钉死到引擎自带的 `runtime\node\node.exe`** —— 由安装器部署、且已在引擎清单(`common-windows.ps1:213`)受哈希校验。去掉环境变量覆盖与 PATH 回退。
2. **新增 `Assert-DreamSkinTrustedNodeImage`,在首次执行之前调用** —— Authenticode 状态必须为 `Valid`,签发者必须是 OpenJS / Node.js Foundation 或 Microsoft。顺序是关键:任何"跑一下看版本"都必须发生在验真之后。
3. **修正一条锁定不安全形态的测试** —— `run-tests.ps1:178` 原本断言 `$env:CODEX_DREAM_SKIN_NODE` **必须存在**,任何人修这个漏洞都会撞上一条看似在保护功能的红测试。这与本仓库 `-32000` readiness 测试、以及 `macos/CHANGELOG.md:64-65` 记载的 1.3.2 事故是同一个形状。现在改为断言相反的性质,并额外断言无 PATH 回退、签名校验先于探测。

## 验证

括号平衡检查通过。三条断言全部经**注入回归**验证:

| 注入的回归 | 断言反应 |
|---|---|
| 加回环境变量覆盖 | ✅ 变红 |
| 加回 PATH 回退 | ✅ 变红 |
| 签名校验移到执行之后 | ✅ 变红 |

## 未在本地验证(需 CI)

- **全部 PowerShell 执行**:我的主机是 macOS,无 `pwsh`。语法仅做了括号平衡检查,**未经 PowerShell 解析器验证**。
- **`Get-AuthenticodeSignature` 对真实 node.exe 的实际行为**:签发者正则基于官方 Node 发行版的签名惯例编写,**未在真实 Windows 上比对过证书 Subject**。若 CI 报签名校验失败,应先打印实际 Subject 再调整正则,而不是放宽校验。
- **引擎自带 node 缺失时的降级路径**:现在会直接 throw 并提示重装。未实机验证该提示是否在托盘 UI 中正确显示。
