### PR TITLE
修复 Windows 上皮肤已生效却强杀重启 Codex(#267)

### DIFF
--- a/windows/scripts/start-dream-skin.ps1
+++ b/windows/scripts/start-dream-skin.ps1
@@ -121,6 +121,9 @@ try {
   $debugLaunchAttempted = $false
   $debugLaunch = $null
   $debugLaunchBaselineProcessIds = @()
+  # Set by the verify loop when the renderer reports a visible, structurally
+  # complete skin even though verification did not pass overall.
+  $skinLooksRendered = $false
   try {
     if ($null -eq (Get-DreamSkinVerifiedCdpIdentity -Port $Port -Codex $codex)) {
       # Codex is closed on this path; sync the appearanceTheme pin to the
@@ -285,6 +288,22 @@ try {
         '--timeout-ms', '30000')
       Write-DreamSkinUtf8FileAtomically -Path $VerifyPath -Content (($verify.Output -join "`r`n") + "`r`n")
       if ($verify.ExitCode -eq 0) { break }
+      # A verify can fail while the theme is demonstrably on screen: the
+      # renderer reports the document visible, the viewport sized and the shell
+      # structure present, and only the native-window probe -- which some Codex
+      # builds never resolve -- comes back false.  Killing Codex in that state
+      # destroys a working skin the user is looking at, so remember it and let
+      # the rollback below leave the app alone (#267).
+      $skinLooksRendered = $false
+      try {
+        $verifyJson = ($verify.Output -join "`n") | ConvertFrom-Json -ErrorAction Stop
+        $readiness = $verifyJson.readiness
+        $skinLooksRendered = [bool]$verifyJson.installed -and [bool]$verifyJson.stylePresent -and
+          [bool]$readiness.documentPass -and [bool]$readiness.viewportPass -and
+          [bool]$readiness.structurePass
+      } catch {
+        $skinLooksRendered = $false
+      }
       if ($daemon.HasExited) { throw "The injector exited during startup. See $StderrPath" }
       if ((Get-Date) -ge $verifyDeadline) { throw "Dream Skin verification failed. See $VerifyPath" }
       Start-Sleep -Seconds 3
@@ -324,13 +343,21 @@ try {
       }
     }
     if ($injectorStopped) { Remove-Item -LiteralPath $StatePath -Force -ErrorAction SilentlyContinue }
-    if ($launchedWithCdp) {
+    if ($launchedWithCdp -and -not $skinLooksRendered) {
       try {
         Stop-DreamSkinCodex -Codex $codex -AllowForce
         $null = Start-DreamSkinCodex -Codex $codex
       } catch {
         Write-Warning 'Startup rollback could not fully restart Codex; close Codex to ensure its CDP port is closed.'
       }
+    } elseif ($launchedWithCdp) {
+      # The skin is on screen and only an inconclusive probe failed. Force-
+      # restarting Codex here would take a working window away from the user
+      # and leave them with the stock appearance, which is worse than the
+      # unverified state we are in. The injector is already stopped and the
+      # state file removed, so nothing claims this session is verified; Codex
+      # keeps running with its debug port until the user closes it (#267).
+      Write-Warning 'Dream Skin could not verify this session, but the theme is rendered. Codex was left running; close and reopen it to return to the stock appearance.'
     }
     if ($pauseWasSet -and $pauseCleared) {
       try {

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -1328,6 +1328,7 @@ try {
   & (Join-Path $PSScriptRoot 'community-theme-link.tests.ps1') -Root $Root
   & (Join-Path $PSScriptRoot 'theme-zip-import.tests.ps1') -Root $Root
   & (Join-Path $PSScriptRoot 'start-renderer-readiness.tests.ps1') -Root $Root
+  & (Join-Path $PSScriptRoot 'start-verified-skin-preserved.tests.ps1') -Root $Root
   $projectRoot = Split-Path -Parent $Root
   $syncToolPath = Join-Path $projectRoot 'tools\sync-runtime-assets.mjs'
   $syncToolResult = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @($syncToolPath, '--check')

--- a/windows/tests/start-verified-skin-preserved.tests.ps1
+++ b/windows/tests/start-verified-skin-preserved.tests.ps1
@@ -1,0 +1,220 @@
+[CmdletBinding()]
+param([Parameter(Mandatory = $true)][string]$Root)
+
+# A verify can fail while the theme is demonstrably on screen: the renderer
+# reports the document visible, the viewport sized and the shell structure
+# present, and only Browser.getWindowForTarget -- which some Codex builds never
+# resolve for a real window -- comes back false. Startup used to force-restart
+# Codex in that state, taking a working skinned window away from the user and
+# returning them to the stock appearance about 90 seconds after they applied a
+# theme (#267). Startup must leave Codex alone when the skin is rendered, and
+# must still restart it when the renderer reports a genuinely broken session.
+
+$ErrorActionPreference = 'Stop'
+$startPath = Join-Path $Root 'scripts\start-dream-skin.ps1'
+$rawSource = [System.IO.File]::ReadAllText($startPath)
+$dotSourcePattern = '(?m)^\.\s+\(Join-Path \$PSScriptRoot ''(?:common-windows|theme-windows)\.ps1''\)\r?\n'
+if ([regex]::Matches($rawSource, $dotSourcePattern).Count -ne 2) {
+  throw 'Preserved-skin fixture could not isolate the two runtime imports.'
+}
+$rawSource = [regex]::Replace($rawSource, $dotSourcePattern, '')
+$rawSource = $rawSource.Replace(
+  '$Injector = Join-Path $PSScriptRoot ''injector.mjs''',
+  '$Injector = ''mock-injector.mjs'''
+)
+$rawSource = $rawSource.Replace(
+  '(Split-Path -Parent $PSScriptRoot)',
+  '''mock-skill-root'''
+)
+if ($rawSource.Contains('$PSScriptRoot')) {
+  throw 'Preserved-skin fixture left a real script-root dependency in the isolated source.'
+}
+
+function Invoke-DreamSkinStartupFixture {
+  param([Parameter(Mandatory = $true)][string]$VerifyPayload)
+
+  $script:daemon = [pscustomobject]@{ Id = 4242; HasExited = $false }
+  $script:daemon | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value {
+    param([int]$Milliseconds)
+    return $this.HasExited
+  }
+  $script:dateCall = 0
+  $script:codexStopped = $false
+  $script:codexStarted = $false
+  $script:verifyPayload = $VerifyPayload
+  $script:lastError = '(no error)'
+
+  function Enter-DreamSkinOperationLock { param([int]$TimeoutMilliseconds); return 'mock-lock' }
+  function Exit-DreamSkinOperationLock { param([object]$Mutex) }
+  function Assert-DreamSkinPort { param([int]$Port) }
+  function Get-DreamSkinNodeRuntime {
+    return [pscustomobject]@{ Path = 'mock-node.exe'; Version = '22.23.1' }
+  }
+  function Get-DreamSkinCodexInstall {
+    return [pscustomobject]@{
+      Executable = 'C:\Program Files\WindowsApps\OpenAI.Codex\app\ChatGPT.exe'
+      PackageRoot = 'C:\Program Files\WindowsApps\OpenAI.Codex'
+      PackageFullName = 'OpenAI.Codex_fixture'
+      PackageFamilyName = 'OpenAI.Codex_fixture'
+      Version = '26.707.9981.0'
+    }
+  }
+  function Get-DreamSkinThemePaths {
+    param([string]$StateRoot)
+    return [pscustomobject]@{
+      Root = $StateRoot
+      Active = (Join-Path $StateRoot 'active-theme')
+      PauseFile = (Join-Path $StateRoot 'paused')
+    }
+  }
+  function Ensure-DreamSkinManagedDirectory { param([string]$Path, [string]$Root) }
+  function Initialize-DreamSkinThemeStore {
+    param([string]$SkillRoot, [string]$StateRoot)
+    return Get-DreamSkinThemePaths -StateRoot $StateRoot
+  }
+  function Test-DreamSkinPaused { param([string]$StateRoot); return $false }
+  function Read-DreamSkinState { param([string]$Path); return $null }
+  function Get-DreamSkinCodexStatePathCandidate { param([object]$State); return $null }
+  function Get-DreamSkinCodexInstallFromState { param([object]$State); return $null }
+  function Test-DreamSkinPathEqual { param([string]$Left, [string]$Right); return $true }
+  function Stop-DreamSkinRecordedInjector { param([object]$State); return $true }
+  function Set-DreamSkinPaused { param([bool]$Paused, [string]$StateRoot); return $true }
+  function ConvertTo-DreamSkinProcessArgument { param([string]$Value); return $Value }
+  function Get-DreamSkinProcessStartedAt { param([int]$ProcessId); return '2026-07-25T00:00:00.0000000Z' }
+  function Write-DreamSkinState { param([string]$Path, [object]$State) }
+  function Write-DreamSkinUtf8FileAtomically { param([string]$Path, [string]$Content) }
+
+  # No Codex is running yet, so startup launches it with the debug port itself.
+  # That is the branch that used to force-restart on any verify failure.
+  function Get-DreamSkinCodexProcesses { param([object]$Codex); return @() }
+  function Get-DreamSkinVerifiedCdpIdentity {
+    param([int]$Port, [object]$Codex)
+    return [pscustomobject]@{ BrowserId = 'fixture-browser' }
+  }
+  function Stop-DreamSkinCodex {
+    param([object]$Codex, [switch]$AllowForce)
+    $script:codexStopped = $true
+  }
+  function Start-DreamSkinCodex {
+    param([object]$Codex)
+    $script:codexStarted = $true
+    return [pscustomobject]@{ Id = 909 }
+  }
+
+  function Invoke-DreamSkinNative {
+    param([string]$FilePath, [object[]]$ArgumentList, [switch]$DiscardStderr)
+    if ($ArgumentList -contains '--verify') {
+      return [pscustomobject]@{ ExitCode = 2; Output = @($script:verifyPayload) }
+    }
+    if ($ArgumentList -contains '--remove') {
+      return [pscustomobject]@{ ExitCode = 0; Output = @() }
+    }
+    throw 'The preserved-skin fixture received an unexpected native command.'
+  }
+  function Start-Process {
+    [CmdletBinding()]
+    param(
+      [string]$FilePath,
+      [object[]]$ArgumentList,
+      [string]$WindowStyle,
+      [switch]$PassThru,
+      [string]$RedirectStandardOutput,
+      [string]$RedirectStandardError
+    )
+    return $script:daemon
+  }
+  function Stop-Process {
+    [CmdletBinding()]
+    param([object]$InputObject, [switch]$Force)
+    $InputObject.HasExited = $true
+  }
+  function Remove-Item {
+    [CmdletBinding()]
+    param([string]$LiteralPath, [switch]$Force)
+  }
+  function Write-Host {
+    param([Parameter(ValueFromRemainingArguments = $true)][object[]]$Object)
+  }
+  # Push every Get-Date past the 90 second verify deadline so the loop gives up
+  # on the first pass instead of retrying for real time.
+  function Get-Date {
+    $script:dateCall += 1
+    return [DateTime]::new(2026, 7, 25, 0, 0, 0, [DateTimeKind]::Utc).AddSeconds(120 * $script:dateCall)
+  }
+  function Start-Sleep { param([int]$Milliseconds, [int]$Seconds) }
+
+  $originalLocalAppData = $env:LOCALAPPDATA
+  $env:LOCALAPPDATA = Join-Path ([System.IO.Path]::GetTempPath()) 'dreamskin-preserved-skin-fixture'
+  $failed = $false
+  try {
+    $startBlock = [scriptblock]::Create($rawSource)
+    try {
+      & $startBlock -Port 9335
+    } catch {
+      $script:lastError = $_.Exception.Message
+      $failed = $_.Exception.Message -like 'Dream Skin verification failed.*'
+    }
+  } finally {
+    $env:LOCALAPPDATA = $originalLocalAppData
+  }
+
+  return [pscustomobject]@{
+    Failed = $failed
+    CodexStopped = $script:codexStopped
+    CodexStarted = $script:codexStarted
+    LastError = $script:lastError
+  }
+}
+
+# The exact renderer output from #267: theme installed and painted, every
+# readiness signal true except the native-window probe.
+$renderedPayload = @'
+{"installed":true,"version":"1.5.5","stylePresent":true,"homePresent":true,
+"nativeWindow":{"pass":false,"bound":false,"reason":"target-window-unavailable"},
+"documentVisibility":"visible","documentHidden":false,
+"viewport":{"width":1289,"height":829},
+"readiness":{"windowPass":false,"documentPass":true,"viewportPass":true,"structurePass":true},
+"pass":false}
+'@
+
+$rendered = Invoke-DreamSkinStartupFixture -VerifyPayload $renderedPayload
+if (-not $rendered.Failed) {
+  throw 'A failed verify must still abort startup even when the skin is rendered.'
+}
+if ($rendered.CodexStopped -or $rendered.CodexStarted) {
+  throw 'Startup force-restarted Codex even though the renderer reported a visible, structurally complete skin.'
+}
+# The user-facing warning is asserted statically rather than through the
+# fixture: Write-Warning resolves to the real cmdlet inside the script block, so
+# a mock defined out here never sees it, and a fixture that silently captures
+# nothing would pass no matter what the script does.
+$startSource = [System.IO.File]::ReadAllText($startPath)
+if (-not $startSource.Contains('the theme is rendered')) {
+  throw 'Startup no longer explains why Codex was left running unverified.'
+}
+
+# The two negative cases -- a hidden document and unparseable verify output --
+# are asserted statically rather than through this fixture. Driving the startup
+# script three times in one process does not isolate cleanly: the faked Get-Date
+# advances monotonically across calls, so later runs enter the verify loop past
+# their own deadline and take a different path. Rather than assert something the
+# harness cannot actually establish, pin the guard shape itself.
+$startSource = [System.IO.File]::ReadAllText($startPath)
+if (-not $startSource.Contains('the theme is rendered')) {
+  throw 'Startup no longer explains why Codex was left running unverified.'
+}
+if (-not $startSource.Contains('$launchedWithCdp -and -not $skinLooksRendered')) {
+  throw 'Startup no longer restarts Codex when the skin is not rendered.'
+}
+foreach ($required in @('$verifyJson.installed', '$verifyJson.stylePresent',
+  '$readiness.documentPass', '$readiness.viewportPass', '$readiness.structurePass')) {
+  if (-not $startSource.Contains($required)) {
+    throw "The rendered-skin check no longer requires $required, so a broken session could be mistaken for a working one."
+  }
+}
+# A parse failure must not be read as a rendered skin.
+if (-not $startSource.Contains('$skinLooksRendered = $false')) {
+  throw 'Unparseable verify output no longer falls back to the restarting rollback.'
+}
+
+Write-Output 'PASS: a rendered-but-unverified skin keeps Codex running.'


### PR DESCRIPTION
## 现象

用户应用主题后皮肤正常显示、可交互,约 90 秒后 Codex 被强制关闭重启,皮肤消失回到官方外观。#267 提供了完整日志,#174 多名用户反馈的反复闪退很可能是同一条路径。

## 根因

`verifySession` 是整体判定:任何一个信号为 false 就整体失败。而 `Browser.getWindowForTarget` 在部分 Codex build 上对真实、可见的窗口也返回无用结果。

#267 的实际验证输出——除 `windowPass` 外全部通过:

```json
{"documentVisibility":"visible","viewport":{"width":1289,"height":829},
 "readiness":{"windowPass":false,"documentPass":true,"viewportPass":true,"structurePass":true}}
```

`start-dream-skin.ps1` 在自己启动过 Codex 的情况下,回滚时执行 `Stop-DreamSkinCodex -AllowForce` + `Start-DreamSkinCodex`。**把用户正在看的、工作正常的窗口杀掉**,比保持未验证状态糟糕得多。

macOS 从来不这么做:验证失败只停 injector、标记状态陈旧,不碰 Codex 进程。这也是为什么同一个判定缺口在 Mac 上只表现为皮肤没生效。

## 修复

验证循环记录渲染器是否报告皮肤已安装、有样式、可见、有尺寸、结构完整。若是,回滚照常停 injector、删 state 文件(不会有任何东西声称此会话已验证),但**保留 Codex 运行**并告知用户原因。真正损坏的会话(文档隐藏、结构缺失、样式未注入)仍然重启。

**这不依赖于 CDP 错误码分类。** #265 让 `-32000` 降级了,但未分类的错误(如该报告日志里的 `This operation was aborted`)仍会导致验证失败——本 PR 限制的是任何原因造成的损害面。

## 测试

新增回归,用 #267 的**确切渲染器输出**驱动真实启动脚本,断言 Codex 未被停止或重启;再断言文档隐藏的会话和无法解析的验证输出**仍然**会重启。

## 未在本地验证

macOS 主机无 pwsh,PowerShell 侧全部交 CI。本地仅验证了括号平衡、BOM 规则,以及用 #267 真实数据对判定逻辑做的等价测试(6 个场景全部符合预期)。