### PR TITLE
ci: cover shared runtime and tools regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           while IFS= read -r file; do
             node --check "$file" >/dev/null
           done < <(
-            find macos windows -type f \( -name '*.mjs' -o -name '*.js' \) -print
+            find runtime tools macos windows -type f \( -name '*.mjs' -o -name '*.js' \) -print
           )
 
       - name: Check Windows PowerShell source encoding
@@ -129,6 +129,7 @@ jobs:
         run: |
           node --test macos/tests/*.test.mjs
           node --test windows/tests/*.test.mjs
+          node --test tools/*.test.mjs
           node macos/scripts/injector.mjs --check-payload >/dev/null
           node windows/scripts/injector.mjs --check-payload >/dev/null
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
           while IFS= read -r file; do
             node --check "$file" >/dev/null
           done < <(
-            find macos windows -type f \( -name '*.mjs' -o -name '*.js' \) -print
+            find runtime tools macos windows -type f \( -name '*.mjs' -o -name '*.js' \) -print
           )
 
       # macos/tests/run-tests.sh already re-checks the macOS runtime assertions
@@ -259,6 +259,7 @@ jobs:
           set -euo pipefail
           node --test macos/tests/*.test.mjs
           node --test windows/tests/*.test.mjs
+          node --test tools/*.test.mjs
           node macos/scripts/injector.mjs --check-payload >/dev/null
           node windows/scripts/injector.mjs --check-payload >/dev/null
 


### PR DESCRIPTION
## Summary / 摘要

- Include `runtime/` and `tools/` in the Node syntax scan.
- Run the existing `tools/*.test.mjs` suite in pull-request CI and the release gate.

## Type / 类型

- [ ] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [x] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [ ] Windows
- [ ] Both / 双平台
- [x] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### User-facing / 用户可见变更

- [x] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

The workflow only syntax-checked macOS and Windows source, so canonical runtime
and maintenance tools could regress without the same gate. This patch adds the
existing directories and test suite; it does not introduce a new dependency.

Validated on Windows at `main@611c101` with:

- Node syntax checks for every `.mjs`/`.js` file under `runtime`, `tools`, `macos`, and `windows` — passed
- `node --test tools/*.test.mjs` — passed
- `node --test windows/tests/*.test.mjs` — passed
- `powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File windows/tests/run-tests.ps1` — passed
- Python YAML parsing of both workflow files — passed
- `git diff --check` — passed

GitHub Actions has not yet run for this branch.

## Tracking issue / 追踪 Issue

Closes #300