### PR TITLE
fix(macos): verify thread routes without a home hero

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,5 +1,16 @@
 # Task Progress
 
+Updated: 2026-07-28 21:51 CST (Asia/Shanghai)
+
+## macOS Thread Route Verification Fix (2026-07-28)
+
+- [in progress] Branch `fix/macos-thread-route-verification` from `main@611c101`.
+- [fact] On this Mac, public Dream Skin `1.5.6` injects the selected Gothic Void Crusade payload into Codex `26.721.41059`: theme ID/revision, CSS, L1 shell/sidebar, viewport and overflow checks all pass. Native `Browser.getWindowForTarget` returns the already-supported `-32000` fallback.
+- [fact] First retry also showed the renderer was hidden. Explicit app activation changed `documentVisibility` to `visible`, but the verifier still failed because runtime scope was `thread` while the legacy home probe returned `homeRoute: true`, `homePresent: false`, `hero: null`. The macOS verifier then incorrectly required a home hero on the thread route and fail-closed.
+- [complete] Added a failing regression for this exact tuple in `macos/tests/window-readiness.test.mjs`; old code failed with `false !== true`. The minimal fix gates home-hero verification and its soft diagnostic on canonical `homePresent`, matching Windows' established verifier contract. A canonical home container without a visible hero still fails.
+- [verified] Targeted window-readiness regression passes. The macOS suite reached and passed syntax, selector, shared-runtime sync, payload, injector and Safe CSS tests before unrelated host gates: the installed ChatGPT runtime fails the shell importer's code-signature validation, and the local Swift 6.3.3 compiler cannot build the Command Line Tools SDK's Swift 6.3.2 module cache. The latter also cannot write the sandboxed clang cache. These are not presented as passes or bypassed.
+- [next] Run focused static checks, inspect and commit the minimal diff, copy the verified injector into the user engine with a timestamped backup, then repeat the real frontmost Codex application/verification.
+
 Updated: 2026-07-25 08:31 HKT (Asia/Hong_Kong)
 
 ## v1.5.1 Version Release (2026-07-25 08:28 HKT)

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,15 +1,17 @@
 # Task Progress
 
-Updated: 2026-07-28 21:51 CST (Asia/Shanghai)
+Updated: 2026-07-28 21:56 CST (Asia/Shanghai)
 
 ## macOS Thread Route Verification Fix (2026-07-28)
 
-- [in progress] Branch `fix/macos-thread-route-verification` from `main@611c101`.
+- [complete] Branch `fix/macos-thread-route-verification` from `main@611c101`; committed the minimal repair as `f462f51` (`fix: verify thread routes without a home hero`).
 - [fact] On this Mac, public Dream Skin `1.5.6` injects the selected Gothic Void Crusade payload into Codex `26.721.41059`: theme ID/revision, CSS, L1 shell/sidebar, viewport and overflow checks all pass. Native `Browser.getWindowForTarget` returns the already-supported `-32000` fallback.
 - [fact] First retry also showed the renderer was hidden. Explicit app activation changed `documentVisibility` to `visible`, but the verifier still failed because runtime scope was `thread` while the legacy home probe returned `homeRoute: true`, `homePresent: false`, `hero: null`. The macOS verifier then incorrectly required a home hero on the thread route and fail-closed.
 - [complete] Added a failing regression for this exact tuple in `macos/tests/window-readiness.test.mjs`; old code failed with `false !== true`. The minimal fix gates home-hero verification and its soft diagnostic on canonical `homePresent`, matching Windows' established verifier contract. A canonical home container without a visible hero still fails.
 - [verified] Targeted window-readiness regression passes. The macOS suite reached and passed syntax, selector, shared-runtime sync, payload, injector and Safe CSS tests before unrelated host gates: the installed ChatGPT runtime fails the shell importer's code-signature validation, and the local Swift 6.3.3 compiler cannot build the Command Line Tools SDK's Swift 6.3.2 module cache. The latter also cannot write the sandboxed clang cache. These are not presented as passes or bypassed.
-- [next] Run focused static checks, inspect and commit the minimal diff, copy the verified injector into the user engine with a timestamped backup, then repeat the real frontmost Codex application/verification.
+- [complete] Static syntax, shared-runtime sync, diff hygiene and the targeted regression pass. The source-tree atomic installer deployed the committed engine with `--no-launch --no-launchers`; its native rollback path retained the prior engine until the replacement was accepted. No public tag, Release, push or installer asset was created.
+- [verified] A real explicit-frontmost Codex smoke now returns `pass: true` for the previously failing tuple: `scope.baseState=thread`, auxiliary `homeRoute=true`, canonical `homePresent=false`, `hero=null`. Exact Gothic Void Crusade ID/revision, installed CSS, visible shell/sidebar/composer, normal viewport, no horizontal overflow and the documented `-32000` native-window fallback all verify. The watcher and Codex are running on loopback `9341`.
+- [handoff] This is a local engine hotfix on the branch above, not a published `1.5.7` release. Future public distribution still requires the normal version bump, CI, DMG build and Release gates.
 
 Updated: 2026-07-25 08:31 HKT (Asia/Hong_Kong)
 

