### PR TITLE
fix(macos): detect ChatGPT by executable path

### DIFF
--- a/macos/CHANGELOG.md
+++ b/macos/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 修复
 
+- 修复 macOS 截断进程名时，菜单栏把已打开的 ChatGPT 误报为未运行的问题。高频状态检查现在只扫描一次进程表并匹配已保存或标准安装位置的完整主可执行路径，应用确认框复用同一状态结果。
 - 注入器日志与 `--check` 结果不再记录页面标题和 URL。这些字段经 `launchctl submit -o` 落进 `~/Library/Application Support/` 下的长期日志文件,而 Codex 的窗口标题包含会话名与项目名。Windows 侧早已修正(见其 1.3.0 条目),macOS 未同步。渲染器探针也不再把 `document.title` 和 `location.href` 回传给宿主,仅保留结构标记。新增仓库级静态检查防止回归。
 
 ### 内部

--- a/macos/scripts/apply-from-menubar-macos.sh
+++ b/macos/scripts/apply-from-menubar-macos.sh
@@ -58,7 +58,6 @@ progress "已收到点击…"
 set +e
 
 CHEAP_RUNNING="false"
-/usr/bin/pgrep -x ChatGPT >/dev/null 2>&1 && CHEAP_RUNNING="true"
 SESSION="off"
 THEME_NAME=""
 PORT="9341"
@@ -68,6 +67,7 @@ if [ -x "$SCRIPT_DIR/status-dream-skin-macos.sh" ]; then
       session=*) SESSION="${line#session=}" ;;
       theme=*) THEME_NAME="${line#theme=}" ;;
       port=*) PORT="${line#port=}" ;;
+      codex=*) CHEAP_RUNNING="${line#codex=}" ;;
     esac
   done < <("$SCRIPT_DIR/status-dream-skin-macos.sh" 2>/dev/null)
 fi

--- a/macos/scripts/status-dream-skin-macos.sh
+++ b/macos/scripts/status-dream-skin-macos.sh
@@ -33,6 +33,7 @@ APPLIED_THEME_ID=""
 CODEX_RUNNING="false"
 OPERATION_STATUS=""
 OPERATION_MESSAGE=""
+SAVED_CODEX_EXE=""
 
 read_json_text_field() {
   # Parse machine-written JSON (one key per line) without python3, which macOS
@@ -87,12 +88,6 @@ injector_identity_matches() {
   [ -n "$actual_start" ] && [ "$actual_start" = "$expected_start" ]
 }
 
-# Codex process: cheap name match only.  26.707 renamed Codex.app to
-# ChatGPT.app, while older installs still expose the former process name.
-if /usr/bin/pgrep -x ChatGPT >/dev/null 2>&1 || /usr/bin/pgrep -x Codex >/dev/null 2>&1; then
-  CODEX_RUNNING="true"
-fi
-
 if [ -f "$STATE_PATH" ]; then
   STATE_SNAPSHOT="$(/bin/cat "$STATE_PATH" 2>/dev/null)"
   saved_port="$(read_json_text_field "$STATE_SNAPSHOT" port)"
@@ -102,6 +97,7 @@ if [ -f "$STATE_PATH" ]; then
   saved_start="$(read_json_text_field "$STATE_SNAPSHOT" injectorStartedAt)"
   saved_node="$(read_json_text_field "$STATE_SNAPSHOT" nodePath)"
   saved_injector="$(read_json_text_field "$STATE_SNAPSHOT" injectorPath)"
+  SAVED_CODEX_EXE="$(read_json_text_field "$STATE_SNAPSHOT" codexExe)"
   APPLIED_THEME_ID="$(read_json_text_field "$STATE_SNAPSHOT" appliedThemeId)"
   APPLIED_THEME_NAME="$(read_json_text_field "$STATE_SNAPSHOT" appliedThemeName)"
   if injector_identity_matches "${pid:-}" "$saved_start" "$saved_node" "$saved_injector" "$PORT"; then
@@ -125,6 +121,21 @@ if [ -f "$STATE_PATH" ]; then
     esac
   fi
 fi
+
+# macOS may truncate the process name exposed to pgrep (for example,
+# /Applications/Ch). Match the complete main command path and ignore helpers.
+while IFS= read -r command_line; do
+  for candidate in "$SAVED_CODEX_EXE" \
+    "/Applications/ChatGPT.app/Contents/MacOS/ChatGPT" \
+    "$HOME/Applications/ChatGPT.app/Contents/MacOS/ChatGPT" \
+    "/Applications/Codex.app/Contents/MacOS/Codex" \
+    "$HOME/Applications/Codex.app/Contents/MacOS/Codex"; do
+    [ -n "$candidate" ] || continue
+    case "$command_line" in
+      "$candidate"|"$candidate "*) CODEX_RUNNING="true"; break 2 ;;
+    esac
+  done
+done < <(/bin/ps -axo command= 2>/dev/null)
 
 if [ -f "$THEME_DIR/theme.json" ]; then
   THEME_SNAPSHOT="$(/bin/cat "$THEME_DIR/theme.json" 2>/dev/null)"

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -667,6 +667,30 @@ STATUS_JSON="$(/usr/bin/env HOME="$STATUS_HOME" "$ROOT/scripts/status-dream-skin
 wait "$STATUS_PID" 2>/dev/null || true
 STATUS_PID=""
 
