### PR TITLE
fix(macos): run signed Node across Rosetta launchers

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,6 +1,37 @@
 # Task Progress
 
-Updated: 2026-07-25 08:31 HKT (Asia/Hong_Kong)
+Updated: 2026-07-27 02:35 CST (Asia/Shanghai)
+
+## macOS Rosetta Launcher Architecture Fix (2026-07-27)
+
+- [in progress] Branch `lt_fix_dream_skin_app_startup` is based on the exact
+  public `v1.5.6` commit `611c101`. The user's primary checkout and its
+  untracked `output/` directory remain untouched.
+- [fact] The legacy clickable App exits before launch because its x86_64 shell
+  context is compared with the official ChatGPT `26.721.41059` arm64-only
+  bundled Node. The signed ChatGPT app and Node are arm64, while the existing
+  theme bytes remain intact.
+- [complete] Replaced the parent-shell `uname -m` / Mach-O header comparison
+  with an actual execution check after the existing fixed-path code-signature
+  and OpenAI Team ID gates. An independent read-only review confirmed this is
+  the smallest cross-architecture fix and does not weaken runtime trust.
+- [verified] A real Rosetta x86_64 shell now validates and executes the official
+  arm64-only Node `v24.14.0`, records the validated runtime identity, and passes
+  the focused candidate-payload check. Bash syntax, the new static regression,
+  renderer, Safe CSS, staging, package and ZIP-boundary tests passed.
+- [blocked] The complete repository wrapper later reached an unrelated Swift
+  bounded-HTTP fixture and stopped because the installed Command Line Tools
+  compiler does not match its macOS SDK and the sandbox cannot write the Clang
+  module cache. Per the local no-compile rule, do not repair or rerun Swift
+  locally; leave that fixture to PR CI.
+- [complete] Synced only the reviewed `common-macos.sh` fix into the installed
+  legacy engine. The prior script and clickable App executable are recoverably
+  backed up under the Dream Skin Application Support repair-backups directory;
+  the App bundle and official ChatGPT bundle were not modified.
+- [pending] Launch through the repaired App and require exact live renderer,
+  loopback CDP and unchanged-theme verification before reporting success.
+- [pending] Commit, push and open a focused PR only after local and installed
+  acceptance pass. No version bump, tag or Release publication is in scope.
 
 ## v1.5.1 Version Release (2026-07-25 08:28 HKT)
 

--- a/macos/references/runtime-notes.md
+++ b/macos/references/runtime-notes.md
@@ -1,7 +1,7 @@
 # Runtime notes
 
 - Discover the official `com.openai.codex` bundle on every launch; do not assume an upgrade keeps the same executable internals.
-- Use `Contents/Resources/cua_node/bin/node` from that bundle. Require Node.js 20+, a valid strict code signature, matching architecture, and OpenAI Team ID `2DC432GLL2` on both app and runtime.
+- Use `Contents/Resources/cua_node/bin/node` from that bundle. Require Node.js 20+, a valid strict code signature, successful execution on the current Mac, and OpenAI Team ID `2DC432GLL2` on both app and runtime.
 - State readers that can run before a validated launch must establish this runtime identity at their own execution boundary; never treat an inherited `NODE` value as proof of trust.
 - Do not ship a Node binary and do not depend on a globally installed `node` or `npm`.
 - Launch the official executable through a per-user `launchd` job with `--remote-debugging-address=127.0.0.1` and a selected port. LaunchServices may discard Chromium flags.

--- a/macos/scripts/common-macos.sh
+++ b/macos/scripts/common-macos.sh
@@ -299,12 +299,9 @@ require_signed_node_runtime() {
   [ "$NODE_TEAM_ID" = "$EXPECTED_CODEX_TEAM_ID" ] \
     || fail "Unexpected bundled Node.js signing team: ${NODE_TEAM_ID:-missing}."
 
-  local machine_arch
   local node_major
-  machine_arch="$(/usr/bin/uname -m)"
-  /usr/bin/file "$RUNTIME_NODE" | /usr/bin/grep -q "$machine_arch" \
-    || fail "The ChatGPT Node.js runtime does not match this Mac architecture ($machine_arch)."
-  NODE_VERSION="$($RUNTIME_NODE --version)"
+  NODE_VERSION="$("$RUNTIME_NODE" --version 2>/dev/null)" \
+    || fail "The signed ChatGPT Node.js runtime could not be executed on this Mac."
   node_major="${NODE_VERSION#v}"
   node_major="${node_major%%.*}"
   case "$node_major" in ''|*[!0-9]*) fail "Could not parse bundled Node.js version: $NODE_VERSION" ;; esac

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -54,6 +54,14 @@ if /usr/bin/grep -F -q 'CODEX_EXPECTED_TEAM_ID' "$ROOT/scripts/common-macos.sh" 
   printf 'macOS runtime identity must use the fixed OpenAI signing requirement.\n' >&2
   exit 1
 fi
