### PR TITLE
fix(windows): fail verification on horizontal overflow

### DIFF
--- a/windows/scripts/injector.mjs
+++ b/windows/scripts/injector.mjs
@@ -1232,8 +1232,8 @@ export async function verifySession(
       nativeWindowPass, fallbackWindowPass,
     };
     result.pass = result.installed && result.version === result.expectedVersion &&
-      result.stylePresent && result.businessClassPollution === 0 && windowPass &&
-      documentPass && viewportPass && structurePass &&
+      result.stylePresent && result.businessClassPollution === 0 && !result.documentOverflow.x &&
+      windowPass && documentPass && viewportPass && structurePass &&
       payloadPass &&
       (!result.homePresent || (Boolean(result.homeSurface?.visible && result.hero?.visible) &&
         (!result.suggestionsPresent || (result.cards.length >= 2 && result.cards.length <= 4))));

--- a/windows/tests/injector-window-readiness.test.mjs
+++ b/windows/tests/injector-window-readiness.test.mjs
@@ -56,12 +56,14 @@ function makeDomFixture({
   hidden = false,
   viewportWidth = 1280,
   viewportHeight = 800,
+  scrollWidth = viewportWidth,
+  scrollHeight = viewportHeight,
 } = {}) {
   const styleNode = {};
   const documentElement = {
-    scrollWidth: viewportWidth,
+    scrollWidth,
     clientWidth: viewportWidth,
-    scrollHeight: viewportHeight,
+    scrollHeight,
     clientHeight: viewportHeight,
     getAttribute: (name) => name === "data-dream-skin" ? "active" : null,
   };
@@ -307,6 +309,21 @@ test("hidden documents and unreasonable viewports cannot pass", async () => {
   });
   assert.equal(tiny.result.pass, false);
   assert.equal(tiny.result.readiness.viewportPass, false);
+});
+
+test("horizontal document overflow cannot be reported as a verified skin", async () => {
+  const horizontal = await verify({
+    dom: makeDomFixture({ scrollWidth: 1281 }),
+  });
+  assert.equal(horizontal.result.documentOverflow.x, true);
+  assert.equal(horizontal.result.pass, false);
+
+  const verticalOnly = await verify({
+    dom: makeDomFixture({ scrollHeight: 1600 }),
+  });
+  assert.equal(verticalOnly.result.documentOverflow.y, true);
+  assert.equal(verticalOnly.result.documentOverflow.x, false);
+  assert.equal(verticalOnly.result.pass, true, "Vertical scrolling is expected for long conversations.");
 });
 
 test("zero-size and CSS-hidden shell anchors cannot satisfy L1", async () => {


### PR DESCRIPTION
## Summary / 摘要

- Fail Windows renderer verification when the document has horizontal overflow.
- Preserve normal vertical scrolling for long conversations.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `windows/CHANGELOG.md` / 已更新 changelog
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

Windows already computed `documentOverflow.x`, but the final pass gate ignored
it. The new fixture keeps scroll axes independent and proves that horizontal
overflow fails while vertical-only overflow passes.

Validated on Windows at `main@611c101` with:

- `node --check windows/scripts/injector.mjs` — passed
- `node --test windows/tests/injector-window-readiness.test.mjs` — passed
- `powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File windows/tests/run-tests.ps1` — passed
- `git diff --check` — passed

No live installer, launcher, or Codex verification was performed.

## Tracking issue / 追踪 Issue

Closes #298