### PR TITLE
fix(packages): reject impossible manifest timestamps

### DIFF
--- a/macos/assets/theme-package-validator.mjs
+++ b/macos/assets/theme-package-validator.mjs
@@ -79,7 +79,7 @@ const KEY_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const CONTROL_PATTERN = /[\u0000-\u001f\u007f]/u;
 const PROVENANCE_CONTROL_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u;
 const COLOR_PATTERN = /^(#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?|#[0-9a-fA-F]{3,4}|rgb\(\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*\)|rgba\(\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*(0|1|1\.0|0?\.[0-9]{1,6})\s*\))$/;
-const RFC3339_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,9})?(?:Z|[+-][0-9]{2}:[0-9]{2})$/;
+const RFC3339_PATTERN = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\.([0-9]{1,9}))?(?:Z|([+-])([0-9]{2}):([0-9]{2}))$/;
 const OPEN_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
 const decoder = new TextDecoder("utf-8", { fatal: true });
 const scriptPath = fileURLToPath(import.meta.url);
@@ -265,7 +265,26 @@ async function sourceFileNames(root) {
 
 function validateTimestamp(value) {
   assertString(value, "manifest.createdAt", { min: 1, max: 40, pattern: RFC3339_PATTERN, controls: null });
-  if (!Number.isFinite(Date.parse(value))) fail("manifest.createdAt is not a valid date-time");
+  const match = RFC3339_PATTERN.exec(value);
+  if (!match) fail("manifest.createdAt is not a valid date-time");
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = match[9] === undefined ? 0 : Number(match[9]);
+  const offsetMinute = match[10] === undefined ? 0 : Number(match[10]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  const calendarValid = month >= 1 && month <= 12
+    && day >= 1 && day <= (daysInMonth[month - 1] ?? 0)
+    && hour <= 23 && minute <= 59 && second <= 59
+    && offsetHour <= 23 && offsetMinute <= 59;
+  if (!calendarValid || !Number.isFinite(Date.parse(value))) {
+    fail("manifest.createdAt is not a valid date-time");
+  }
 }
 
 function validateOfficialTheme(value) {

--- a/macos/tests/theme-package-validator.test.mjs
+++ b/macos/tests/theme-package-validator.test.mjs
@@ -172,6 +172,24 @@ try {
     "theme.json",
   ]);
 
+  const impossibleTimestamp = await makeOfficial("official-impossible-timestamp", {
+    mutateManifest: (manifest) => { manifest.createdAt = "2026-02-30T00:00:00Z"; },
+  });
+  await expectRejected(
+    impossibleTimestamp.source,
+    "macos",
+    /createdAt is not a valid date-time/,
+    "impossible-timestamp",
+  );
+
+  const leapTimestamp = await makeOfficial("official-valid-leap-timestamp", {
+    mutateManifest: (manifest) => {
+      manifest.createdAt = "2024-02-29T23:59:59.123456789+05:30";
+    },
+  });
+  const leapResult = await validate(leapTimestamp.source, "windows", "valid-leap-timestamp");
+  assert.equal(leapResult.output.format, "official");
+
   const legacyOfficial = await makeOfficial("legacy-official-no-css", { css: false });
   await expectRejected(
     legacyOfficial.source,

--- a/runtime/theme-package-validator.mjs
+++ b/runtime/theme-package-validator.mjs
@@ -79,7 +79,7 @@ const KEY_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const CONTROL_PATTERN = /[\u0000-\u001f\u007f]/u;
 const PROVENANCE_CONTROL_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u;
 const COLOR_PATTERN = /^(#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?|#[0-9a-fA-F]{3,4}|rgb\(\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*\)|rgba\(\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*(0|1|1\.0|0?\.[0-9]{1,6})\s*\))$/;
-const RFC3339_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,9})?(?:Z|[+-][0-9]{2}:[0-9]{2})$/;
+const RFC3339_PATTERN = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\.([0-9]{1,9}))?(?:Z|([+-])([0-9]{2}):([0-9]{2}))$/;
 const OPEN_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
 const decoder = new TextDecoder("utf-8", { fatal: true });
 const scriptPath = fileURLToPath(import.meta.url);
@@ -265,7 +265,26 @@ async function sourceFileNames(root) {
 
 function validateTimestamp(value) {
   assertString(value, "manifest.createdAt", { min: 1, max: 40, pattern: RFC3339_PATTERN, controls: null });
-  if (!Number.isFinite(Date.parse(value))) fail("manifest.createdAt is not a valid date-time");
+  const match = RFC3339_PATTERN.exec(value);
+  if (!match) fail("manifest.createdAt is not a valid date-time");
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = match[9] === undefined ? 0 : Number(match[9]);
+  const offsetMinute = match[10] === undefined ? 0 : Number(match[10]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  const calendarValid = month >= 1 && month <= 12
+    && day >= 1 && day <= (daysInMonth[month - 1] ?? 0)
+    && hour <= 23 && minute <= 59 && second <= 59
+    && offsetHour <= 23 && offsetMinute <= 59;
+  if (!calendarValid || !Number.isFinite(Date.parse(value))) {
+    fail("manifest.createdAt is not a valid date-time");
+  }
 }
 
 function validateOfficialTheme(value) {

--- a/windows/assets/theme-package-validator.mjs
+++ b/windows/assets/theme-package-validator.mjs
@@ -79,7 +79,7 @@ const KEY_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const CONTROL_PATTERN = /[\u0000-\u001f\u007f]/u;
 const PROVENANCE_CONTROL_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u;
 const COLOR_PATTERN = /^(#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?|#[0-9a-fA-F]{3,4}|rgb\(\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*\)|rgba\(\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*,\s*(0|1|1\.0|0?\.[0-9]{1,6})\s*\))$/;
-const RFC3339_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,9})?(?:Z|[+-][0-9]{2}:[0-9]{2})$/;
+const RFC3339_PATTERN = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\.([0-9]{1,9}))?(?:Z|([+-])([0-9]{2}):([0-9]{2}))$/;
 const OPEN_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
 const decoder = new TextDecoder("utf-8", { fatal: true });
 const scriptPath = fileURLToPath(import.meta.url);
@@ -265,7 +265,26 @@ async function sourceFileNames(root) {
 
 function validateTimestamp(value) {
   assertString(value, "manifest.createdAt", { min: 1, max: 40, pattern: RFC3339_PATTERN, controls: null });
-  if (!Number.isFinite(Date.parse(value))) fail("manifest.createdAt is not a valid date-time");
+  const match = RFC3339_PATTERN.exec(value);
+  if (!match) fail("manifest.createdAt is not a valid date-time");
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = match[9] === undefined ? 0 : Number(match[9]);
+  const offsetMinute = match[10] === undefined ? 0 : Number(match[10]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  const calendarValid = month >= 1 && month <= 12
+    && day >= 1 && day <= (daysInMonth[month - 1] ?? 0)
+    && hour <= 23 && minute <= 59 && second <= 59
+    && offsetHour <= 23 && offsetMinute <= 59;
+  if (!calendarValid || !Number.isFinite(Date.parse(value))) {
+    fail("manifest.createdAt is not a valid date-time");
+  }
 }
 
 function validateOfficialTheme(value) {


### PR DESCRIPTION
## Summary / 摘要

- Validate RFC 3339 calendar fields for `manifest.createdAt` before accepting a theme package.
- Keep the runtime and both generated platform validator copies synchronized.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [ ] Windows
- [x] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

A shape regex plus `Date.parse()` can accept a normalized impossible date such
as 2026-02-30. The patch checks leap years, days per month, clock ranges, and
offset ranges before retaining `Date.parse()` as a final parseability check.

Validated on Windows at `main@611c101` with:

- `node --check` for runtime, macOS, and Windows validators — passed
- `node tools/sync-runtime-assets.mjs --check` — passed
- `node --test macos/tests/theme-package-validator.test.mjs` — passed
- `powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File windows/tests/run-tests.ps1` — passed
- `git diff --check` — passed

macOS-native importer integration and Desktop smoke tests remain CI/device
gates.

## Tracking issue / 追踪 Issue

Closes #297