### PR TITLE
把 image-metadata.mjs 纳入 runtime 同步闸门

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,19 @@ windows/presets/preset-gothic-void-crusade/theme.json text eol=lf
 windows/installer/languages/ChineseSimplified.isl text eol=lf
 windows/installer/languages/Inno-Setup-License.txt text eol=lf
 
+# sync-runtime-assets.mjs compares generated content to what is on disk byte
+# for byte, and it emits LF. A CRLF checkout would make --check fail on Windows
+# for files nobody edited, so the shared runtime source and everything compiled
+# from it stay LF on every platform -- sources included, not just outputs.
+runtime/** text eol=lf
+tools/selectors.json text eol=lf
+macos/assets/** text eol=lf
+windows/assets/** text eol=lf
+macos/scripts/image-metadata.mjs text eol=lf
+windows/scripts/image-metadata.mjs text eol=lf
+macos/scripts/validate-safe-css-file.mjs text eol=lf
+windows/scripts/validate-safe-css-file.mjs text eol=lf
+
 # Keep artwork out of text normalization and text diffs.
 *.png binary
 *.jpg binary

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ release/
 runtime/*
 !runtime/
 !runtime/dream-skin.css
+!runtime/image-metadata.mjs
 !runtime/renderer-inject.js
 !runtime/safe-css-policy.json
 !runtime/safe-css-validator.mjs

--- a/runtime/image-metadata.mjs
+++ b/runtime/image-metadata.mjs
@@ -1,0 +1,131 @@
+const SOF_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7,
+  0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
+]);
+export const MAX_IMAGE_DIMENSION = 16384;
+export const MAX_IMAGE_PIXELS = 50_000_000;
+
+function uint16be(bytes, offset) {
+  return bytes[offset] * 256 + bytes[offset + 1];
+}
+
+function uint16le(bytes, offset) {
+  return bytes[offset] + bytes[offset + 1] * 256;
+}
+
+function uint24le(bytes, offset) {
+  return bytes[offset] + bytes[offset + 1] * 256 + bytes[offset + 2] * 65536;
+}
+
+function uint32be(bytes, offset) {
+  return bytes[offset] * 0x1000000 + bytes[offset + 1] * 0x10000 +
+    bytes[offset + 2] * 0x100 + bytes[offset + 3];
+}
+
+function uint32le(bytes, offset) {
+  return bytes[offset] + bytes[offset + 1] * 0x100 + bytes[offset + 2] * 0x10000 +
+    bytes[offset + 3] * 0x1000000;
+}
+
+function ascii(bytes, offset, length) {
+  return String.fromCharCode(...bytes.subarray(offset, offset + length));
+}
+
+function pngDimensions(bytes) {
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (bytes.length < 24 || signature.some((value, index) => bytes[index] !== value) ||
+      uint32be(bytes, 8) !== 13 || ascii(bytes, 12, 4) !== "IHDR") return null;
+  const width = uint32be(bytes, 16);
+  const height = uint32be(bytes, 20);
+  return width > 0 && height > 0 ? { width, height } : null;
+}
+
+function jpegDimensions(bytes) {
+  if (bytes.length < 12 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
+  let offset = 2;
+  while (offset + 9 < bytes.length) {
+    if (bytes[offset] !== 0xff) {
+      offset += 1;
+      continue;
+    }
+    while (offset < bytes.length && bytes[offset] === 0xff) offset += 1;
+    const marker = bytes[offset++];
+    if (marker === 0xd9 || marker === 0xda) break;
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd8)) continue;
+    if (offset + 2 > bytes.length) break;
+    const length = uint16be(bytes, offset);
+    if (length < 2 || offset + length > bytes.length) break;
+    if (SOF_MARKERS.has(marker) && length >= 7) {
+      const height = uint16be(bytes, offset + 3);
+      const width = uint16be(bytes, offset + 5);
+      return width > 0 && height > 0 ? { width, height } : null;
+    }
+    offset += length;
+  }
+  return null;
+}
+
+function webpDimensions(bytes) {
+  if (bytes.length < 20 || ascii(bytes, 0, 4) !== "RIFF" || ascii(bytes, 8, 4) !== "WEBP") {
+    return null;
+  }
+  const riffEnd = Math.min(bytes.length, uint32le(bytes, 4) + 8);
+  let offset = 12;
+  while (offset + 8 <= riffEnd) {
+    const type = ascii(bytes, offset, 4);
+    const size = bytes[offset + 4] + bytes[offset + 5] * 256 +
+      bytes[offset + 6] * 65536 + bytes[offset + 7] * 0x1000000;
+    const data = offset + 8;
+    if (data + size > riffEnd) break;
+    if (type === "VP8X" && size >= 10) {
+      return { width: uint24le(bytes, data + 4) + 1, height: uint24le(bytes, data + 7) + 1 };
+    }
+    if (type === "VP8L" && size >= 5 && bytes[data] === 0x2f) {
+      const width = 1 + bytes[data + 1] + ((bytes[data + 2] & 0x3f) << 8);
+      const height = 1 + (bytes[data + 2] >> 6) + (bytes[data + 3] << 2) +
+        ((bytes[data + 4] & 0x0f) << 10);
+      return { width, height };
+    }
+    if (type === "VP8 " && size >= 10 && bytes[data + 3] === 0x9d &&
+      bytes[data + 4] === 0x01 && bytes[data + 5] === 0x2a) {
+      return {
+        width: uint16le(bytes, data + 6) & 0x3fff,
+        height: uint16le(bytes, data + 8) & 0x3fff,
+      };
+    }
+    offset = data + size + (size % 2);
+  }
+  return null;
+}
+
+export function classifyImageDimensions({ width, height }) {
+  const ratio = width / height;
+  if (
+    !Number.isSafeInteger(width) || !Number.isSafeInteger(height)
+    || width < 1 || height < 1
+    || width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION
+    || width * height > MAX_IMAGE_PIXELS
+    || !Number.isFinite(ratio)
+  ) return null;
+  const aspect = ratio >= 2.25 ? "ultrawide" : ratio >= 1.45 ? "wide"
+    : ratio >= 1.08 ? "landscape" : ratio >= 0.9 ? "square" : "portrait";
+  return {
+    width,
+    height,
+    ratio,
+    wide: ratio >= 1.75,
+    aspect,
+    taskMode: ratio >= 2.25 ? "banner" : "ambient",
+  };
+}
+
+export function readImageMetadata(value, extension = "") {
+  const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
+  const normalized = extension.toLowerCase();
+  let dimensions = null;
+  if (normalized === ".png" || bytes[0] === 0x89) dimensions = pngDimensions(bytes);
+  else if (normalized === ".jpg" || normalized === ".jpeg" ||
+    (bytes[0] === 0xff && bytes[1] === 0xd8)) dimensions = jpegDimensions(bytes);
+  else if (normalized === ".webp" || ascii(bytes, 8, 4) === "WEBP") dimensions = webpDimensions(bytes);
+  return dimensions ? classifyImageDimensions(dimensions) : null;
+}

--- a/tools/sync-runtime-assets.mjs
+++ b/tools/sync-runtime-assets.mjs
@@ -66,6 +66,48 @@ function compileSafeCssFileValidator(source) {
   return source.replace(canonicalImport, 'from "../assets/safe-css-validator.mjs"');
 }
 
+// Both injectors enforce the 16384px / 50MP decode limits through this parser,
+// so the two platform copies must not drift. Windows additionally needs a tiny
+// CLI so theme-windows.ps1 can shell out to it; that entry point is appended
+// here instead of being maintained as a second hand-edited copy of the parser.
+const WINDOWS_IMAGE_METADATA_CLI = `
+// Keep the PowerShell theme store on the same strict parser as the injector.
+// The CLI is intentionally tiny: it only reads a user-selected file and emits
+// validated dimensions; it never writes or follows a caller-provided output.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [mode, imagePath] = process.argv.slice(2);
+  if (mode !== "--check" || !imagePath) {
+    console.error("Usage: image-metadata.mjs --check <image>");
+    process.exitCode = 2;
+  } else {
+    try {
+      const resolved = path.resolve(imagePath);
+      const bytes = await fs.readFile(resolved);
+      const metadata = readImageMetadata(bytes, path.extname(resolved));
+      if (!metadata) throw new Error("Image metadata is invalid or exceeds the 16384px / 50MP safety limit");
+      console.log(JSON.stringify(metadata));
+    } catch (error) {
+      console.error(error?.message ?? String(error));
+      process.exitCode = 2;
+    }
+  }
+}
+`;
+
+function compileWindowsImageMetadata(source) {
+  if (source.includes("process.argv")) {
+    throw new Error("runtime/image-metadata.mjs must stay a pure parser; the CLI is appended at sync time");
+  }
+  const imports = [
+    'import fs from "node:fs/promises";',
+    'import path from "node:path";',
+    'import { fileURLToPath } from "node:url";',
+    "",
+    "",
+  ].join("\n");
+  return `${imports}${source.trimEnd()}\n${WINDOWS_IMAGE_METADATA_CLI}`;
+}
+
 const sourceCss = await fs.readFile(path.join(projectRoot, "runtime", "dream-skin.css"), "utf8");
 const sourceRuntime = await fs.readFile(path.join(projectRoot, "runtime", "renderer-inject.js"), "utf8");
 const sourceThemePackageValidator = await fs.readFile(
@@ -82,6 +124,10 @@ const sourceSafeCssPolicy = await fs.readFile(
 );
 const sourceSafeCssFileValidator = await fs.readFile(
   path.join(projectRoot, "runtime", "validate-safe-css-file.mjs"),
+  "utf8",
+);
+const sourceImageMetadata = await fs.readFile(
+  path.join(projectRoot, "runtime", "image-metadata.mjs"),
   "utf8",
 );
 const outputs = [
@@ -127,6 +173,14 @@ const outputs = [
       "macos/scripts/validate-safe-css-file.mjs",
       "windows/scripts/validate-safe-css-file.mjs",
     ],
+  },
+  {
+    content: sourceImageMetadata,
+    paths: ["macos/scripts/image-metadata.mjs"],
+  },
+  {
+    content: compileWindowsImageMetadata(sourceImageMetadata),
+    paths: ["windows/scripts/image-metadata.mjs"],
   },
 ];
 

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -1331,7 +1331,12 @@ try {
   $projectRoot = Split-Path -Parent $Root
   $syncToolPath = Join-Path $projectRoot 'tools\sync-runtime-assets.mjs'
   $syncToolResult = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @($syncToolPath, '--check')
-  if ($syncToolResult.ExitCode -ne 0) { throw "Runtime contract tool failed: $syncToolPath" }
+  if ($syncToolResult.ExitCode -ne 0) {
+    # The tool names each stale file on stdout; without this the failure is
+    # indistinguishable from the tool not running at all.
+    $syncDetail = ($syncToolResult.Output -join "`n").Trim()
+    throw "Runtime contract tool failed: $syncToolPath`n$syncDetail"
+  }
   $doctorToolPath = Join-Path $projectRoot 'tools\doctor-selectors.test.mjs'
   $doctorToolResult = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @($doctorToolPath)
   if ($doctorToolResult.ExitCode -ne 0) { throw "Runtime contract tool failed: $doctorToolPath" }


### PR DESCRIPTION
## 问题

双端 injector 都靠这个解析器执行 `AGENTS.md:41` 规定的 16384px / 50MP 解码限制(`macos/scripts/injector.mjs:784`、`theme-windows.ps1:246`),但它是**唯一逃过同步闸门的共享安全组件**:

`tools/sync-runtime-assets.mjs` 的 outputs 覆盖 14 个文件,`macos/tests/run-tests.sh:142` 用 `--check` 卡住漂移。`image-metadata.mjs` 不在列表里,于是两端各有一份手工维护的副本,**没有任何机制保证它们一致**。有人只改一端的尺寸限制,CI 不会报错,两平台的图片安全边界就静默分叉了。

当前两份**恰好**等价 —— 我实测剥掉 Windows 多出的 CLI 包装后,解析器核心逐字节相同。本 PR 把"恰好"变成"必然"。

## 改法

沿用项目已有模式(`compileSafeCssFileValidator` 编译时改写 import):

- `runtime/image-metadata.mjs` 成为唯一源(纯解析器)
- Windows 需要的 CLI 入口在同步时追加,不再作为第二份手工副本维护
- 两端产物注册进 outputs,自动受 `--check` 保护

## 验证

| 项 | 结果 |
|---|---|
| 生成产物与原文件 | **逐字节一致**(纯机制改动,零行为变化) |
| `sync-runtime-assets --check` | exit 0 |
| macOS / Windows 测试 | 47/47、11/11 |
| 双端 `--check-payload` | pass |
| Windows CLI 实跑 | `{"width":2560,"height":1440,...}` 正常 |

**反重言验证**:把 runtime 源里的 `MAX_IMAGE_DIMENSION` 从 16384 改成 32768,`--check` 报告双端 `out-of-date` 并 exit 1;还原后 exit 0。闸门确实拦得住。

## 未在本地验证

PowerShell 侧调用路径(`theme-windows.ps1:246` shell out 到这个 CLI)—— macOS 主机无 pwsh,交 CI。但生成文件与合入前逐字节相同,该路径的行为不可能改变。