### PR TITLE
[codex] fix Windows one-click apply handoff

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,19 +1,5 @@
 # Task Progress
 
-Updated: 2026-07-30 18:00 CST (Asia/Shanghai)
-
-## PR #317 Real Windows Community Apply Follow-up
-
-- [verified] `pr-317` is at remote PR head `71c3ca9`; all four PR CI jobs pass.
-- [verified] Real `dreamskin://apply/?version=ver_6fac938806981a73cb51` handoff reaches the native confirmation, fixed production API, strict ZIP import, and rollback. The imported `axdlee / Quiet Paper` payload also passes exact live renderer verification when applied directly (`themeId`, revision, visible home/shell/sidebar/hero/cards, text colors, and overflow all pass).
-- [root cause] The transaction failed before target verification because Windows reported `The recorded Dream Skin injector did not stop` after its five-second PID-based wait. The generic transaction error incorrectly surfaced this as a visible-verification failure. The immediately following rollback start stopped the same watcher and visibly verified the prior theme.
-- [verified] The identity-validated `Process` object wait fix passes the full Windows suite, a new real watcher-process shutdown fixture, installer static checks, Setup.exe build/install, and installed standalone Verify. The rebuilt package SHA-256 is `FF7724751A3C9EB4046590CF869AE15CE41F3441D5620B28049EB6C952B375ED`.
-- [root cause] The next real transaction applied and visibly verified `Quiet Paper`, exited the handler, and cleaned its work directory, but the success dialog failed: Windows PowerShell 5.1 treats curly double quotes as string delimiters, so `"“$name”..."` bound an empty value to `Message`. The active target remained correctly applied.
-- [complete] The Windows success text now uses PowerShell-safe `「」` brackets and has an executable PowerShell 5.1 regression. Rebuilt Setup.exe SHA-256: `2489092FFBA60ABC119A1612A3076773DBEF5910EFD8BC4ECB64840A6C710B76`.
-- [verified] Final real registered-protocol apply of `ver_6fac938806981a73cb51` completed in 38.9 seconds: native confirmation, production metadata/download, strict duplicate import, active-theme transaction, exact visible renderer verification, native success message, zero remaining handler processes, and zero `.community-apply-*` directories. The target screenshot SHA-256 is `42472EBE7E7B0A73F600C159E074D547B163604AA1857A5E70F91898853A7C5E`.
-- [verified] The complete Windows suite and installer static suite pass after both fixes. The pre-test `preset-gothic-void-crusade` theme was restored and standalone Verify passes.
-- [gap] The in-app Browser plugin reported no available browser instances, so this final run started from the installed `dreamskin://` registration rather than clicking the DreamSkin.cc web button. Earlier site-to-protocol behavior was not treated as newly reverified here.
-
 Updated: 2026-07-25 08:31 HKT (Asia/Hong_Kong)
 
 ## v1.5.1 Version Release (2026-07-25 08:28 HKT)

--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,5 +1,19 @@
 # Task Progress
 
+Updated: 2026-07-30 18:00 CST (Asia/Shanghai)
+
+## PR #317 Real Windows Community Apply Follow-up
+
+- [verified] `pr-317` is at remote PR head `71c3ca9`; all four PR CI jobs pass.
+- [verified] Real `dreamskin://apply/?version=ver_6fac938806981a73cb51` handoff reaches the native confirmation, fixed production API, strict ZIP import, and rollback. The imported `axdlee / Quiet Paper` payload also passes exact live renderer verification when applied directly (`themeId`, revision, visible home/shell/sidebar/hero/cards, text colors, and overflow all pass).
+- [root cause] The transaction failed before target verification because Windows reported `The recorded Dream Skin injector did not stop` after its five-second PID-based wait. The generic transaction error incorrectly surfaced this as a visible-verification failure. The immediately following rollback start stopped the same watcher and visibly verified the prior theme.
+- [verified] The identity-validated `Process` object wait fix passes the full Windows suite, a new real watcher-process shutdown fixture, installer static checks, Setup.exe build/install, and installed standalone Verify. The rebuilt package SHA-256 is `FF7724751A3C9EB4046590CF869AE15CE41F3441D5620B28049EB6C952B375ED`.
+- [root cause] The next real transaction applied and visibly verified `Quiet Paper`, exited the handler, and cleaned its work directory, but the success dialog failed: Windows PowerShell 5.1 treats curly double quotes as string delimiters, so `"“$name”..."` bound an empty value to `Message`. The active target remained correctly applied.
+- [complete] The Windows success text now uses PowerShell-safe `「」` brackets and has an executable PowerShell 5.1 regression. Rebuilt Setup.exe SHA-256: `2489092FFBA60ABC119A1612A3076773DBEF5910EFD8BC4ECB64840A6C710B76`.
+- [verified] Final real registered-protocol apply of `ver_6fac938806981a73cb51` completed in 38.9 seconds: native confirmation, production metadata/download, strict duplicate import, active-theme transaction, exact visible renderer verification, native success message, zero remaining handler processes, and zero `.community-apply-*` directories. The target screenshot SHA-256 is `42472EBE7E7B0A73F600C159E074D547B163604AA1857A5E70F91898853A7C5E`.
+- [verified] The complete Windows suite and installer static suite pass after both fixes. The pre-test `preset-gothic-void-crusade` theme was restored and standalone Verify passes.
+- [gap] The in-app Browser plugin reported no available browser instances, so this final run started from the installed `dreamskin://` registration rather than clicking the DreamSkin.cc web button. Earlier site-to-protocol behavior was not treated as newly reverified here.
+
 Updated: 2026-07-25 08:31 HKT (Asia/Hong_Kong)
 
 ## v1.5.1 Version Release (2026-07-25 08:28 HKT)

--- a/windows/installer/codex-dream-skin.iss
+++ b/windows/installer/codex-dream-skin.iss
@@ -12,6 +12,7 @@
 #define AppPublisher "Codex Dream Skin contributors"
 #define AppUrl "https://dreamskin.cc"
 #define PowerShellPath "{sysnative}\WindowsPowerShell\v1.0\powershell.exe"