+# The main executable can have a truncated process name on macOS even though
+# its command starts with the complete path saved by the launcher.
+STATUS_CODEX_EXE="$TMP/Fake ChatGPT"
+/bin/bash -c 'exec -a "$1" /bin/sleep 600' _ "$STATUS_CODEX_EXE" &
+STATUS_PID="$!"
+/bin/sleep 0.08
+"$NODE" -e '
+  const fs = require("node:fs");
+  const [file, codexExe] = process.argv.slice(1);
+  fs.writeFileSync(file, `${JSON.stringify({
+    schemaVersion: 4,
+    session: "off",
+    codexExe,
+  })}\n`);
+' "$STATUS_STATE_ROOT/state.json" "$STATUS_CODEX_EXE"
+STATUS_JSON="$(/usr/bin/env HOME="$STATUS_HOME" "$ROOT/scripts/status-dream-skin-macos.sh" --json)"
+"$NODE" -e '
+  const value = JSON.parse(process.argv[1]);
+  if (value.codexRunning !== true) process.exit(1);
+' "$STATUS_JSON"
+/bin/kill -TERM "$STATUS_PID" 2>/dev/null || true
+wait "$STATUS_PID" 2>/dev/null || true
+STATUS_PID=""
+
 # The common stop path must reject a real watcher running on 19341 when the
 # saved state claims 1934, even though nodePath/injectorPath/start-time all
 # match. This exercises the signal gate directly (status has its own matcher).


### PR DESCRIPTION
## Summary / 摘要

- Replace `pgrep -x ChatGPT` / `Codex` status detection with one process-table scan that matches the full main executable command path.
- Reuse the status script's `codex` result in the menu-bar apply prompt so both UI paths report the same state.
- Add a regression fixture for a full command path whose process name cannot match the expected app name.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [x] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [x] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

### Root cause and impact

On the reproduced macOS 26 session, the main process was:

```text
/Applications/ChatGPT.app/Contents/MacOS/ChatGPT --remote-debugging-address=127.0.0.1 --remote-debugging-port=9341
```

but `ps` exposed its `comm` value as `/Applications/Ch`. Therefore `pgrep -x ChatGPT` returned no PID even while ChatGPT was running. The menu showed ChatGPT as closed and the apply action offered the cold-start prompt.

The status path remains deliberately cheap: it scans `ps` once, matches only the saved or standard main executable path, and does not invoke Node, CDP, `codesign`, or `lsof`. Helper processes do not use the main executable path. Sensitive start/stop paths continue to use the existing signed runtime and executable identity validation in `common-macos.sh`.

### Validation

- Before the fix on the affected live session: `pgrep -x ChatGPT` returned no PID while `ps` showed the complete main command path.
- After the fix: `status-dream-skin-macos.sh --json` reported `codexRunning: true` for that same running process.
- Added a regression fixture whose command begins with the saved full executable path while its process name belongs to `/bin/sleep`.
- `CI=1 CODEX_DREAM_SKIN_SKIP_DOCTOR=1 macos/tests/run-tests.sh` passed twice after the final fixture cleanup, including signed-runtime theme switching and runtime-state integration.
- Bash syntax checks and `git diff --check` passed.

The repository skipped SwiftPM/XCTest because this host has Command Line Tools rather than a full matching Xcode macOS platform. Doctor was deliberately skipped; this change only affects non-destructive status presentation and prompt selection.
