### PR TITLE
fix(macos): keep menu bar item reachable

### DIFF
--- a/macos/CHANGELOG.md
+++ b/macos/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 修复
 
+- 修复菜单栏拥挤时仅菜单栏 App 的唯一入口可能在首次启动就被 macOS 隐藏的问题。状态项现在使用稳定的 autosave 名称，且只在用户尚未保存位置时设置可达的初始位置；后续手动排列仍由 AppKit 持久化并恢复。
 - 注入器日志与 `--check` 结果不再记录页面标题和 URL。这些字段经 `launchctl submit -o` 落进 `~/Library/Application Support/` 下的长期日志文件,而 Codex 的窗口标题包含会话名与项目名。Windows 侧早已修正(见其 1.3.0 条目),macOS 未同步。渲染器探针也不再把 `document.title` 和 `location.href` 回传给宿主,仅保留结构标记。新增仓库级静态检查防止回归。
 
 ### 内部

--- a/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
+++ b/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
@@ -17,7 +17,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   }
 
   private let fileManager = FileManager.default
-  private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+  private lazy var statusItem: NSStatusItem = {
+    let autosaveName = "cc.dreamskin.menubar.primary"
+    let preferredPositionKey = "NSStatusItem Preferred Position \(autosaveName)"
+    if UserDefaults.standard.object(forKey: preferredPositionKey) == nil {
+      // Keep this menu-bar-only app reachable on its first launch. AppKit
+      // persists later user rearrangement under the same autosave name.
+      UserDefaults.standard.set(0.0, forKey: preferredPositionKey)
+    }
+    let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+    item.autosaveName = autosaveName
+    return item
+  }()
   private let menu = NSMenu()
   private var snapshot = StatusSnapshot()
   private var statusRefreshRunning = false

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -73,6 +73,10 @@ fi
   "$ROOT/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift"
 /usr/bin/grep -F -q 'CommunityRecovery.preserveRollbackSnapshot' \
   "$ROOT/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift"
+/usr/bin/grep -F -q 'item.autosaveName = autosaveName' \
+  "$ROOT/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift"
+/usr/bin/grep -F -q 'NSStatusItem Preferred Position' \
+  "$ROOT/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift"
 /usr/bin/grep -F -q 'recovery/community-*/active-before' \
   "$ROOT/scripts/switch-theme-macos.sh"
 /usr/bin/grep -F -q 'CFBundleURLTypes.0.CFBundleURLSchemes.0' "$ROOT/scripts/build-dmg.sh"


### PR DESCRIPTION
## Summary / 摘要

- Give the menu-bar-only app a stable `NSStatusItem.autosaveName`.
- Seed AppKit's preferred position only when no saved position exists, keeping the sole app entry point reachable on a crowded menu bar while preserving later user rearrangement.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [x] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [x] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

### Root cause and impact

`NSStatusItem.isVisible` can remain true even when AppKit omits an item because the menu bar has no remaining space. This application is `LSUIElement` and has no Dock icon or regular window, so an omitted status item makes every control unreachable.

A minimal native AppKit status-item process reproduced the same omission on the affected Mac. Without changing or restarting that process, freeing menu-bar space made its item appear. Seeding position `0` then placed it beside the system controls, which isolates the failure to status-item placement rather than icon rendering or application startup.

### Compatibility note

`autosaveName` is public AppKit API. AppKit does not expose a public status-item priority API, so the first-launch seed uses the preference key AppKit persists for that autosave name. The key is written only when absent; after that, AppKit's saved user arrangement wins. If maintainers prefer not to rely on this persistence detail, the `autosaveName` part can remain independently useful but cannot guarantee first-launch reachability under crowding.

### Validation

- `CI=1 CODEX_DREAM_SKIN_SKIP_DOCTOR=1 macos/tests/run-tests.sh` passed, including signed-runtime theme switching and runtime-state integration.
- Built an arm64 application directly with the Command Line Tools macOS SDK; `codesign --verify --deep --strict` and `plutil -lint` passed.
- Launched that build with an isolated first-run preferences home. It created a second native Dream Skin status item beside the system controls without replacing the installed app.
- `git diff --check` passed.

The repository skipped SwiftPM/XCTest because this host has Command Line Tools rather than a full matching Xcode macOS platform. Doctor was deliberately skipped; this change does not touch installation, injection, restore, or the signed ChatGPT runtime.