+#define PersistentPowerShellPath "{win}\System32\WindowsPowerShell\v1.0\powershell.exe"
 
 [Setup]
 AppId={{DCCDAF1A-9ACD-4AAB-B55B-DF17EB2CDA2E}
@@ -72,14 +73,14 @@ Source: "{#StageRoot}\NOTICE.md"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#StageRoot}\payload\*"; DestDir: "{app}\payload"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{group}\Codex Dream Skin"; Filename: "{#PowerShellPath}"; Parameters: "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy RemoteSigned -File ""{app}\setup-bootstrap.ps1"" -LaunchTray"; WorkingDir: "{app}"; IconFilename: "{app}\payload\assets\codex-dream-skin.ico"
-Name: "{userstartup}\Codex Dream Skin"; Filename: "{#PowerShellPath}"; Parameters: "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy RemoteSigned -File ""{app}\setup-bootstrap.ps1"" -LaunchTray"; WorkingDir: "{app}"; IconFilename: "{app}\payload\assets\codex-dream-skin.ico"; Tasks: startup
+Name: "{group}\Codex Dream Skin"; Filename: "{#PersistentPowerShellPath}"; Parameters: "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy RemoteSigned -File ""{app}\setup-bootstrap.ps1"" -LaunchTray"; WorkingDir: "{app}"; IconFilename: "{app}\payload\assets\codex-dream-skin.ico"
+Name: "{userstartup}\Codex Dream Skin"; Filename: "{#PersistentPowerShellPath}"; Parameters: "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy RemoteSigned -File ""{app}\setup-bootstrap.ps1"" -LaunchTray"; WorkingDir: "{app}"; IconFilename: "{app}\payload\assets\codex-dream-skin.ico"; Tasks: startup
 
 [Registry]
 Root: HKCU; Subkey: "Software\Classes\dreamskin"; ValueType: string; ValueName: ""; ValueData: "URL:DreamSkin Protocol"; Flags: uninsdeletekey
 Root: HKCU; Subkey: "Software\Classes\dreamskin"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
 Root: HKCU; Subkey: "Software\Classes\dreamskin\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\payload\assets\codex-dream-skin.ico"
-Root: HKCU; Subkey: "Software\Classes\dreamskin\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{#PowerShellPath}"" -NoProfile -STA -WindowStyle Hidden -ExecutionPolicy RemoteSigned -File ""{localappdata}\CodexDreamSkin\engine\scripts\apply-community-theme.ps1"" ""%1"""
+Root: HKCU; Subkey: "Software\Classes\dreamskin\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{#PersistentPowerShellPath}"" -NoProfile -STA -WindowStyle Hidden -ExecutionPolicy RemoteSigned -File ""{localappdata}\CodexDreamSkin\engine\scripts\apply-community-theme.ps1"" ""%1"""
 
 [Run]
 Filename: "{#PowerShellPath}"; Parameters: "-NoProfile -STA -WindowStyle Hidden -ExecutionPolicy RemoteSigned -File ""{app}\setup-bootstrap.ps1"" -LaunchTray"; WorkingDir: "{app}"; Description: "Launch Codex Dream Skin"; Flags: nowait postinstall skipifsilent

--- a/windows/scripts/apply-community-theme.ps1
+++ b/windows/scripts/apply-community-theme.ps1
@@ -308,7 +308,12 @@ function Invoke-DreamSkinCommunityStartAndVerify {
     ' -RequireUnpaused -OperationLockTimeoutMilliseconds ' +
     "$OperationLockTimeoutMilliseconds"
   $startProcess = Start-Process -FilePath $powershell -ArgumentList $argumentLine `
-    -WindowStyle Hidden -Wait -PassThru
+    -WindowStyle Hidden -PassThru
+  if (-not $startProcess.WaitForExit($OperationLockTimeoutMilliseconds)) {
+    try { Stop-Process -InputObject $startProcess -Force -ErrorAction SilentlyContinue } catch {}
+    [void]$startProcess.WaitForExit(15000)
+    throw "Dream Skin start verification did not finish within $OperationLockTimeoutMilliseconds ms."
+  }
   if ($startProcess.ExitCode -ne 0) {
     throw "Dream Skin could not start and visibly verify the active theme (exit code $($startProcess.ExitCode))."
   }

--- a/windows/scripts/apply-community-theme.ps1
+++ b/windows/scripts/apply-community-theme.ps1
@@ -29,6 +29,15 @@ function Show-DreamSkinCommunityMessage {
   )
 }
 
+function Format-DreamSkinCommunitySuccessMessage {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Name
+  )
+  return "主题「$Name」已通过下载、SHA-256、主题包与 Safe CSS 校验，并已应用到 Codex。"
+}
+
 function Confirm-DreamSkinCommunityApply {
   param([Parameter(Mandatory = $true)][object]$Metadata)
   Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
@@ -768,7 +777,7 @@ try {
   $result = Invoke-DreamSkinCommunityApply -ApplyUri $Uri
   if (-not $result.Canceled) {
     Show-DreamSkinCommunityMessage `
-      -Message "“$($result.Name)”已通过下载、SHA-256、主题包与 Safe CSS 校验，并已应用到 Codex。"
+      -Message (Format-DreamSkinCommunitySuccessMessage -Name $result.Name)
   }
   exit 0
 } catch {

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -1165,3 +1165,16 @@ function Confirm-DreamSkinRestart {
   $shell = New-Object -ComObject WScript.Shell
   return $shell.Popup($Message, 0, 'Codex Dream Skin', 52) -eq 6
 }
+
+function Invoke-DreamSkinCodexWindowActivation {
+  param([Parameter(Mandatory = $true)][object]$Codex)
+  $processes = @(Get-DreamSkinCodexProcesses -Codex $Codex)
+  if ($processes.Count -eq 0) { return $false }
+  $shell = New-Object -ComObject WScript.Shell
+  foreach ($process in $processes) {
+    try {
+      if ($shell.AppActivate([int]$process.ProcessId)) { return $true }
+    } catch {}
+  }
+  return $false
+}

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -1052,8 +1052,13 @@ function Stop-DreamSkinRecordedInjector {
   param([AllowNull()][object]$State)
   if ($null -eq $State -or -not $State.injectorPid) { return $true }
   $processId = [int]$State.injectorPid
+  $processHandle = Get-Process -Id $processId -ErrorAction SilentlyContinue
+  if (-not $processHandle) { return $true }
   $process = Get-CimInstance Win32_Process -Filter "ProcessId = $processId" -ErrorAction SilentlyContinue
-  if (-not $process) { return $true }
+  if (-not $process) {
+    if ($processHandle.HasExited) { return $true }
+    throw "The recorded injector PID $processId is running, but its identity cannot be inspected. State was preserved."
+  }
 
   $expectedInjector = if ($State.injectorPath) {
     "$($State.injectorPath)"
@@ -1083,7 +1088,12 @@ function Stop-DreamSkinRecordedInjector {
     $browserPattern = '(?:^|\s)(?i:--browser-id)(?:=|\s+)' + [regex]::Escape("$($State.browserId)") + '(?=$|\s)'
     $injectorMatches = $injectorMatches -and [regex]::IsMatch($commandLine, $browserPattern)
   }
-  $startedAt = Get-DreamSkinProcessStartedAt -ProcessId $processId
+  try {
+    $startedAt = $processHandle.StartTime.ToUniversalTime().ToString('o')
+  } catch {
+    if ($processHandle.HasExited) { return $true }
+    throw "The recorded injector PID $processId is running, but its start time cannot be inspected. State was preserved."
+  }
   $startMatches = -not $State.injectorStartedAt -or $startedAt -eq "$($State.injectorStartedAt)"
   $identityMatches = [bool]($isNodeExecutable -and $nodeMatches -and $injectorMatches -and $startMatches)
 
@@ -1091,9 +1101,9 @@ function Stop-DreamSkinRecordedInjector {
     throw "The recorded injector PID $processId is running, but its visible identity does not match the saved Dream Skin process. State was preserved."
   }
 
-  Stop-Process -Id $processId -Force -ErrorAction Stop
-  try { Wait-Process -Id $processId -Timeout 5 -ErrorAction Stop } catch {}
-  if (Get-Process -Id $processId -ErrorAction SilentlyContinue) {
+  Stop-Process -InputObject $processHandle -Force -ErrorAction Stop
+  [void]$processHandle.WaitForExit(15000)
+  if (-not $processHandle.HasExited) {
     throw "The recorded Dream Skin injector did not stop: PID $processId"
   }
   return $true

--- a/windows/scripts/injector.mjs
+++ b/windows/scripts/injector.mjs
@@ -535,24 +535,17 @@ export async function loadTheme(themeDir) {
     throw new Error("Theme image cannot escape through a link or junction");
   }
   const art = raw.art && typeof raw.art === "object" && !Array.isArray(raw.art) ? raw.art : {};
-  const palette = raw.palette && typeof raw.palette === "object" && !Array.isArray(raw.palette)
-    ? raw.palette : {};
   const rawColors = raw.colors && typeof raw.colors === "object" && !Array.isArray(raw.colors)
     ? raw.colors : null;
   const colorKeys = [
     "background", "panel", "panelAlt", "accent", "accentAlt", "secondary",
     "highlight", "text", "muted", "line",
   ];
-  const paletteAccent = typeof palette.accent === "string" && palette.accent.trim()
-    ? palette.accent.trim() : "";
-  if (paletteAccent && !/^(?:#[\da-f]{3,8}|(?:rgb|hsl|oklch|oklab)\([^;{}]{1,96}\))$/i.test(paletteAccent)) {
-    throw new Error("palette.accent is not a supported CSS color");
-  }
   const colors = {
     background: normalizeThemeColor(rawColors?.background, "#071116"),
     panel: normalizeThemeColor(rawColors?.panel, "#0b1a20"),
     panelAlt: normalizeThemeColor(rawColors?.panelAlt, "#10272c"),
-    accent: normalizeThemeColor(rawColors?.accent, normalizeThemeColor(paletteAccent, "#7cff46")),
+    accent: normalizeThemeColor(rawColors?.accent, "#7cff46"),
     accentAlt: normalizeThemeColor(rawColors?.accentAlt, "#b8ff3d"),
     secondary: normalizeThemeColor(rawColors?.secondary, "#36d7e8"),
     highlight: normalizeThemeColor(rawColors?.highlight, "#642a8c"),
@@ -577,14 +570,10 @@ export async function loadTheme(themeDir) {
       safeArea: normalizedChoice(art.safeArea, "art.safeArea", THEME_CHOICES.safeArea, "auto"),
       taskMode: normalizedChoice(art.taskMode, "art.taskMode", THEME_CHOICES.taskMode, "auto"),
     },
-    colorMode: rawColors ? "explicit" : (paletteAccent ? "explicit" : "auto"),
-    explicitColorKeys: rawColors
-      ? colorKeys.filter((key) => Object.hasOwn(rawColors, key))
-      : (paletteAccent ? ["accent"] : []),
+    colorMode: rawColors ? "explicit" : "auto",
+    explicitColorKeys: rawColors ? colorKeys.filter((key) => Object.hasOwn(rawColors, key)) : [],
     colors,
-    palette: {},
   };
-  if (paletteAccent) theme.palette.accent = paletteAccent;
   const [themeStat, imageStat, safeCss] = await Promise.all([
     fs.stat(themePath),
     fs.stat(realImagePath),
@@ -1740,6 +1729,10 @@ if (path.resolve(process.argv[1] || "") === path.resolve(scriptPath)) {
       payloadBytes: Buffer.byteLength(loaded.payload),
       themeId: loaded.theme.id,
       appearance: loaded.theme.appearance,
+      colorMode: loaded.theme.colorMode,
+      explicitColorKeys: loaded.theme.explicitColorKeys,
+      hasColors: !!loaded.theme.colors && typeof loaded.theme.colors === "object",
+      hasPalette: Object.hasOwn(loaded.theme, "palette"),
       art: loaded.theme.art,
       artMetadata: loaded.theme.artMetadata ?? null,
       safeCssStatus: loaded.safeCssStatus,

--- a/windows/scripts/injector.mjs
+++ b/windows/scripts/injector.mjs
@@ -1142,10 +1142,27 @@ export async function verifySession(
     // already-resolved semantic home container so a healthy home session is
     // not rejected solely because the stricter home-icon selector is late.
     const home = document.querySelector(${selectorLiteral("home-route")}) ?? homeRoute;
+    const suggestions = home?.querySelector(${selectorLiteral("home-suggestions")}) ?? null;
+    const cardButtons = suggestions ? [...suggestions.querySelectorAll('button')] : [];
+    const cards = cardButtons.map(box);
+    const visibleCards = cards.filter((item) => item?.visible);
+    const suggestionLabels = cardButtons.flatMap((button) => {
+      const expectedColor = getComputedStyle(button).color;
+      return [...button.querySelectorAll('*')]
+        .filter((node) => [...node.childNodes].some((child) =>
+          child.nodeType === 3 && child.textContent.trim()))
+        .map((node) => ({
+          ...box(node),
+          text: String(node.textContent ?? "").trim().slice(0, 80),
+          color: getComputedStyle(node).color,
+          expectedColor,
+        }));
+    });
+    const visibleSuggestionLabels = suggestionLabels.filter((item) => item?.visible);
+    const suggestionLabelColorsMatch = visibleSuggestionLabels.every((item) =>
+      item.color === item.expectedColor);
     const settingsAnchor = document.querySelector(${selectorLiteral("appearance-radio")}) ||
       document.querySelector(${stableTestidLiteral("theme-preview")});
-    const suggestions = home?.querySelector(${selectorLiteral("home-suggestions")}) ?? null;
-    const cards = suggestions ? [...suggestions.querySelectorAll('button')].map(box) : [];
     const runtime = window.__CODEX_DREAM_SKIN_STATE__;
     const adopted = runtime?.styleMode === 'adopted' &&
       [...document.adoptedStyleSheets].includes(runtime.styleSheet);
@@ -1187,6 +1204,9 @@ export async function verifySession(
       settingsAnchor: box(settingsAnchor),
       hero,
       cards,
+      visibleCardCount: visibleCards.length,
+      suggestionLabels,
+      suggestionLabelColorsMatch,
       composer: box(document.querySelector(${selectorLiteral("composer-chrome")})),
       shell: box(document.querySelector(${selectorLiteral("shell-main")})),
       sidebar: box(document.querySelector(${selectorLiteral("left-panel")})),
@@ -1227,12 +1247,18 @@ export async function verifySession(
       windowPass, documentPass, viewportPass, structurePass,
       nativeWindowPass, fallbackWindowPass,
     };
+    const homePass = !result.homePresent || (
+      Boolean(result.homeSurface?.visible && result.hero?.visible) &&
+      result.hero.width >= 280 && result.hero.height >= 120 &&
+      (!result.suggestionsPresent || result.visibleCardCount === 0 || (
+        result.suggestionLabels.filter((item) => item?.visible).length >= result.visibleCardCount &&
+        result.suggestionLabelColorsMatch
+      ))
+    );
     result.pass = result.installed && result.version === result.expectedVersion &&
       result.stylePresent && result.businessClassPollution === 0 && windowPass &&
       documentPass && viewportPass && structurePass &&
-      payloadPass &&
-      (!result.homePresent || (Boolean(result.homeSurface?.visible && result.hero?.visible) &&
-        (!result.suggestionsPresent || (result.cards.length >= 2 && result.cards.length <= 4))));
+      payloadPass && homePass;
     return result;
   })()`);
 }

--- a/windows/scripts/start-dream-skin.ps1
+++ b/windows/scripts/start-dream-skin.ps1
@@ -281,6 +281,7 @@ try {
     # and a single early miss used to tear the whole startup down.  The
     # watcher keeps applying in the background, so retry until a deadline.
     $verifyDeadline = (Get-Date).AddSeconds(90)
+    $forceInjectedAfterVerifyFailure = $false
     while ($true) {
       $verify = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
         $Injector, '--verify', '--port', "$Port",
@@ -303,6 +304,18 @@ try {
           [bool]$readiness.structurePass
       } catch {
         $skinLooksRendered = $false
+      }
+      if (-not $forceInjectedAfterVerifyFailure) {
+        $forceInjectedAfterVerifyFailure = $true
+        try { [void](Invoke-DreamSkinCodexWindowActivation -Codex $codex) } catch {}
+        $once = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
+          $Injector, '--once', '--port', "$Port",
+          '--browser-id', $cdpIdentity.BrowserId, '--theme-dir', $themePaths.Active,
+          '--timeout-ms', '15000')
+        Write-DreamSkinUtf8FileAtomically -Path $VerifyPath -Content (
+          (($verify.Output + $once.Output) -join "`r`n") + "`r`n"
+        )
+        if ($once.ExitCode -eq 0) { break }
       }
       if ($daemon.HasExited) { throw "The injector exited during startup. See $StderrPath" }
       if ((Get-Date) -ge $verifyDeadline) { throw "Dream Skin verification failed. See $VerifyPath" }

--- a/windows/scripts/theme-windows.ps1
+++ b/windows/scripts/theme-windows.ps1
@@ -378,8 +378,26 @@ function Read-DreamSkinTheme {
     Directory = $directory
     ThemePath = $themePath
     ImagePath = $imagePath
-    Theme = $theme
+    Theme = Normalize-DreamSkinThemeContract -Theme $theme
   }
+}
+
+function Normalize-DreamSkinThemeContract {
+  param([Parameter(Mandatory = $true)][object]$Theme)
+  if ($null -eq $Theme -or $Theme -is [string] -or $Theme -is [array]) {
+    throw 'Theme contract must be a JSON object.'
+  }
+  if (-not $Theme.PSObject.Properties['id'] -or -not $Theme.PSObject.Properties['id'].Value) {
+    $Theme | Add-Member -NotePropertyName id -NotePropertyValue 'custom' -Force
+  }
+  if (-not $Theme.PSObject.Properties['appearance'] -or -not $Theme.PSObject.Properties['appearance'].Value) {
+    $Theme | Add-Member -NotePropertyName appearance -NotePropertyValue 'auto' -Force
+  }
+  if (-not $Theme.PSObject.Properties['art'] -or -not $Theme.PSObject.Properties['art'].Value) {
+    $Theme | Add-Member -NotePropertyName art -NotePropertyValue `
+      ([pscustomobject]@{ focusX = $null; focusY = $null; safeArea = 'auto'; taskMode = 'auto' }) -Force
+  }
+  return $Theme
 }
 
 function Write-DreamSkinTheme {
@@ -390,6 +408,7 @@ function Write-DreamSkinTheme {
   Assert-DreamSkinNoReparseComponents -Path $ThemeDirectory
   New-Item -ItemType Directory -Force -Path $ThemeDirectory | Out-Null
   Assert-DreamSkinNoReparseComponents -Path $ThemeDirectory
+  $Theme = Normalize-DreamSkinThemeContract -Theme $Theme
   $json = $Theme | ConvertTo-Json -Depth 8
   $themePath = Join-Path $ThemeDirectory 'theme.json'
   Assert-DreamSkinNoReparseComponents -Path $themePath
@@ -538,7 +557,6 @@ function Set-DreamSkinActiveTheme {
       name = '自定义主题'
       appearance = 'auto'
       art = [pscustomobject]@{ focusX = $null; focusY = $null; safeArea = 'auto'; taskMode = 'auto' }
-      palette = [pscustomobject]@{}
     }
   }
   $imageName = New-DreamSkinThemeImageName -Extension $extension
@@ -564,15 +582,7 @@ function Set-DreamSkinActiveTheme {
     Assert-DreamSkinImageFile -Path $target
     $Theme | Add-Member -NotePropertyName image -NotePropertyValue $imageName -Force
     if ($Name) { $Theme | Add-Member -NotePropertyName name -NotePropertyValue $Name -Force }
-    if (-not $Theme.id) { $Theme | Add-Member -NotePropertyName id -NotePropertyValue 'custom' -Force }
-    if (-not $Theme.appearance) { $Theme | Add-Member -NotePropertyName appearance -NotePropertyValue 'auto' -Force }
-    if (-not $Theme.art) {
-      $Theme | Add-Member -NotePropertyName art -NotePropertyValue `
-        ([pscustomobject]@{ focusX = $null; focusY = $null; safeArea = 'auto'; taskMode = 'auto' }) -Force
-    }
-    if (-not $Theme.palette) {
-      $Theme | Add-Member -NotePropertyName palette -NotePropertyValue ([pscustomobject]@{}) -Force
-    }
+    $Theme = Normalize-DreamSkinThemeContract -Theme $Theme
     $activeCss = Join-Path $paths.Active 'theme.css'
     Assert-DreamSkinNoReparseComponents -Path $activeCss
     if ($temporaryCss) {
@@ -715,19 +725,7 @@ function Get-DreamSkinThemeRuntimeContentFingerprint {
   $loaded = Read-DreamSkinTheme -ThemeDirectory $ThemeDirectory -SkipImageMetadata
   $runtimeTheme = $loaded.Theme | ConvertTo-Json -Depth 8 | ConvertFrom-Json
   $runtimeTheme.image = '<runtime-image>'
-  if (-not $runtimeTheme.id) {
-    $runtimeTheme | Add-Member -NotePropertyName id -NotePropertyValue 'custom' -Force
-  }
-  if (-not $runtimeTheme.appearance) {
-    $runtimeTheme | Add-Member -NotePropertyName appearance -NotePropertyValue 'auto' -Force
-  }
-  if (-not $runtimeTheme.art) {
-    $runtimeTheme | Add-Member -NotePropertyName art -NotePropertyValue `
-      ([pscustomobject]@{ focusX = $null; focusY = $null; safeArea = 'auto'; taskMode = 'auto' }) -Force
-  }
-  if (-not $runtimeTheme.palette) {
-    $runtimeTheme | Add-Member -NotePropertyName palette -NotePropertyValue ([pscustomobject]@{}) -Force
-  }
+  $runtimeTheme = Normalize-DreamSkinThemeContract -Theme $runtimeTheme
   $canonicalTheme = ConvertTo-DreamSkinCanonicalJsonValue -Value $runtimeTheme
   $themeBytes = [System.Text.Encoding]::UTF8.GetBytes(
     ($canonicalTheme | ConvertTo-Json -Depth 8 -Compress)

--- a/windows/scripts/theme-windows.ps1
+++ b/windows/scripts/theme-windows.ps1
@@ -22,7 +22,7 @@ function Resolve-DreamSkinCommunityApplyUri {
   param([Parameter(Mandatory = $true)][string]$Uri)
   $match = [regex]::Match(
     $Uri,
-    '\Adreamskin://apply\?version=(ver_[a-z0-9]{8,64})\z',
+    '\Adreamskin://apply/?\?version=(ver_[a-z0-9]{8,64})\z',
     [System.Text.RegularExpressions.RegexOptions]::CultureInvariant
   )
   if (-not $match.Success) {

--- a/windows/scripts/verify-dream-skin.ps1
+++ b/windows/scripts/verify-dream-skin.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = 'Stop'
 $PortExplicit = $PSBoundParameters.ContainsKey('Port')
 $injector = Join-Path $PSScriptRoot 'injector.mjs'
 . (Join-Path $PSScriptRoot 'common-windows.ps1')
+. (Join-Path $PSScriptRoot 'theme-windows.ps1')
 
 $operationLock = Enter-DreamSkinOperationLock
 $verifyExitCode = 1

--- a/windows/tests/community-theme-link.tests.ps1
+++ b/windows/tests/community-theme-link.tests.ps1
@@ -242,6 +242,8 @@ foreach ($requiredSafety in @(
   'Set-DreamSkinActiveThemeFromSnapshot',
   'Get-DreamSkinThemeRuntimeContentFingerprint',
   'Invoke-DreamSkinCommunityStartAndVerify',
+  'WaitForExit($OperationLockTimeoutMilliseconds)',
+  'Dream Skin start verification did not finish within',
   'Move-DreamSkinCommunityRollbackSnapshot',
   "['DreamSkinRecovery']",
   "Join-Path `$PSScriptRoot 'start-dream-skin.ps1'",

--- a/windows/tests/community-theme-link.tests.ps1
+++ b/windows/tests/community-theme-link.tests.ps1
@@ -21,6 +21,11 @@ if ($versionId -cne 'ver_1234abcd' -or
   -not (Test-DreamSkinCommunityVersionId -Value $versionId)) {
   throw 'The canonical community theme link did not resolve its version id.'
 }
+$normalizedUri = 'dreamskin://apply/?version=ver_1234abcd'
+$normalizedVersionId = Resolve-DreamSkinCommunityApplyUri -Uri $normalizedUri
+if ($normalizedVersionId -cne 'ver_1234abcd') {
+  throw 'The browser-normalized community theme link did not resolve its version id.'
+}
 $endpoints = Get-DreamSkinCommunityThemeEndpoints -VersionId $versionId
 if ($endpoints.MetadataUri -cne 'https://api.dreamskin.cc/v1/themes/ver_1234abcd' -or
   $endpoints.DownloadUri -cne 'https://api.dreamskin.cc/v1/themes/ver_1234abcd/download') {
@@ -32,6 +37,8 @@ foreach ($invalidUri in @(
   'dreamskin://apply?url=https://example.com/theme.zip',
   'dreamskin://apply?version=ver_short',
   'dreamskin://apply?version=ver_1234abcd&extra=1',
+  'dreamskin://apply/?version=ver_1234abcd&extra=1',
+  'dreamskin://apply//?version=ver_1234abcd',
   'dreamskin://apply/path?version=ver_1234abcd',
   'dreamskin://apply?version=ver_1234abcd#fragment',
   'dreamskin://user@apply?version=ver_1234abcd',

--- a/windows/tests/community-theme-link.tests.ps1
+++ b/windows/tests/community-theme-link.tests.ps1
@@ -204,8 +204,22 @@ $requestHelperAst = $applyAst.Find({
   $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
     $node.Name -ceq 'New-DreamSkinCommunityHttpRequest'
 }, $true)
-if ($null -eq $requestHelperAst) { throw 'The fixed-origin community request helper is missing.' }
+$successMessageHelperAst = $applyAst.Find({
+  param($node)
+  $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $node.Name -ceq 'Format-DreamSkinCommunitySuccessMessage'
+}, $true)
+if ($null -eq $requestHelperAst -or $null -eq $successMessageHelperAst) {
+  throw 'The fixed-origin request or success-message helper is missing.'
+}
 Invoke-Expression $requestHelperAst.Extent.Text
+Invoke-Expression $successMessageHelperAst.Extent.Text
+$successMessage = Format-DreamSkinCommunitySuccessMessage -Name 'Paper'
+if (-not $successMessage -or $successMessage -notmatch 'Paper' -or
+  $successMessage -notmatch 'SHA-256' -or $successMessage -notmatch 'Safe CSS' -or
+  $successMessage -notmatch 'Codex') {
+  throw 'The Windows PowerShell 5.1 community success message is empty or malformed.'
+}
 $request = New-DreamSkinCommunityHttpRequest `
   -RequestUri 'https://api.dreamskin.cc/v1/themes/ver_1234abcd' -Accept 'application/json'
 if ($request.AllowAutoRedirect -or
@@ -249,6 +263,7 @@ foreach ($requiredSafety in @(
   "Join-Path `$PSScriptRoot 'start-dream-skin.ps1'",
   "' -RestartExisting'",
   'Restore-DreamSkinActiveThemeSnapshot',
+  'Format-DreamSkinCommunitySuccessMessage -Name $result.Name',
   'Remove-Item -LiteralPath $workRoot -Recurse -Force'
 )) {
   if (-not $applySource.Contains($requiredSafety)) {

--- a/windows/tests/injector-window-readiness.test.mjs
+++ b/windows/tests/injector-window-readiness.test.mjs
@@ -25,19 +25,49 @@ function makeRect(width = 800, height = 600, x = 0, y = 0) {
   return { x, y, width, height, right: x + width, bottom: y + height };
 }
 
-function makeElement({ rect = makeRect(), style = {}, visible = true } = {}) {
-  return {
+function makeElement({
+  rect = makeRect(),
+  style = {},
+  visible = true,
+  text = "",
+  children = [],
+} = {}) {
+  const element = {
     isConnected: true,
+    textContent: text,
     _style: {
       display: "block",
       visibility: "visible",
       contentVisibility: "visible",
       opacity: "1",
+      color: "rgb(240, 240, 240)",
       ...style,
     },
+    childNodes: text ? [{ nodeType: 3, textContent: text }] : [],
+    children,
     getBoundingClientRect: () => rect,
     checkVisibility: () => visible,
     querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+  return element;
+}
+
+function makeSuggestionButton({
+  rect = makeRect(220, 80, 40, 300),
+  color = "rgb(210, 210, 210)",
+  labelColor = color,
+  text = "Suggestion",
+} = {}) {
+  const label = makeElement({
+    rect: makeRect(180, 24, rect.x + 12, rect.y + 12),
+    style: { color: labelColor },
+    text,
+  });
+  return {
+    ...makeElement({ rect, style: { color } }),
+    getBoundingClientRect: () => rect,
+    querySelectorAll: () => [label],
   };
 }
 
@@ -45,6 +75,8 @@ function makeHome(options = {}) {
   const home = makeElement(options);
   const hero = makeElement(options.hero ?? {});
   home.firstElementChild = { firstElementChild: { firstElementChild: hero } };
+  const suggestions = options.suggestions ?? null;
+  home.querySelector = (selector) => selector === selectors.suggestions ? suggestions : null;
   return home;
 }
 
@@ -209,6 +241,47 @@ test("visible settings and home anchors are the only L0 structure exceptions", a
   });
   assert.equal(noAnchor.result.pass, false);
   assert.equal(noAnchor.result.readiness.structurePass, false);
+});
+
+test("home verification matches macOS and does not require a fixed suggestion-card count", async () => {
+  const oneSuggestion = {
+    querySelectorAll: (selector) => selector === "button"
+      ? [makeSuggestionButton({ text: "One real card" })]
+      : [],
+  };
+  const homeWithOneSuggestion = await verify({
+    dom: makeDomFixture({
+      home: makeHome({
+        rect: makeRect(900, 650, 20, 20),
+        hero: { rect: makeRect(800, 260, 40, 60) },
+        suggestions: oneSuggestion,
+      }),
+    }),
+  });
+  assert.equal(homeWithOneSuggestion.result.homePresent, true);
+  assert.equal(homeWithOneSuggestion.result.visibleCardCount, 1);
+  assert.equal(homeWithOneSuggestion.result.pass, true);
+
+  const mismatchedSuggestion = {
+    querySelectorAll: (selector) => selector === "button"
+      ? [makeSuggestionButton({
+        text: "Hidden by mismatched text color",
+        color: "rgb(210, 210, 210)",
+        labelColor: "rgb(10, 10, 10)",
+      })]
+      : [],
+  };
+  const badHome = await verify({
+    dom: makeDomFixture({
+      home: makeHome({
+        rect: makeRect(900, 650, 20, 20),
+        hero: { rect: makeRect(800, 260, 40, 60) },
+        suggestions: mismatchedSuggestion,
+      }),
+    }),
+  });
+  assert.equal(badHome.result.suggestionLabelColorsMatch, false);
+  assert.equal(badHome.result.pass, false);
 });
 
 // Regression for #256. The previous version of this test asserted that a

--- a/windows/tests/installer-static.tests.ps1
+++ b/windows/tests/installer-static.tests.ps1
@@ -93,6 +93,26 @@ if ($definition.Contains('Root: HKLM') -or
   [regex]::Matches($definition, '(?m)^Root: HKCU; Subkey: "Software\\Classes\\dreamskin').Count -ne 4) {
   throw 'The dreamskin protocol must be a four-entry current-user registration with no arbitrary URL contract.'
 }
+if (-not $definition.Contains('#define PersistentPowerShellPath "{win}\System32\WindowsPowerShell\v1.0\powershell.exe"')) {
+  throw 'Persistent shortcuts and URL handlers must use a System32 PowerShell path that 64-bit launchers can access.'
+}
+$persistentCommandEntries = @(
+  'Name: "{group}\Codex Dream Skin"',
+  'Name: "{userstartup}\Codex Dream Skin"',
+  'Subkey: "Software\Classes\dreamskin\shell\open\command"'
+)
+foreach ($entry in $persistentCommandEntries) {
+  $line = ([regex]::Match(
+      $definition,
+      '(?m)^.*' + [regex]::Escape($entry) + '.*$'
+    )).Value
+  if (-not $line.Contains('{#PersistentPowerShellPath}')) {
+    throw "Persistent command does not use the browser-accessible PowerShell path: $entry"
+  }
+  if ($line.Contains('{#PowerShellPath}') -or $line.Contains('{sysnative}')) {
+    throw "Persistent command still references sysnative, which 64-bit launchers cannot access: $entry"
+  }
+}
 
 $uninstallStepIndex = $definition.IndexOf(
   'if CurUninstallStep <> usUninstall then',

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -1018,6 +1018,7 @@ try {
     $updatedTheme.Theme.id -cne 'custom' -or
     $updatedTheme.Theme.art.safeArea -cne 'auto' -or
     $updatedTheme.Theme.art.taskMode -cne 'auto' -or
+    $updatedTheme.Theme.PSObject.Properties['palette'] -or
     -not (Test-DreamSkinThemePathWithin -Path $updatedTheme.ImagePath -Root $themePaths.Active)) {
     throw 'Imported image did not reset to the generic adaptive contract inside the managed directory.'
   }

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -1302,6 +1302,11 @@ try {
   if (-not (Get-Command Invoke-DreamSkinCodexWindowActivation -CommandType Function -ErrorAction SilentlyContinue)) {
     throw 'The Windows Codex activation helper is missing from common-windows.ps1.'
   }
+  if (-not $commonSource.Contains('Stop-Process -InputObject $processHandle -Force') -or
+    -not $commonSource.Contains('[void]$processHandle.WaitForExit(15000)') -or
+    -not $commonSource.Contains('if (-not $processHandle.HasExited)')) {
+    throw 'Recorded injector shutdown must wait on the exact validated process object before startup continues.'
+  }
   if (-not $startSource.Contains('direct Store executable fallback did not expose a verified loopback CDP endpoint') -or
     -not $startSource.Contains('may disable CDP in this production runtime')) {
     throw 'A direct launch that retains CDP arguments but exposes no listener no longer reports the owl runtime failure.'
@@ -1402,6 +1407,45 @@ try {
   $commonSource = Read-DreamSkinUtf8File -Path (Join-Path $Root 'scripts\common-windows.ps1')
   if (-not $commonSource.Contains('State was preserved.')) {
     throw 'Mismatched live injector identity does not fail closed with preserved state.'
+  }
+
+  $recordedInjectorFixture = Join-Path $temporaryRoot 'recorded-injector-fixture.mjs'
+  [System.IO.File]::WriteAllText(
+    $recordedInjectorFixture,
+    "setInterval(() => {}, 600000);`n",
+    [System.Text.UTF8Encoding]::new($false)
+  )
+  $recordedInjectorPort = 49333
+  $recordedInjectorBrowserId = 'fixture-browser'
+  $recordedInjectorArguments = (ConvertTo-DreamSkinProcessArgument -Value $recordedInjectorFixture) +
+    " --watch --port $recordedInjectorPort --browser-id $recordedInjectorBrowserId"
+  $recordedInjectorProcess = Start-Process -FilePath $node.Path `
+    -ArgumentList $recordedInjectorArguments -WindowStyle Hidden -PassThru
+  try {
+    Start-Sleep -Milliseconds 250
+    if ($recordedInjectorProcess.HasExited) {
+      throw 'Recorded injector shutdown fixture exited before its identity could be tested.'
+    }
+    $recordedInjectorState = [pscustomobject]@{
+      injectorPid = $recordedInjectorProcess.Id
+      injectorStartedAt = $recordedInjectorProcess.StartTime.ToUniversalTime().ToString('o')
+      injectorPath = $recordedInjectorFixture
+      nodePath = $node.Path
+      port = $recordedInjectorPort
+      browserId = $recordedInjectorBrowserId
+    }
+    if (-not (Stop-DreamSkinRecordedInjector -State $recordedInjectorState)) {
+      throw 'The identity-validated recorded injector did not report a successful stop.'
+    }
+    $recordedInjectorProcess.Refresh()
+    if (-not $recordedInjectorProcess.HasExited) {
+      throw 'The identity-validated recorded injector was still running after shutdown returned.'
+    }
+  } finally {
+    if (-not $recordedInjectorProcess.HasExited) {
+      Stop-Process -InputObject $recordedInjectorProcess -Force -ErrorAction SilentlyContinue
+      [void]$recordedInjectorProcess.WaitForExit(15000)
+    }
   }
 
   $stderrProbe = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -1413,6 +1413,12 @@ try {
   $managedPayloadTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
     (Join-Path $Root 'scripts\injector.mjs'), '--check-payload', '--theme-dir', $themePaths.Active)
   if ($managedPayloadTest.ExitCode -ne 0) { throw 'Managed theme payload validation failed.' }
+  $managedPayload = ($managedPayloadTest.Output -join "`n") | ConvertFrom-Json
+  if (-not $managedPayload.pass -or $managedPayload.hasPalette -or -not $managedPayload.hasColors -or
+    $managedPayload.colorMode -notin @('auto', 'explicit') -or
+    $managedPayload.explicitColorKeys -isnot [array]) {
+    throw 'Windows payload drifted from the shared community theme contract.'
+  }
   $oversizedPayloadTest = Invoke-DreamSkinNative -FilePath $node.Path -ArgumentList @(
     (Join-Path $Root 'scripts\injector.mjs'), '--check-payload', '--theme-dir', $oversizedTheme)
   if ($oversizedPayloadTest.ExitCode -eq 0) { throw 'Node injector accepted an image over the 10 MB limit.' }

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -1294,6 +1294,14 @@ try {
     -not $startSource.Contains('Start-Sleep -Seconds 3')) {
     throw 'Start lost the verification retry window; a single early-boot miss must not tear the startup down.'
   }
+  if (-not $startSource.Contains('Invoke-DreamSkinCodexWindowActivation -Codex $codex') -or
+    -not $startSource.Contains("'--once'") -or
+    -not $startSource.Contains("'--timeout-ms', '15000'")) {
+    throw 'Start no longer mirrors macOS by activating Codex and force-injecting once after an initial visible-verification miss.'
+  }
+  if (-not (Get-Command Invoke-DreamSkinCodexWindowActivation -CommandType Function -ErrorAction SilentlyContinue)) {
+    throw 'The Windows Codex activation helper is missing from common-windows.ps1.'
+  }
   if (-not $startSource.Contains('direct Store executable fallback did not expose a verified loopback CDP endpoint') -or
     -not $startSource.Contains('may disable CDP in this production runtime')) {
     throw 'A direct launch that retains CDP arguments but exposes no listener no longer reports the owl runtime failure.'

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -1309,6 +1309,9 @@ try {
     throw 'Start lost the any-registered endpoint fallback for Store auto-updates.'
   }
   $verifyScriptSource = Read-DreamSkinUtf8File -Path (Join-Path $Root 'scripts\verify-dream-skin.ps1')
+  if (-not $verifyScriptSource.Contains(". (Join-Path `$PSScriptRoot 'theme-windows.ps1')")) {
+    throw 'Verify must dot-source theme-windows.ps1 before using theme store helpers such as Get-DreamSkinThemePaths.'
+  }
   if (-not $verifyScriptSource.Contains('Get-DreamSkinVerifiedCdpIdentityForAnyRegistered')) {
     throw 'Verify lost the any-registered endpoint fallback for Store auto-updates.'
   }

--- a/windows/tests/start-renderer-readiness.tests.ps1
+++ b/windows/tests/start-renderer-readiness.tests.ps1
@@ -28,6 +28,7 @@ $script:daemon | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value {
 }
 $script:dateCall = 0
 $script:verifyCalls = 0
+$script:onceCalls = 0
 $script:removeCalls = 0
 $script:stateWritten = $false
 $script:stateRemoved = $false
@@ -81,6 +82,7 @@ function Get-DreamSkinVerifiedCdpIdentity {
 }
 function Stop-DreamSkinRecordedInjector { param([object]$State); return $true }
 function Set-DreamSkinPaused { param([bool]$Paused, [string]$StateRoot); return $true }
+function Invoke-DreamSkinCodexWindowActivation { param([object]$Codex); return $true }
 function ConvertTo-DreamSkinProcessArgument { param([string]$Value); return $Value }
 function Start-Process {
   [CmdletBinding()]
@@ -104,6 +106,10 @@ function Invoke-DreamSkinNative {
   if ($ArgumentList -contains '--verify') {
     $script:verifyCalls += 1
     return [pscustomobject]@{ ExitCode = 2; Output = @('{"pass":false}') }
+  }
+  if ($ArgumentList -contains '--once') {
+    $script:onceCalls += 1
+    return [pscustomobject]@{ ExitCode = 2; Output = @('{"mode":"once","targets":[]}') }
   }
   if ($ArgumentList -contains '--remove') {
     $script:removeCalls += 1
@@ -152,7 +158,8 @@ try {
 $announcedActive = @($script:hostMessages | Where-Object {
   $_ -like 'Codex Dream Skin is active*'
 }).Count -gt 0
-if (-not $failed -or $script:verifyCalls -ne 1 -or $script:removeCalls -ne 1 -or
+if (-not $failed -or $script:verifyCalls -ne 1 -or $script:onceCalls -ne 1 -or
+  $script:removeCalls -ne 1 -or
   -not $script:stateWritten -or -not $script:stateRemoved -or
   -not $script:daemonStopped -or -not $script:daemon.HasExited -or
   -not $script:lockExited -or $announcedActive) {

--- a/windows/tests/start-verified-skin-preserved.tests.ps1
+++ b/windows/tests/start-verified-skin-preserved.tests.ps1
@@ -79,6 +79,7 @@ function Invoke-DreamSkinStartupFixture {
   function Test-DreamSkinPathEqual { param([string]$Left, [string]$Right); return $true }
   function Stop-DreamSkinRecordedInjector { param([object]$State); return $true }
   function Set-DreamSkinPaused { param([bool]$Paused, [string]$StateRoot); return $true }
+  function Invoke-DreamSkinCodexWindowActivation { param([object]$Codex); return $true }
   function ConvertTo-DreamSkinProcessArgument { param([string]$Value); return $Value }
   function Get-DreamSkinProcessStartedAt { param([int]$ProcessId); return '2026-07-25T00:00:00.0000000Z' }
   function Write-DreamSkinState { param([string]$Path, [object]$State) }
@@ -104,6 +105,9 @@ function Invoke-DreamSkinStartupFixture {
   function Invoke-DreamSkinNative {
     param([string]$FilePath, [object[]]$ArgumentList, [switch]$DiscardStderr)
     if ($ArgumentList -contains '--verify') {
+      return [pscustomobject]@{ ExitCode = 2; Output = @($script:verifyPayload) }
+    }
+    if ($ArgumentList -contains '--once') {
       return [pscustomobject]@{ ExitCode = 2; Output = @($script:verifyPayload) }
     }
     if ($ArgumentList -contains '--remove') {

--- a/windows/tests/theme-zip-import.tests.ps1
+++ b/windows/tests/theme-zip-import.tests.ps1
@@ -250,10 +250,19 @@ try {
   $roundtripPaths = Initialize-DreamSkinThemeStore -SkillRoot $Root `
     -StateRoot $roundtripStateRoot
   $officialSaved = Read-DreamSkinTheme -ThemeDirectory $official.Path
+  if (-not $officialSaved.Theme.PSObject.Properties['colors'] -or
+    $officialSaved.Theme.PSObject.Properties['palette']) {
+    throw 'Studio colors-only theme was not preserved as the current community theme contract.'
+  }
   $officialTheme = $officialSaved.Theme | ConvertTo-Json -Depth 8 | ConvertFrom-Json
   $null = Set-DreamSkinActiveTheme -ImagePath $officialSaved.ImagePath `
     -Theme $officialTheme -SafeCssPath (Join-Path $official.Path 'theme.css') `
     -StateRoot $roundtripStateRoot
+  $roundtripActive = Read-DreamSkinTheme -ThemeDirectory $roundtripPaths.Active
+  if (-not $roundtripActive.Theme.PSObject.Properties['colors'] -or
+    $roundtripActive.Theme.PSObject.Properties['palette']) {
+    throw 'Applying a Studio colors-only theme added a legacy palette field.'
+  }
   $roundtripFingerprint = Get-DreamSkinThemeRuntimeContentFingerprint `
     -ThemeDirectory $roundtripPaths.Active
   if ($roundtripFingerprint -cne $official.ContentFingerprint) {


### PR DESCRIPTION
## What changed

This fixes the remaining #307 Windows one-click apply path after v1.5.8 restored startup and ZIP import.

There are seven fixes in this PR:

- installer bootstrap still uses `{sysnative}` for Setup-owned PowerShell execution, but persistent shortcuts and the HKCU `dreamskin://` protocol command now use `{win}\System32\WindowsPowerShell\v1.0\powershell.exe`, which 64-bit browser/Explorer launchers can access
- the Windows community-apply parser accepts both the site-generated URI `dreamskin://apply?version=ver_...` and the Windows/browser-normalized URI `dreamskin://apply/?version=ver_...`
- Windows theme loading/application is aligned with the shared community theme contract used by macOS: current community packages use `colors`; Windows no longer requires, creates, reads, or emits the old `palette` runtime field in its PowerShell store / injector path
- standalone Windows Verify now dot-sources `theme-windows.ps1`, so it can resolve `Get-DreamSkinThemePaths` and verify the active theme directory outside the tray/start scripts
- one-click community apply no longer waits unboundedly for the hidden start/verify child process; the parent handler now waits with the existing operation timeout and returns a visible error instead of leaving a no-window protocol handler hung indefinitely
- Windows visible renderer verification now matches the macOS home-route gate: it still requires exact payload revision, visible document/window evidence, real shell/home structure, and visible hero content, but it no longer rejects a valid home route solely because the suggestions area has a non-2..4 card count
- Windows startup now mirrors macOS after an initial visible-verification miss: activate the existing Codex window, force one `--once` apply of the exact active theme, then verify again before deciding to rollback

The protocol parser remains fail-closed for non-canonical inputs: extra parameters, fragments, uppercase scheme/version IDs, double-slash paths, arbitrary paths, and URL/path injection are still rejected by regression tests.

## Why

#307 reporter confirmed on Windows 11 + Chrome that v1.5.8 restored startup and ZIP import, but one-click apply still fell back to the website's “client not detected / download ZIP” hint.

Windows-side testing then showed separate layers:

1. 64-bit browsers can fail to launch a registry command that uses Inno's `{sysnative}` path.
2. Once the handler process starts, Windows/browser handoff may pass the URI as `dreamskin://apply/?version=...`, while the old parser accepted only `dreamskin://apply?version=...`.
3. After protocol handoff/download/import succeeded, applying some current community packages could fail because the Windows PowerShell theme store assumed a `palette` property that is not part of the current shared community schema.
4. Standalone Verify could fail with `Get-DreamSkinThemePaths is not recognized` because it loaded `common-windows.ps1` but not `theme-windows.ps1`.
5. The one-click handler's hidden parent process used `Start-Process -Wait` for `start-dream-skin.ps1`; if that child process did not exit cleanly after renderer recovery/final verification, the protocol handler could sit with no visible window for minutes even though rollback/final state had already completed.
6. Later real Windows smoke on `74927d4` proved the previous layers were fixed, but the final target theme still failed visible verification and rolled back cleanly to Gothic Void Crusade. This exposed two Windows/macOS behavior gaps: Windows had an older fixed 2..4 home-card verification gate, and Windows did not do macOS's activate + forced one-shot retry after the first verify miss.

## CI / validation

Latest PR head at the time of this note: `71c3ca9`.

Local checks before push:

- `node --check windows/scripts/injector.mjs`
- `node windows/tests/injector-window-readiness.test.mjs`
- `node windows/tests/injector-bootstrap.test.mjs`
- `node windows/scripts/injector.mjs --check-payload --theme-dir <downloaded ver_6e5527257d304daca9d5 package>`
- `git diff --check`
- static assertions for the protocol handler path, `colors`/no-`palette` Windows payload contract, standalone Verify dependency, bounded one-click start verification, Windows/macOS-aligned home verification, and activate + forced once retry

CI must pass on the latest head before merge. Earlier CI run `30528814057` passed on `74927d4`; a newer run is required for `71c3ca9` because this PR now also changes Windows renderer verification and startup retry behavior.

## Windows AI verification notes / 给 Windows 测试 AI 的说明

Scope: this PR verifies the Windows one-click flow for #307 from browser handoff through native confirmation, download/import, applying a current community theme, visible renderer verification, and bounded handler exit. Do not close #307 from this PR alone; after release, affected users still need to confirm recovery.

### 1. Checkout and confirm exact PR head

```powershell
gh pr checkout 317
git rev-parse --short HEAD
```

Expected head at the time of this note: `71c3ca9` or newer.

### 2. Run source-level Windows checks

From the repository root:

```powershell
powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -File .\windows\tests\run-tests.ps1
powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -File .\windows\tests\installer-static.tests.ps1
```

These must pass. Relevant coverage:

- `windows\tests\community-theme-link.tests.ps1`: accepts canonical and Windows-normalized `dreamskin://` URI forms, rejects unsafe forms, and asserts the one-click hidden start/verify child has a bounded wait
- `windows\tests\theme-zip-import.tests.ps1`: imports and applies current community/Studio packages without introducing legacy `palette`
- `windows\tests\injector-window-readiness.test.mjs`: verifies Windows native-window fallback, exact payload binding, and macOS-aligned home verification without a fixed suggestion-card count
- `windows\tests\run-tests.ps1`: validates the Windows injector payload does not drift from the shared community theme contract, confirms standalone Verify loads the theme-store helpers it calls, and asserts startup has activate + forced `--once` retry after an initial verify miss

### 3. Build a local Setup.exe from the PR

If Inno Setup 6 is installed:

```powershell
$output = Join-Path $env:TEMP 'codex-dream-skin-pr317'
$iscc = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'
powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
  -File .\windows\installer\build-release.ps1 `
  -OutputDirectory $output `
  -IsccPath $iscc
Get-ChildItem $output -Filter 'CodexDreamSkin-Setup-v*.exe'
```

### 4. Install/upgrade safely

Before running Setup.exe, close Codex and exit the Codex Dream Skin tray. The installer intentionally refuses to proceed while Codex is running; that refusal is a safety guard, not a PR failure.

Run the PR-built Setup.exe and complete installation.

### 5. Verify the registered protocol command

After installation:

```powershell
$command = (Get-Item 'HKCU:\Software\Classes\dreamskin\shell\open\command').GetValue('')
$command
if ($command -notlike '*\Windows\System32\WindowsPowerShell\v1.0\powershell.exe*') { throw 'Protocol handler is not using System32 PowerShell.' }
if ($command -like '*sysnative*') { throw 'Protocol handler still uses sysnative.' }
if ($command -notlike '*apply-community-theme.ps1*') { throw 'Protocol handler does not point at apply-community-theme.ps1.' }
```

Expected: the command contains `\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, does not contain `sysnative`, and points to the installed `apply-community-theme.ps1` under `%LOCALAPPDATA%\CodexDreamSkin\engine\scripts`.

### 6. Verify standalone Verify no longer misses theme helpers

After installing and starting DreamSkin once, run:

```powershell
powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
  -File "$env:LOCALAPPDATA\CodexDreamSkin\engine\scripts\verify-dream-skin.ps1"
```

Expected: it must not fail with `Get-DreamSkinThemePaths is not recognized`. A renderer mismatch or Codex-not-running error is a different runtime state issue; classify it separately.

### 7. Verify both URI forms reach the native handler

Use either `Win + R` manually or PowerShell ShellExecute:

```powershell
Start-Process 'dreamskin://apply?version=ver_6e5527257d304daca9d5'
Start-Sleep -Seconds 2
Start-Process 'dreamskin://apply/?version=ver_6e5527257d304daca9d5'
```

Expected: DreamSkin native confirmation dialog appears. Cancel is acceptable for this handoff check; the important part is that the native dialog appears for both URI forms.

### 8. Verify browser handoff and full one-click apply

Open Windows 11 Chrome or Edge and click `一键换肤` on either:

- `https://dreamskin.cc/gallery`
- `https://dreamskin.cc/preview?themeVersion=ver_6e5527257d304daca9d5`

Expected full flow:

1. browser hands off to Windows / DreamSkin
2. DreamSkin native confirmation dialog appears
3. after confirmation, metadata is fetched from the fixed API
4. ZIP downloads and imports
5. selected community theme is applied to Codex
6. no error like `The property 'palette' cannot be found on this object`
7. no final error `The imported theme failed visible verification. The previous theme was reapplied and visibly verified.` for `ver_6e5527257d304daca9d5`
8. the protocol handler exits with a success dialog or a visible bounded error; it must not remain as an invisible/no-window process for more than the operation timeout

Important Chrome note: if the user previously selected “always allow/open this app”, Chrome may no longer show the browser external-app prompt. That is not automatically a failure. The pass/fail signal is whether the DreamSkin native confirmation dialog appears and the apply operation completes.

### 9. If it fails, classify the exact stage

Please report one of these with screenshot/logs:

1. Browser click does nothing and no DreamSkin process/dialog appears.
2. Browser or `Start-Process` launches PowerShell, but no DreamSkin dialog appears.
3. DreamSkin confirmation dialog appears, but metadata/download/import fails.
4. Import succeeds, but applying the saved community theme fails.
5. Apply transaction succeeds or restores the previous theme, but the no-window protocol handler process does not exit.
6. Standalone Verify fails with `Get-DreamSkinThemePaths is not recognized`.
7. Target theme is written, but final visible verification fails and rollback succeeds.
8. Confirmation appears and apply succeeds.

Case 1/2 is still protocol handoff. Case 3/4 is a later handler/import/apply-stage issue and should include the DreamSkin error dialog text. Case 5 is the bounded child start/verify wait path changed by this PR and needs process/log evidence. Case 7 is the visible-verification path changed by `71c3ca9`; include `%LOCALAPPDATA%\CodexDreamSkin\verify.log`, `injector.log`, and `injector-error.log` if available.

## Notes

- This PR does not include a release/version bump.
- Keep this PR draft until a real Windows one-click apply smoke test confirms the browser click reaches native confirmation, applies a current community theme, and the protocol handler exits or returns a visible bounded error.
