### PR TITLE
fix(macos): align custom theme output with runtime schema

### DIFF
--- a/macos/scripts/write-theme.mjs
+++ b/macos/scripts/write-theme.mjs
@@ -121,18 +121,22 @@ const name = validateText(valueFor("name", "我的 Codex Dream Skin"), "name", 8
 const tagline = validateText(
   valueFor("tagline", "把喜欢的画面变成可交互的 Codex 工作台。"),
   "tagline",
-  160,
+  120,
   "把喜欢的画面变成可交互的 Codex 工作台。",
 );
 const quote = validateText(
   valueFor("quote", "MAKE SOMETHING WONDERFUL"),
   "quote",
-  80,
+  120,
   "MAKE SOMETHING WONDERFUL",
 );
 const appearance = validateChoice(valueFor("appearance", "auto"), "appearance", ["auto", "light", "dark"]);
 const safeArea = validateChoice(valueFor("safe-area", "auto"), "safe-area", ["auto", "left", "right", "center", "none"]);
-const taskMode = validateChoice(valueFor("task-mode", "auto"), "task-mode", ["auto", "ambient", "banner", "off"]);
+const taskMode = validateChoice(
+  valueFor("task-mode", "auto"),
+  "task-mode",
+  ["auto", "ambient", "banner", "full", "off"],
+);
 const focusX = hasValue("focus-x") ? validateUnit(valueFor("focus-x"), "focus-x") : null;
 const focusY = hasValue("focus-y") ? validateUnit(valueFor("focus-y"), "focus-y") : null;
 

--- a/macos/tests/write-theme-contract.test.mjs
+++ b/macos/tests/write-theme-contract.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { loadTheme } from "../scripts/injector.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const macosRoot = path.resolve(here, "..");
+const writer = path.join(macosRoot, "scripts", "write-theme.mjs");
+const fixtureImage = path.join(macosRoot, "assets", "portal-hero.png");
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) resolve({ stdout, stderr });
+      else reject(new Error(stderr || stdout || `${command} exited with ${code}`));
+    });
+  });
+}
+
+test("custom theme writer matches the injector text and task-mode contract", async () => {
+  const output = await fs.mkdtemp(path.join(os.tmpdir(), "dreamskin-write-contract."));
+  try {
+    await fs.copyFile(fixtureImage, path.join(output, "background.png"));
+    const longTagline = "界".repeat(130);
+    const longQuote = "光".repeat(130);
+    await run(process.execPath, [
+      writer,
+      "custom",
+      "--output-dir", output,
+      "--image", "background.png",
+      "--name", "Writer contract fixture",
+      "--tagline", longTagline,
+      "--quote", longQuote,
+      "--task-mode", "full",
+    ]);
+
+    const raw = JSON.parse(await fs.readFile(path.join(output, "theme.json"), "utf8"));
+    assert.equal(Array.from(raw.tagline).length, 120);
+    assert.equal(Array.from(raw.quote).length, 120);
+    assert.equal(raw.art.taskMode, "full");
+
+    const loaded = await loadTheme(output);
+    assert.equal(loaded.theme.tagline, "界".repeat(120));
+    assert.equal(loaded.theme.quote, "光".repeat(120));
+    assert.equal(loaded.theme.art.taskMode, "full");
+  } finally {
+    await fs.rm(output, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary / 摘要

- Align `write-theme.mjs` with the runtime loader's 120-code-point limits.
- Allow the documented `art.taskMode=full` value and lock the writer-to-loader contract with a regression test.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [x] macOS
- [ ] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复再应用

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

The writer accepted a 160-code-point tagline, only 80 code points of quote text,
and rejected `full`, while the runtime accepted a 120/120/full contract.

Validated on `main@611c101` with:

- `node --check macos/scripts/write-theme.mjs` — passed
- `node --test macos/tests/write-theme-contract.test.mjs` — passed
- `git diff --check` — passed

The added test writes a theme, reads its JSON, and loads it through the runtime.
macOS Desktop verification, Doctor, Swift/Xcode coverage, and a full macOS host
suite remain CI or device gates.

## Tracking issue / 追踪 Issue

Closes #295