### PR TITLE
fix(windows): enforce theme schemaVersion at runtime

### DIFF
--- a/windows/scripts/injector.mjs
+++ b/windows/scripts/injector.mjs
@@ -518,6 +518,9 @@ export async function loadTheme(themeDir) {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     throw new Error("Theme root must be an object");
   }
+  if (raw.schemaVersion !== 1) {
+    throw new Error("Theme must use schemaVersion 1");
+  }
   const image = normalizedText(raw.image, "image", null, 240);
   if (!image || path.isAbsolute(image)) throw new Error("Theme image must be a relative path");
   const imagePath = path.resolve(realThemeDir, image);
@@ -561,6 +564,7 @@ export async function loadTheme(themeDir) {
     line: normalizeThemeColor(rawColors?.line, "rgba(124, 255, 70, .28)"),
   };
   const theme = {
+    schemaVersion: 1,
     id: normalizeThemeText(raw.id, "custom", 80, "id", themePath),
     name: normalizeThemeText(raw.name, "Codex Dream Skin", 80, "name", themePath),
     brandSubtitle: normalizeThemeText(raw.brandSubtitle, "CODEX DREAM SKIN", 120, "brandSubtitle", themePath),

--- a/windows/scripts/theme-windows.ps1
+++ b/windows/scripts/theme-windows.ps1
@@ -534,6 +534,7 @@ function Set-DreamSkinActiveTheme {
   try { $oldImage = (Read-DreamSkinTheme -ThemeDirectory $paths.Active).ImagePath } catch {}
   if ($null -eq $Theme) {
     $Theme = [pscustomobject]@{
+      schemaVersion = 1
       id = 'custom'
       name = '自定义主题'
       appearance = 'auto'

--- a/windows/tests/theme-schema-contract.test.mjs
+++ b/windows/tests/theme-schema-contract.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { loadTheme } from "../scripts/injector.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const windowsRoot = path.resolve(here, "..");
+const sourceImage = path.join(windowsRoot, "assets", "dream-reference.jpg");
+
+async function makeTheme(root, schemaVersion, includeSchema = true) {
+  await fs.copyFile(sourceImage, path.join(root, "background.jpg"));
+  const theme = {
+    id: "schema-contract-fixture",
+    name: "Schema contract fixture",
+    image: "background.jpg",
+  };
+  if (includeSchema) theme.schemaVersion = schemaVersion;
+  await fs.writeFile(path.join(root, "theme.json"), `${JSON.stringify(theme, null, 2)}\n`);
+}
+
+async function withTheme(schemaVersion, includeSchema, callback) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "dreamskin-schema-contract."));
+  try {
+    await makeTheme(root, schemaVersion, includeSchema);
+    await callback(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+test("Windows runtime accepts and preserves theme schemaVersion 1", async () => {
+  await withTheme(1, true, async (root) => {
+    const loaded = await loadTheme(root);
+    assert.equal(loaded.theme.schemaVersion, 1);
+  });
+});
+
+test("Windows runtime rejects missing and future theme schema versions", async () => {
+  await withTheme(undefined, false, async (root) => {
+    await assert.rejects(loadTheme(root), /must use schemaVersion 1/);
+  });
+  await withTheme(2, true, async (root) => {
+    await assert.rejects(loadTheme(root), /must use schemaVersion 1/);
+  });
+  await withTheme("1", true, async (root) => {
+    await assert.rejects(loadTheme(root), /must use schemaVersion 1/);
+  });
+});


### PR DESCRIPTION
## Summary / 摘要

- Require numeric `schemaVersion: 1` in the Windows runtime loader.
- Preserve the normalized schema version and add explicit compatibility coverage.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [x] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [x] Windows
- [ ] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [ ] Environment noted below / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `windows/CHANGELOG.md` / 已更新 changelog
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

macOS already requires `raw.schemaVersion === 1`; Windows silently treated
missing, string, and future values as v1. The patch makes the platforms agree.
All tracked theme fixtures declare numeric schema version 1. The former portable
theme-contract issue #63 is closed, so this PR deliberately does not claim to
close it.

Validated on Windows at `main@611c101` with:

- `node --check windows/scripts/injector.mjs` — passed
- `node --test windows/tests/theme-schema-contract.test.mjs` — passed
- `powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File windows/tests/run-tests.ps1` — passed
- `git diff --check` — passed

No live installer, launcher, or Codex theme was exercised.

## Tracking issue / 追踪 Issue

Closes #299