### PR TITLE
fix(windows): distinguish dot-prefixed names from traversal

### DIFF
--- a/windows/scripts/injector.mjs
+++ b/windows/scripts/injector.mjs
@@ -483,6 +483,13 @@ function sameFileStat(left, right) {
     && left.ctimeMs === right.ctimeMs;
 }
 
+function isContainedRelativePath(relativePath) {
+  return relativePath !== ""
+    && !path.isAbsolute(relativePath)
+    && relativePath !== ".."
+    && !relativePath.startsWith(`..${path.sep}`);
+}
+
 async function loadSafeCss(themeRoot) {
   const cssPath = path.join(themeRoot, "theme.css");
   let handle;
@@ -522,7 +529,7 @@ export async function loadTheme(themeDir) {
   if (!image || path.isAbsolute(image)) throw new Error("Theme image must be a relative path");
   const imagePath = path.resolve(realThemeDir, image);
   const relativeImage = path.relative(realThemeDir, imagePath);
-  if (!relativeImage || relativeImage.startsWith("..") || path.isAbsolute(relativeImage)) {
+  if (!isContainedRelativePath(relativeImage)) {
     throw new Error("Theme image must remain inside the selected theme directory");
   }
   const extension = path.extname(imagePath).toLowerCase();
@@ -531,7 +538,7 @@ export async function loadTheme(themeDir) {
   }
   const realImagePath = await fs.realpath(imagePath);
   const realRelativeImage = path.relative(realThemeDir, realImagePath);
-  if (!realRelativeImage || realRelativeImage.startsWith("..") || path.isAbsolute(realRelativeImage)) {
+  if (!isContainedRelativePath(realRelativeImage)) {
     throw new Error("Theme image cannot escape through a link or junction");
   }
   const art = raw.art && typeof raw.art === "object" && !Array.isArray(raw.art) ? raw.art : {};

--- a/windows/tests/theme-path-containment.test.mjs
+++ b/windows/tests/theme-path-containment.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { loadTheme } from "../scripts/injector.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const windowsRoot = path.resolve(here, "..");
+const sourceImage = path.join(windowsRoot, "assets", "dream-reference.jpg");
+
+async function writeTheme(root, image) {
+  await fs.writeFile(path.join(root, "theme.json"), `${JSON.stringify({
+    schemaVersion: 1,
+    id: "path-containment-fixture",
+    name: "Path containment fixture",
+    image,
+  }, null, 2)}\n`);
+}
+
+test("an in-directory image name beginning with two dots is not mistaken for traversal", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "dreamskin-dot-image."));
+  try {
+    const imageName = "..hero.jpg";
+    await fs.copyFile(sourceImage, path.join(root, imageName));
+    await writeTheme(root, imageName);
+
+    const loaded = await loadTheme(root);
+    assert.equal(loaded.theme.image, imageName);
+    assert.equal(loaded.imagePath, await fs.realpath(path.join(root, imageName)));
+    assert.ok(loaded.imageBytes.length > 0);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("real parent-directory traversal remains rejected", async () => {
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "dreamskin-parent-traversal."));
+  const root = path.join(parent, "theme");
+  try {
+    await fs.mkdir(root);
+    await fs.copyFile(sourceImage, path.join(parent, "outside.jpg"));
+    await writeTheme(root, `..${path.sep}outside.jpg`);
+
+    await assert.rejects(
+      loadTheme(root),
+      /must remain inside the selected theme directory/,
+    );
+  } finally {
+    await fs.rm(parent, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary / 摘要

- Replace prefix-based path traversal detection with component-aware containment.
- Preserve rejection of real traversal and link/junction escapes while accepting an in-directory `..hero.jpg` name.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `windows/CHANGELOG.md` / 已更新 changelog
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

`relativePath.startsWith("..")` rejected both `..\\outside.jpg` and the legal
same-directory filename `..hero.jpg`. The new helper rejects only empty,
absolute, exact-parent, and parent-segment paths before and after `realpath`.

Validated on Windows at `main@611c101` with:

- `node --check windows/scripts/injector.mjs` — passed
- `node --test windows/tests/theme-path-containment.test.mjs` — passed
- `powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File windows/tests/run-tests.ps1` — passed
- `git diff --check` — passed

No live installer, launcher, or Codex theme was exercised.

## Tracking issue / 追踪 Issue

Closes #296