+SIGNED_RUNTIME_BODY="$(
+  /usr/bin/sed -n '/^require_signed_node_runtime() {/,/^}/p' "$ROOT/scripts/common-macos.sh"
+)"
+if /usr/bin/printf '%s\n' "$SIGNED_RUNTIME_BODY" |
+    /usr/bin/grep -E -q 'uname[[:space:]]+-m|/usr/bin/(file|lipo)|/usr/sbin/sysctl'; then
+  printf 'Signed Node compatibility must be proven by execution, not the launcher architecture.\n' >&2
+  exit 1
+fi
 
 # The native menu bar control plane and XCTest require a complete, matching
 # Xcode platform. CommandLineTools-only hosts report this platform blocker;
@@ -467,10 +475,27 @@ run_signed_runtime_switch_test() {
   [ -z "$(/usr/bin/find "$switch_state" -maxdepth 1 -name '.theme-switch.*' -print -quit)" ]
 }
 
+run_translated_signed_runtime_test() {
+  if [ "$(/usr/bin/uname -m)" != "arm64" ] ||
+      ! /usr/bin/arch -x86_64 /usr/bin/true >/dev/null 2>&1; then
+    printf 'SKIP: Rosetta signed-runtime regression requires Apple Silicon with Rosetta.\n'
+    return 0
+  fi
+  /usr/bin/arch -x86_64 /bin/bash -c '
+    . "$1/scripts/common-macos.sh"
+    [ "$(/usr/bin/uname -m)" = "x86_64" ]
+    discover_codex_app
+    require_signed_node_runtime
+    [ "$NODE_VERSION" = "$("$NODE" --version)" ]
+    [ "$DREAM_SKIN_VALIDATED_RUNTIME_PID" = "$$" ]
+  ' _ "$ROOT"
+}
+
 if [ "${CODEX_DREAM_SKIN_SKIP_SIGNED_RUNTIME_TESTS:-0}" = "1" ]; then
   printf 'SKIP: switch-theme integration requires an installed, signed Codex app.\n'
   SWITCH_RUNTIME_RESULT="skipped"
 else
+  run_translated_signed_runtime_test
   run_signed_runtime_switch_test
   SWITCH_RUNTIME_RESULT="passed"
 fi


### PR DESCRIPTION
Change-Id: I06a06d7b705bbd3706ec3798125e6a77a05f387f

## Summary / 摘要

- Fix legacy macOS launchers that run under Rosetta while the official ChatGPT bundle ships an arm64-only Node.
- Keep the fixed-path code-signature and OpenAI Team ID gates, then prove compatibility by executing the validated Node instead of comparing it with the parent shell architecture.
- Add an Apple Silicon + Rosetta signed-runtime regression and a static guard against launcher-architecture prechecks.
- Align the runtime contract documentation.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [x] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [x] Links and wording reviewed / 已检查链接与表述

### macOS (when code under macos/ changes)

- [ ] macos/tests/run-tests.sh passed / 已通过
- [ ] Doctor (optional): macos/scripts/doctor-macos.sh
- [ ] Live verify (if inject/CSS/start path): verify-dream-skin-macos.sh or Desktop Verify
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under windows/ changes)

- [ ] Relevant install / start / verify / restore scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated macos/CHANGELOG.md (and macos/VERSION if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does not modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does not silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (127.0.0.1) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

- Real Apple Silicon regression: an x86_64 Rosetta shell successfully validated and executed the official arm64 Node v24.14.0 and recorded the validated runtime identity.
- Bash syntax, git diff --check, renderer, Safe CSS, staging, package, and ZIP-boundary regressions passed before an unrelated fixture.
- The complete local wrapper then stopped at the bounded-community HTTP Swift fixture because the local Command Line Tools compiler does not match its macOS SDK and the sandbox cannot write the Clang module cache. Swift compilation was not retried locally; PR CI remains the gate.
- Exact installed legacy-engine payload passed the same Rosetta validation and preserved the active theme hashes.
- No version bump or Release publication is included.
