### PR TITLE
fix(safe-css): accept registered blur variable

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,6 +1,27 @@
 # Task Progress
 
-Updated: 2026-07-25 08:31 HKT (Asia/Hong_Kong)
+Updated: 2026-07-28 16:16 CST (Asia/Shanghai)
+
+## Safe CSS backdrop-filter variable fix (2026-07-28)
+
+- [in progress] Worktree `/Users/yeelight/Desktop/workspace/ai/Codex-Dream-Skin-safe-css-fix`
+  on branch `codex/fix-safe-css-backdrop-var`, based on `upstream/main@611c101`.
+- [complete] Reproduced the public `0.1.1` theme failure against the client Safe CSS
+  validator. The package contains `blur(var(--ds-theme-surface-blur))`, which is a
+  registered contract value but cannot match the client's non-nested blur regex.
+- [complete] A cross-platform regression now accepts the registered blur variable
+  and still rejects an unrelated registered variable. The canonical runtime
+  validator minimally captures the nested function argument, and the generated
+  macOS/Windows copies are byte-identical.
+- [verified] Safe CSS tests passed 9/9; all portable macOS Node tests passed 54/54;
+  all portable Windows Node tests passed 17/17; both injector payload checks,
+  runtime asset sync check, `git diff --check`, and the applicable macOS repository
+  suite passed. The real public `0.1.1` market package validates as the official
+  format through both platform validators. Full-Xcode, installed signed-runtime,
+  and Doctor integrations were environment skips. This macOS host has no
+  PowerShell, so PowerShell 5.1/7 remain explicit PR CI gates.
+- [approved] Explicit approval was received to commit the reviewed five-file
+  change, push the feature branch, and open the upstream pull request.
 
 ## v1.5.1 Version Release (2026-07-25 08:28 HKT)
 

--- a/macos/assets/safe-css-validator.mjs
+++ b/macos/assets/safe-css-validator.mjs
@@ -278,7 +278,7 @@ function validatePropertyValue(property, value) {
   }
   if (property === "backdrop-filter") {
     if (value.toLowerCase() === "none") return true;
-    const match = value.match(/^blur\(\s*([^\s)]+)\s*\)$/i);
+    const match = value.match(/^blur\(\s*(.+?)\s*\)$/i);
     return Boolean(match && (
       registeredVar(match[1], new Set(["--ds-theme-surface-blur"]))
       || zeroOrPx(match[1], 0, 20)

--- a/macos/tests/safe-css-validator.test.mjs
+++ b/macos/tests/safe-css-validator.test.mjs
@@ -68,6 +68,25 @@ test("accepts only the bounded public part/property/value contract", () => {
   }
 });
 
+test("accepts the registered surface blur variable inside backdrop-filter", () => {
+  const source = `[data-ds-part="sidebar"] {
+  backdrop-filter: blur(var(--ds-theme-surface-blur));
+}`;
+  for (const validator of validators) {
+    assert.deepEqual(validator.validateSafeCss(source), {
+      contract: "dreamskin-safe-css/1",
+      status: "validated",
+      bytes: new TextEncoder().encode(source).length,
+      ruleCount: 1,
+      declarationCount: 1,
+    });
+  }
+  assertRejected(
+    `[data-ds-part="sidebar"] { backdrop-filter: blur(var(--ds-theme-surface-radius)); }`,
+    "value/unsupported",
+  );
+});
+
 test("rejects selector escape, global reach, DOM coupling, and unregistered parts", () => {
   for (const source of [
     `:root { color: #fff; }`,

--- a/runtime/safe-css-validator.mjs
+++ b/runtime/safe-css-validator.mjs
@@ -278,7 +278,7 @@ function validatePropertyValue(property, value) {
   }
   if (property === "backdrop-filter") {
     if (value.toLowerCase() === "none") return true;
-    const match = value.match(/^blur\(\s*([^\s)]+)\s*\)$/i);
+    const match = value.match(/^blur\(\s*(.+?)\s*\)$/i);
     return Boolean(match && (
       registeredVar(match[1], new Set(["--ds-theme-surface-blur"]))
       || zeroOrPx(match[1], 0, 20)

--- a/windows/assets/safe-css-validator.mjs
+++ b/windows/assets/safe-css-validator.mjs
@@ -278,7 +278,7 @@ function validatePropertyValue(property, value) {
   }
   if (property === "backdrop-filter") {
     if (value.toLowerCase() === "none") return true;
-    const match = value.match(/^blur\(\s*([^\s)]+)\s*\)$/i);
+    const match = value.match(/^blur\(\s*(.+?)\s*\)$/i);
     return Boolean(match && (
       registeredVar(match[1], new Set(["--ds-theme-surface-blur"]))
       || zeroOrPx(match[1], 0, 20)


### PR DESCRIPTION
## Summary / 摘要

- Fix the client Safe CSS validator rejecting the registered `--ds-theme-surface-blur` variable inside `backdrop-filter: blur(...)`.
- Keep the existing value boundary intact: only `--ds-theme-surface-blur` or a bounded `0..20px` value is accepted.
- Add a cross-platform regression that accepts the blur variable and still rejects an unrelated registered variable.
- Regenerate byte-identical macOS and Windows validator assets from the canonical runtime source.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [ ] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [ ] Windows
- [x] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [x] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [ ] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [x] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

- Root cause: the old outer blur regex stopped at the first closing parenthesis, so the already registered value `var(--ds-theme-surface-blur)` could never reach the existing variable allowlist.
- RED/GREEN: the new focused test reproduced `Safe CSS value is not allowed for backdrop-filter` before the fix and passes after the one-line canonical validator change.
- The production public theme package that exposed the issue was revalidated through both platform package validators; both returned `format: official` and `safeCssStatus: validated`.
- Local checks passed: Safe CSS 9/9, portable macOS Node 54/54, portable Windows Node 17/17, both injector payload checks, runtime asset sync check, `git diff --check`, and the applicable macOS repository suite.
- macOS environment: macOS host with Node.js available. Full-Xcode, installed signed-runtime, and Doctor integrations were skipped by their documented environment gates.
- Windows environment: no PowerShell runtime is installed on this macOS host. PowerShell 5.1 and PowerShell 7 execution remain explicit PR CI gates.
- Changelog was intentionally left unchanged in this focused validator patch; maintainers can place the entry in the target release section.
