### PR TITLE
fix(macos): verify thread routes without a home hero

### DIFF
--- a/macos/scripts/injector.mjs
+++ b/macos/scripts/injector.mjs
@@ -244,7 +244,7 @@ export function assessRendererVerification(renderer, nativeWindow, expected) {
     && (!expected.expectedRevision || result.revision === expected.expectedRevision);
   const visibleSuggestionLabels = Array.isArray(result.suggestionLabels)
     ? result.suggestionLabels.filter((item) => item?.visible) : [];
-  const homePass = !result.homeRoute || (
+  const homePass = !result.homePresent || (
     result.homePresent && result.hero?.visible && result.hero.width >= 280
     && result.hero.height >= 120 && (result.visibleCardCount === 0 || (
       visibleSuggestionLabels.length >= result.visibleCardCount
@@ -268,7 +268,7 @@ export function assessRendererVerification(renderer, nativeWindow, expected) {
   result.softNotes = {
     projectButtonOptional: !result.projectButton?.visible,
     composerOptionalOnNonTaskRoutes: !result.composer?.visible,
-    suggestionCardsOptional: result.homeRoute && result.visibleCardCount === 0,
+    suggestionCardsOptional: result.homePresent && result.visibleCardCount === 0,
   };
   return result;
 }

--- a/macos/tests/window-readiness.test.mjs
+++ b/macos/tests/window-readiness.test.mjs
@@ -56,6 +56,29 @@ const baseRenderer = {
 assert.equal(readyNativeWindow.status, "ready");
 assert.equal(assessRendererVerification(baseRenderer, readyNativeWindow, exactPayload).pass, true);
 
+// Codex can retain a home-icon probe while the canonical home container has
+// already disappeared during a thread-route transition. The auxiliary signal
+// is diagnostic only: an otherwise healthy thread renderer must not be forced
+// to expose a home hero that cannot exist on that route.
+const threadWithStaleHomeSignal = { ...baseRenderer, homeRoute: true };
+assert.equal(
+  assessRendererVerification(threadWithStaleHomeSignal, readyNativeWindow, exactPayload).pass,
+  true,
+  "A thread renderer with no canonical home container must not require a home hero.",
+);
+
+const actualHomeWithoutHero = {
+  ...baseRenderer,
+  scope: { level: "L1", baseState: "home" },
+  homeRoute: true,
+  homePresent: true,
+};
+assert.equal(
+  assessRendererVerification(actualHomeWithoutHero, readyNativeWindow, exactPayload).pass,
+  false,
+  "A canonical home route must still expose its visible hero.",
+);
+
 const windowCalls = [];
 assert.equal((await inspectNativeWindow({
   target: { id: "target-main" },


### PR DESCRIPTION
## Summary / 摘要

  - 修复 macOS 验证器将 thread 页误判为首页的问题。
  - 仅当规范首页容器存在时要求 Hero；真实首页缺 Hero 仍会 fail closed。
  - 新增会话页残留 home 信号的回归测试。

  ## Verification / 验证

  - node macos/tests/window-readiness.test.mjs
  - node --check macos/scripts/injector.mjs
  - node tools/sync-runtime-assets.mjs --check
  - git diff --check

  ## Security / 安全

  - 不修改官方 Codex.app、app.asar 或签名。
  - CDP 保持仅本机回环。
  - 不改写 API Key 或 Base URL。