--- a/macos/scripts/injector.mjs
+++ b/macos/scripts/injector.mjs
@@ -244,7 +244,7 @@ export function assessRendererVerification(renderer, nativeWindow, expected) {
     && (!expected.expectedRevision || result.revision === expected.expectedRevision);
   const visibleSuggestionLabels = Array.isArray(result.suggestionLabels)
     ? result.suggestionLabels.filter((item) => item?.visible) : [];
-  const homePass = !result.homeRoute || (
+  const homePass = !result.homePresent || (
     result.homePresent && result.hero?.visible && result.hero.width >= 280
     && result.hero.height >= 120 && (result.visibleCardCount === 0 || (
       visibleSuggestionLabels.length >= result.visibleCardCount
@@ -268,7 +268,7 @@ export function assessRendererVerification(renderer, nativeWindow, expected) {
   result.softNotes = {
     projectButtonOptional: !result.projectButton?.visible,
     composerOptionalOnNonTaskRoutes: !result.composer?.visible,
-    suggestionCardsOptional: result.homeRoute && result.visibleCardCount === 0,
+    suggestionCardsOptional: result.homePresent && result.visibleCardCount === 0,
   };
   return result;
 }

--- a/macos/tests/window-readiness.test.mjs
+++ b/macos/tests/window-readiness.test.mjs
@@ -56,6 +56,29 @@ const baseRenderer = {
 assert.equal(readyNativeWindow.status, "ready");
 assert.equal(assessRendererVerification(baseRenderer, readyNativeWindow, exactPayload).pass, true);
 
+// Codex can retain a home-icon probe while the canonical home container has
+// already disappeared during a thread-route transition. The auxiliary signal
+// is diagnostic only: an otherwise healthy thread renderer must not be forced
+// to expose a home hero that cannot exist on that route.
+const threadWithStaleHomeSignal = { ...baseRenderer, homeRoute: true };
+assert.equal(
+  assessRendererVerification(threadWithStaleHomeSignal, readyNativeWindow, exactPayload).pass,
+  true,
+  "A thread renderer with no canonical home container must not require a home hero.",
+);
+
+const actualHomeWithoutHero = {
+  ...baseRenderer,
+  scope: { level: "L1", baseState: "home" },
+  homeRoute: true,
+  homePresent: true,
+};
+assert.equal(
+  assessRendererVerification(actualHomeWithoutHero, readyNativeWindow, exactPayload).pass,
+  false,
+  "A canonical home route must still expose its visible hero.",
+);
+
 const windowCalls = [];
 assert.equal((await inspectNativeWindow({
   target: { id: "target-main" },


### PR DESCRIPTION
## Summary / 摘要

- 修复 macOS 验证器将会话页中的残留 home-icon 辅助信号误判为首页的问题。
- 仅在规范首页容器实际存在时要求 Hero；真实首页缺少 Hero 仍然 fail closed。
- 新增实机复现 tuple 的回归测试，并记录本地部署与验证事实。

## Type / 类型

- [x] Bug fix / 缺陷修复
- [x] Docs / 文档

## Platform / 平台

- [x] macOS

## Self-check / 自测

- [x] Relevant targeted regression: `node macos/tests/window-readiness.test.mjs`
- [x] Static syntax: `node --check macos/scripts/injector.mjs`
- [x] Shared runtime sync: `node tools/sync-runtime-assets.mjs --check`
- [x] Live verify: explicit-frontmost real Codex returned `pass: true`
- [ ] `macos/tests/run-tests.sh` passed — not fully available on this host; see Notes.

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环

## Notes / 补充

Observed failing renderer state: `scope.baseState=thread`, `homeRoute=true`, `homePresent=false`, `hero=null`. Before the fix, the auxiliary `homeRoute` value forced a nonexistent home Hero and stopped an otherwise valid injection.

The final real Codex verification passed exact Gothic Void Crusade ID/revision, installed CSS, visible shell/sidebar/composer, viewport, no horizontal overflow, and the documented `-32000` Browser window fallback.

The full macOS suite reached and passed syntax, selector, shared-runtime sync, payload, injector and Safe CSS checks before unrelated host gates: the installed ChatGPT runtime failed shell-importer signature validation, and the local Swift 6.3.3 compiler cannot build the Command Line Tools SDK Swift 6.3.2 module cache. Please use GitHub Actions macOS CI as the full platform gate.

No tag, Release, version bump, or installer asset is included in this PR.