### PR TITLE
feat(theme): add visual sidebar overrides

### DIFF
--- a/TASK_PROGRESS.md
+++ b/TASK_PROGRESS.md
@@ -1,6 +1,20 @@
 # Task Progress
 
-Updated: 2026-07-25 08:31 HKT (Asia/Hong_Kong)
+Updated: 2026-07-31 CST (Asia/Shanghai)
+
+## Theme UI Overrides on v1.5.9 (2026-07-31)
+
+- [complete] Started the work scope from `origin/main@cd71dfd` (v1.5.9)
+  without restoring the obsolete pre-v1.5 runtime architecture. The upstream
+  26.721+ home/composer visibility repair remains authoritative.
+- [complete] Ported the macOS theme-local sidebar labels, navigation artwork,
+  project-folder artwork, and composer placeholder into the shared
+  attribute-only renderer contract. Native text, accessibility metadata,
+  project/task names, ordering, and event handlers remain unchanged.
+- [verified] Shared assets are synchronized byte-for-byte. Both platform
+  renderer/payload suites, 76 portable Node tests, the macOS Swift build/XCTest,
+  and the complete macOS repository regression suite passed; signed-runtime
+  integrations and Doctor were explicitly skipped in the repository test mode.
 
 ## v1.5.1 Version Release (2026-07-25 08:28 HKT)
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -198,6 +198,48 @@ the same priority over automatic inference. The home route remains expressive;
 task routes keep native content, cards, composer, and code readable above the
 image layer.
 
+### Visual navigation copy and icons
+
+Local macOS theme folders can visually relabel Codex's fixed sidebar navigation
+and replace its fixed navigation or project-folder icons with theme-local PNG
+artwork. These overrides never change native button text, accessibility labels,
+event handlers, project names, task names, ordering, or expansion state.
+Unsupported or newly renamed Codex controls keep their native appearance.
+
+```json
+{
+  "ui": {
+    "composerPlaceholder": "财神在此，有求必应…",
+    "sidebar": {
+      "workspace": { "icon": "icon-workspace.png" },
+      "newTask": { "icon": "icon-new-task.png" },
+      "pullRequests": { "icon": "icon-pull-requests.png" },
+      "sites": { "icon": "icon-sites.png" },
+      "scheduled": { "icon": "icon-scheduled.png" },
+      "plugins": { "icon": "icon-plugins.png" },
+      "pinned": { "label": "财神置顶" }
+    },
+    "projectIcons": {
+      "closed": { "icon": "icon-folder-closed.png" },
+      "open": { "icon": "icon-folder-open.png" }
+    }
+  }
+}
+```
+
+Supported sidebar roles are `workspace`, `newTask`, `pullRequests`, `sites`,
+`scheduled`, `plugins`, and `pinned`. Each role accepts a visual `label`, a
+short Unicode `glyph`, or an `icon`; an icon takes precedence over a glyph.
+Labels are limited to 48 Unicode characters, glyphs to 8, and the composer
+placeholder to 120. Icons must be PNG files beside `theme.json`, no larger than
+256 KB or 512 px per side.
+
+`ui.projectIcons.closed` and `ui.projectIcons.open` follow the native project
+row's `aria-expanded` state. The switcher snapshots these referenced files with
+the theme, so switching away and back restores the whole visual pack in one
+operation. Theme ZIP imports remain on the published three-file Safe CSS
+contract; add visual icon packs directly to a local saved theme folder.
+
 CLI example:
 
 ```bash

--- a/macos/assets/dream-skin.css
+++ b/macos/assets/dream-skin.css
@@ -262,6 +262,148 @@ html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg {
   color: var(--ds-accent) !important;
 }
 
+/* Theme navigation overrides remain visual-only: native text, aria labels,
+   click handlers, project names, and task names are never rewritten. */
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-label"][data-dream-label],
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="section-label"][data-dream-label],
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"][data-dream-label] {
+  font-size: 0 !important;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-label"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  color: inherit;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 590;
+  letter-spacing: 0;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"] {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"][data-dream-glyph]::before {
+  content: attr(data-dream-glyph);
+  flex: 0 0 auto;
+  font-size: 16px;
+  line-height: 1;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"][data-dream-icon-kind="image"]::before {
+  content: "";
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  background: var(--dream-skin-nav-image) center / contain no-repeat;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ds-text);
+  font-size: 17px;
+  line-height: 24px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-icon"] {
+  display: grid !important;
+  flex: 0 0 18px;
+  width: 18px !important;
+  height: 18px !important;
+  place-items: center;
+  line-height: 0 !important;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-icon"] svg,
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="project-icon"] svg {
+  display: none !important;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-icon"][data-dream-glyph]::after {
+  content: attr(data-dream-glyph);
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  color: var(--ds-accent);
+  font-size: 15px;
+  line-height: 18px;
+  text-align: center;
+  transform: translateZ(0);
+  transition: transform .16s ease, filter .16s ease;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-icon"][data-dream-icon-kind="image"]::after {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 18px;
+  background: var(--dream-skin-nav-image) center / contain no-repeat;
+  transform: translateZ(0);
+  transition: transform .16s ease, filter .16s ease;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="project-icon"] {
+  display: grid !important;
+  flex: 0 0 18px;
+  width: 18px !important;
+  height: 18px !important;
+  place-items: center;
+  line-height: 0 !important;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="project-icon"]::after {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 18px;
+  background: var(--dream-skin-project-image) center / 150% no-repeat;
+  filter: drop-shadow(0 1px 2px rgb(var(--ds-accent-rgb) / .18));
+  transform: translateZ(0);
+  transition: transform .16s ease, filter .16s ease;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-app-action-sidebar-project-row]:hover [data-dream-ui-role="project-icon"]::after,
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-button]:hover [data-dream-ui-role="nav-icon"]::after {
+  filter: drop-shadow(0 2px 4px rgb(var(--ds-accent-rgb) / .32));
+  transform: translateY(-1px);
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="section-label"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  color: rgb(var(--ds-muted-rgb) / .92);
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 720;
+  letter-spacing: .02em;
+}
+
 html[data-dream-skin="active"] aside.app-shell-left-panel button[aria-label^="切换模式"] {
   background: transparent !important;
   border: 0 !important;
@@ -1083,6 +1225,18 @@ html[data-dream-skin="active"] .composer-surface-chrome button:not([class~="bg-t
 html[data-dream-skin="active"] .composer-surface-chrome p.placeholder::after {
   color: rgb(var(--ds-muted-rgb) / .82) !important;
   opacity: 1 !important;
+}
+
+html[data-dream-skin="active"] .composer-surface-chrome
+  p.placeholder[data-dream-ui-role="composer-placeholder"][data-dream-label] {
+  font-size: 0 !important;
+}
+
+html[data-dream-skin="active"] .composer-surface-chrome
+  p.placeholder[data-dream-ui-role="composer-placeholder"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  font-size: 15px;
+  line-height: 1.5;
 }
 
 /* Search routes ship an opaque sticky band and input surface. Keep the

--- a/macos/assets/renderer-inject.js
+++ b/macos/assets/renderer-inject.js
@@ -18,6 +18,10 @@
   const PAYLOAD_REVISION = __DREAM_SKIN_PAYLOAD_REVISION_JSON__;
   const THEME = themeConfig && typeof themeConfig === "object" ? themeConfig : {};
   const ART = THEME.art && typeof THEME.art === "object" ? THEME.art : {};
+  const UI = THEME.ui && typeof THEME.ui === "object" ? THEME.ui : {};
+  const SIDEBAR_UI = UI.sidebar && typeof UI.sidebar === "object" ? UI.sidebar : {};
+  const PROJECT_ICONS = UI.projectIcons && typeof UI.projectIcons === "object"
+    ? UI.projectIcons : {};
   const ART_METADATA = THEME.artMetadata && typeof THEME.artMetadata === "object"
     ? THEME.artMetadata : null;
   const ANALYSIS_CACHE_KEY = "__CODEX_DREAM_SKIN_ANALYSIS_CACHE__";
@@ -569,6 +573,15 @@
   };
 
   const partNodes = new Set();
+  const uiNodes = new Set();
+  const UI_ATTRIBUTES = [
+    "data-dream-ui-role",
+    "data-dream-ui-button",
+    "data-dream-label",
+    "data-dream-glyph",
+    "data-dream-icon-kind",
+    "data-dream-project-state",
+  ];
   const queryAll = (selector) => {
     if (!selector) return [];
     try { return [...document.querySelectorAll(selector)]; } catch { return []; }
@@ -580,6 +593,137 @@
         desired.set(node, part);
       }
     }
+  };
+  const clearVisualNode = (node) => {
+    for (const attribute of UI_ATTRIBUTES) node.removeAttribute?.(attribute);
+    node.style?.removeProperty("--dream-skin-nav-image");
+    node.style?.removeProperty("--dream-skin-project-image");
+  };
+  const markVisualNode = (desired, node, attributes = {}, styles = {}) => {
+    if (!node) return;
+    desired.add(node);
+    for (const [name, value] of Object.entries(attributes)) {
+      if (typeof value === "string" && value) setAttribute(node, name, value);
+    }
+    for (const [name, value] of Object.entries(styles)) {
+      if (typeof value === "string" && value) setStyleProperty(node, name, value);
+    }
+  };
+  const normalizedNativeLabel = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const findButtonByNativeLabel = (buttons, labels) => buttons.find((button) =>
+    labels.includes(normalizedNativeLabel(button.textContent)));
+  const applySidebarButtonOverride = (desired, button, role, spec, workspace = false) => {
+    if (!button || !spec || typeof spec !== "object") return;
+    markVisualNode(desired, button, { "data-dream-ui-button": role });
+    const label = workspace
+      ? button.querySelector?.("span.truncate") || button.querySelector?.("span")
+      : button.querySelector?.(".text-fade-truncate");
+    if (spec.label) {
+      markVisualNode(desired, label, {
+        "data-dream-ui-role": workspace ? "workspace-label" : "nav-label",
+        "data-dream-label": spec.label,
+      });
+    }
+    if (spec.iconDataUrl) {
+      if (workspace) {
+        markVisualNode(desired, label, {
+          "data-dream-ui-role": "workspace-label",
+          "data-dream-icon-kind": "image",
+        }, {
+          "--dream-skin-nav-image": `url("${spec.iconDataUrl}")`,
+        });
+        return;
+      }
+      const icon = button.querySelector?.("svg")?.parentElement;
+      markVisualNode(desired, icon, {
+        "data-dream-ui-role": "nav-icon",
+        "data-dream-icon-kind": "image",
+      }, {
+        "--dream-skin-nav-image": `url("${spec.iconDataUrl}")`,
+      });
+      return;
+    }
+    if (!spec.glyph) return;
+    if (workspace) {
+      markVisualNode(desired, label, {
+        "data-dream-ui-role": "workspace-label",
+        "data-dream-glyph": spec.glyph,
+      });
+      return;
+    }
+    const icon = button.querySelector?.("svg")?.parentElement;
+    markVisualNode(desired, icon, {
+      "data-dream-ui-role": "nav-icon",
+      "data-dream-glyph": spec.glyph,
+    });
+  };
+  const refreshVisualOverrides = () => {
+    const desired = new Set();
+    const sidebar = selectorNodes("left-panel")[0];
+    if (sidebar && Object.keys(SIDEBAR_UI).length) {
+      const buttons = [...(sidebar.querySelectorAll?.("button") || [])];
+      const workspaceButton = buttons.find((button) => {
+        const label = normalizedNativeLabel(button.getAttribute?.("aria-label"));
+        return label.startsWith("切换模式") || label.toLowerCase().startsWith("switch mode");
+      });
+      applySidebarButtonOverride(
+        desired, workspaceButton, "workspace", SIDEBAR_UI.workspace, true,
+      );
+      for (const [role, labels] of [
+        ["newTask", ["新建任务", "New task", "New thread"]],
+        ["pullRequests", ["拉取请求", "Pull requests"]],
+        ["sites", ["站点", "Sites"]],
+        ["scheduled", ["已安排", "Scheduled"]],
+        ["plugins", ["插件", "Plugins"]],
+      ]) {
+        applySidebarButtonOverride(
+          desired,
+          findButtonByNativeLabel(buttons, labels),
+          role,
+          SIDEBAR_UI[role],
+        );
+      }
+      if (SIDEBAR_UI.pinned?.label) {
+        const toggles = [
+          ...(sidebar.querySelectorAll?.("button[data-app-action-sidebar-section-toggle]") || []),
+        ];
+        const pinnedLabel = findButtonByNativeLabel(toggles, ["置顶", "Pinned"])
+          ?.querySelector?.("span");
+        markVisualNode(desired, pinnedLabel, {
+          "data-dream-ui-role": "section-label",
+          "data-dream-label": SIDEBAR_UI.pinned.label,
+        });
+      }
+    }
+    if (sidebar && Object.keys(PROJECT_ICONS).length) {
+      for (const row of sidebar.querySelectorAll?.("[data-app-action-sidebar-project-row]") || []) {
+        const icon = row.querySelector?.('[data-sidebar-project-drop-zone="project-icon"]')
+          || row.querySelector?.(":scope > span:first-child");
+        if (!icon?.querySelector?.("svg")) continue;
+        const state = row.getAttribute?.("aria-expanded") === "true" ? "open" : "closed";
+        const spec = PROJECT_ICONS[state];
+        if (!spec?.iconDataUrl) continue;
+        markVisualNode(desired, icon, {
+          "data-dream-ui-role": "project-icon",
+          "data-dream-icon-kind": "image",
+          "data-dream-project-state": state,
+        }, {
+          "--dream-skin-project-image": `url("${spec.iconDataUrl}")`,
+        });
+      }
+    }
+    if (typeof UI.composerPlaceholder === "string" && UI.composerPlaceholder) {
+      const placeholder = selectorNodes("composer-chrome")[0]?.querySelector?.("p.placeholder");
+      markVisualNode(desired, placeholder, {
+        "data-dream-ui-role": "composer-placeholder",
+        "data-dream-label": UI.composerPlaceholder,
+      });
+    }
+    for (const node of uiNodes) {
+      if (!desired.has(node)) clearVisualNode(node);
+    }
+    uiNodes.clear();
+    for (const node of desired) uiNodes.add(node);
   };
   const refreshParts = () => {
     metrics.partPasses += 1;
@@ -612,12 +756,20 @@
       }
       partNodes.add(node);
     }
+    refreshVisualOverrides();
   };
 
   const removeParts = () => {
     for (const node of partNodes) node.removeAttribute?.(PART_ATTR);
     partNodes.clear();
     for (const node of queryAll(`[${PART_ATTR}]`)) node.removeAttribute?.(PART_ATTR);
+  };
+  const removeVisualOverrides = () => {
+    for (const node of uiNodes) clearVisualNode(node);
+    uiNodes.clear();
+    for (const node of queryAll("[data-dream-ui-role], [data-dream-ui-button]")) {
+      clearVisualNode(node);
+    }
   };
 
   const scopeMatches = (scope, baseState, overlay) => {
@@ -685,6 +837,7 @@
       }
     }
     removeParts();
+    removeVisualOverrides();
     state?.rootObserver?.disconnect();
     state?.partObserver?.disconnect();
     if (bodyReadyHandler && typeof document.removeEventListener === "function") {
@@ -791,7 +944,12 @@
   };
   const observePartTree = (node) => {
     if (!partObserver || !node) return;
-    partObserver.observe(node, { childList: true, subtree: true });
+    partObserver.observe(node, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["aria-expanded"],
+    });
   };
   observeAttributes(document.documentElement);
   const observeBody = () => {

--- a/macos/scripts/injector.mjs
+++ b/macos/scripts/injector.mjs
@@ -48,6 +48,8 @@ const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
 const CDP_ID_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
 const MAX_ART_BYTES = 10 * 1024 * 1024;
 const MAX_SAFE_CSS_BYTES = 256 * 1024;
+const MAX_UI_ICON_BYTES = 256 * 1024;
+const MAX_UI_ICON_SIDE = 512;
 const OPERATION_UI_HOST_ID = "chatgpt-dream-skin-operation";
 const OPERATION_UI_REGISTRY_KEY = "__CHATGPT_DREAM_SKIN_OPERATION_UI__";
 const OPERATION_KINDS = new Set(["apply", "pause", "switch"]);
@@ -650,6 +652,18 @@ export async function loadTheme(themeDir) {
     }
     return value;
   };
+  const iconFile = (value, name) => {
+    if (value === undefined) return "";
+    if (typeof value !== "string" || /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u.test(value)) {
+      throw new Error(`${configPath} has an invalid ${name} field`);
+    }
+    const normalized = value.trim();
+    if (!normalized) return "";
+    if (path.basename(normalized) !== normalized || !/\.png$/i.test(normalized)) {
+      throw new Error(`${configPath} ${name} must be a PNG filename inside its theme directory`);
+    }
+    return normalized;
+  };
   const rawColors = raw.colors && typeof raw.colors === "object" && !Array.isArray(raw.colors)
     ? raw.colors : null;
   const colorKeys = [
@@ -667,6 +681,64 @@ export async function loadTheme(themeDir) {
     safeArea: choice(rawArt.safeArea, "art.safeArea", ["auto", "left", "right", "center", "none"]),
     taskMode: choice(rawArt.taskMode, "art.taskMode", ["auto", "ambient", "banner", "full", "off"]),
   };
+  if (raw.ui !== undefined && (!raw.ui || typeof raw.ui !== "object" || Array.isArray(raw.ui))) {
+    throw new Error(`${configPath} has an invalid ui field`);
+  }
+  const rawUi = raw.ui || {};
+  if (
+    rawUi.sidebar !== undefined
+    && (!rawUi.sidebar || typeof rawUi.sidebar !== "object" || Array.isArray(rawUi.sidebar))
+  ) {
+    throw new Error(`${configPath} has an invalid ui.sidebar field`);
+  }
+  if (
+    rawUi.projectIcons !== undefined
+    && (!rawUi.projectIcons || typeof rawUi.projectIcons !== "object"
+      || Array.isArray(rawUi.projectIcons))
+  ) {
+    throw new Error(`${configPath} has an invalid ui.projectIcons field`);
+  }
+  const sidebar = {};
+  for (const role of [
+    "workspace", "newTask", "pullRequests", "sites", "scheduled", "plugins", "pinned",
+  ]) {
+    const rawEntry = rawUi.sidebar?.[role];
+    if (rawEntry === undefined) continue;
+    if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+      throw new Error(`${configPath} has an invalid ui.sidebar.${role} field`);
+    }
+    const entry = {
+      label: normalizeThemeText(
+        rawEntry.label, "", 48, `ui.sidebar.${role}.label`, configPath,
+      ),
+      glyph: normalizeThemeText(
+        rawEntry.glyph, "", 8, `ui.sidebar.${role}.glyph`, configPath,
+      ),
+      icon: iconFile(rawEntry.icon, `ui.sidebar.${role}.icon`),
+    };
+    if (entry.label || entry.glyph || entry.icon) sidebar[role] = entry;
+  }
+  const projectIcons = {};
+  for (const state of ["closed", "open"]) {
+    const rawEntry = rawUi.projectIcons?.[state];
+    if (rawEntry === undefined) continue;
+    if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+      throw new Error(`${configPath} has an invalid ui.projectIcons.${state} field`);
+    }
+    const icon = iconFile(rawEntry.icon, `ui.projectIcons.${state}.icon`);
+    if (icon) projectIcons[state] = { icon };
+  }
+  const ui = {};
+  const composerPlaceholder = normalizeThemeText(
+    rawUi.composerPlaceholder,
+    "",
+    120,
+    "ui.composerPlaceholder",
+    configPath,
+  );
+  if (Object.keys(sidebar).length) ui.sidebar = sidebar;
+  if (Object.keys(projectIcons).length) ui.projectIcons = projectIcons;
+  if (composerPlaceholder) ui.composerPlaceholder = composerPlaceholder;
   const theme = {
     schemaVersion: 1,
     id: normalizeThemeText(raw.id, "custom", 80, "id", configPath),
@@ -697,6 +769,7 @@ export async function loadTheme(themeDir) {
   if (Object.values(art).some((value) => value !== undefined)) {
     theme.art = Object.fromEntries(Object.entries(art).filter(([, value]) => value !== undefined));
   }
+  if (Object.keys(ui).length) theme.ui = ui;
   const requestedImagePath = path.join(assetsRoot, theme.image);
   let imagePath;
   try {
@@ -735,6 +808,61 @@ export async function loadTheme(themeDir) {
       throw new Error(`Theme image must be a non-empty file no larger than ${MAX_ART_BYTES} bytes`);
     }
     const safeCss = await loadSafeCss(assetsRoot);
+    let uiIconBytes = 0;
+    const loadedIcons = new Map();
+    const loadUiIcon = async (iconName, label) => {
+      let iconData = loadedIcons.get(iconName);
+      if (iconData) return iconData;
+      const requestedIconPath = path.join(assetsRoot, iconName);
+      let iconPath;
+      try {
+        iconPath = await fs.realpath(requestedIconPath);
+      } catch (error) {
+        if (error.code === "ENOENT") throw new Error(`Theme UI icon is missing: ${requestedIconPath}`);
+        throw error;
+      }
+      assertContainedPath(assetsRoot, iconPath, label);
+      let iconHandle;
+      try {
+        iconHandle = await fs.open(iconPath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+      } catch (error) {
+        if (error.code === "ELOOP") throw new Error(`${label} changed into a symbolic link while loading`);
+        throw error;
+      }
+      try {
+        const before = await iconHandle.stat();
+        if (!before.isFile() || before.size < 1 || before.size > MAX_UI_ICON_BYTES) {
+          throw new Error(`${label} must be a non-empty PNG no larger than ${MAX_UI_ICON_BYTES} bytes`);
+        }
+        const bytes = await iconHandle.readFile();
+        const after = await iconHandle.stat();
+        if (!sameFileStat(before, after) || bytes.length !== after.size) {
+          throw new Error(`${label} changed while being loaded`);
+        }
+        const metadata = readImageMetadata(bytes, ".png");
+        if (
+          !metadata
+          || metadata.width < 1
+          || metadata.height < 1
+          || metadata.width > MAX_UI_ICON_SIDE
+          || metadata.height > MAX_UI_ICON_SIDE
+        ) {
+          throw new Error(`${label} must be a valid PNG no larger than ${MAX_UI_ICON_SIDE}px per side`);
+        }
+        iconData = `data:image/png;base64,${bytes.toString("base64")}`;
+        loadedIcons.set(iconName, iconData);
+        uiIconBytes += bytes.length;
+        return iconData;
+      } finally {
+        await iconHandle.close();
+      }
+    };
+    for (const [role, entry] of Object.entries(theme.ui?.sidebar || {})) {
+      if (entry.icon) entry.iconDataUrl = await loadUiIcon(entry.icon, `Theme UI icon ${role}`);
+    }
+    for (const [state, entry] of Object.entries(theme.ui?.projectIcons || {})) {
+      entry.iconDataUrl = await loadUiIcon(entry.icon, `Theme project icon ${state}`);
+    }
     return {
       art,
       assetsRoot,
@@ -744,6 +872,7 @@ export async function loadTheme(themeDir) {
       safeCssPath: safeCss?.path ?? null,
       safeCssStatus: safeCss ? "validated" : "none",
       theme,
+      uiIconBytes,
     };
   } finally {
     await imageHandle.close();
@@ -776,7 +905,7 @@ export async function loadPayload(themeDir) {
     loadTheme(themeDir),
   ]);
   const { css, template } = staticAssets;
-  const { art, extension, safeCss, safeCssStatus, theme } = loaded;
+  const { art, extension, safeCss, safeCssStatus, theme, uiIconBytes = 0 } = loaded;
   const combinedCss = safeCss ? `${css}\n${safeCss}\n` : css;
   const styleRevision = createHash("sha256").update(combinedCss).digest("hex").slice(0, 20);
   const artMetadata = readImageMetadata(art, extension);
@@ -810,6 +939,7 @@ export async function loadPayload(themeDir) {
   assertPayloadIntegrity(payload);
   return {
     imageBytes: art.length,
+    uiIconBytes,
     payload,
     revision,
     safeCssStatus,
@@ -2073,6 +2203,7 @@ if (path.resolve(process.argv[1] || "") === path.resolve(scriptPath)) {
         themeId: loaded.theme.id,
         themeName: loaded.theme.name,
         imageBytes: loaded.imageBytes,
+        uiIconBytes: loaded.uiIconBytes,
         payloadBytes: Buffer.byteLength(loaded.payload),
         safeCssStatus: loaded.safeCssStatus,
         artMetadata: loaded.theme.artMetadata ?? null,

--- a/macos/scripts/stage-theme.mjs
+++ b/macos/scripts/stage-theme.mjs
@@ -12,6 +12,7 @@ if (!sourceDirArg || !stageDirArg) {
 const MAX_CONFIG_BYTES = 1024 * 1024;
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
 const MAX_CSS_BYTES = 256 * 1024;
+const MAX_UI_ICON_BYTES = 256 * 1024;
 const OPEN_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
 
 function assertContained(rootPath, candidatePath, label) {
@@ -106,6 +107,38 @@ async function main() {
     throw new Error("Theme image contains control characters");
   }
 
+  const iconNames = new Set();
+  const addIcon = (entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry) || entry.icon === undefined) return;
+    if (
+      typeof entry.icon !== "string"
+      || path.basename(entry.icon) !== entry.icon
+      || !/\.png$/i.test(entry.icon)
+      || /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u.test(entry.icon)
+    ) {
+      throw new Error("Theme UI icons must be PNG filenames inside the theme directory");
+    }
+    if (entry.icon.toLowerCase() === theme.image.toLowerCase()) {
+      throw new Error("Theme UI icons must not replace the theme image");
+    }
+    iconNames.add(entry.icon);
+  };
+  const sidebar = theme.ui?.sidebar;
+  if (sidebar !== undefined && (!sidebar || typeof sidebar !== "object" || Array.isArray(sidebar))) {
+    throw new Error("Theme ui.sidebar must be an object");
+  }
+  for (const role of [
+    "workspace", "newTask", "pullRequests", "sites", "scheduled", "plugins", "pinned",
+  ]) addIcon(sidebar?.[role]);
+  const projectIcons = theme.ui?.projectIcons;
+  if (
+    projectIcons !== undefined
+    && (!projectIcons || typeof projectIcons !== "object" || Array.isArray(projectIcons))
+  ) {
+    throw new Error("Theme ui.projectIcons must be an object");
+  }
+  for (const state of ["closed", "open"]) addIcon(projectIcons?.[state]);
+
   const imagePath = path.resolve(sourceRoot, theme.image);
   assertContained(sourceRoot, imagePath, "Theme image");
   const [image, safeCss] = await Promise.all([
@@ -114,22 +147,39 @@ async function main() {
   ]);
   if (image.bytes.length < 1) throw new Error("Theme image is empty");
   if (safeCss) decodeAndValidateSafeCss(safeCss.bytes);
+  const icons = [];
+  for (const iconName of [...iconNames].sort()) {
+    const iconPath = path.resolve(sourceRoot, iconName);
+    assertContained(sourceRoot, iconPath, "Theme UI icon");
+    const icon = await readStableFile(iconPath, `Theme UI icon ${iconName}`, MAX_UI_ICON_BYTES);
+    if (icon.bytes.length < 1) throw new Error(`Theme UI icon ${iconName} is empty`);
+    icons.push({ name: iconName, bytes: icon.bytes });
+  }
 
   const stageRoot = await fs.realpath(stageDirArg);
   const stageStat = await fs.stat(stageRoot);
   if (!stageStat.isDirectory()) throw new Error("Theme stage must be a directory");
   assertContained(stageRoot, path.join(stageRoot, "theme.json"), "Staged theme config");
   assertContained(stageRoot, path.join(stageRoot, theme.image), "Staged theme image");
+  for (const icon of icons) {
+    assertContained(stageRoot, path.join(stageRoot, icon.name), "Staged theme UI icon");
+  }
 
-  // Write both files from the already-open, stable descriptors. The caller
-  // publishes the image first and theme.json last, so the watcher only ever
-  // observes a complete pair; subsequent source edits cannot race the copy.
+  // Write every file from already-open, stable descriptors. The caller
+  // publishes assets first and theme.json last, so the watcher only ever
+  // observes a complete pack; subsequent source edits cannot race the copy.
   await writeExclusive(path.join(stageRoot, theme.image), image.bytes);
+  for (const icon of icons) await writeExclusive(path.join(stageRoot, icon.name), icon.bytes);
   if (safeCss) await writeExclusive(path.join(stageRoot, "theme.css"), safeCss.bytes);
   await writeExclusive(path.join(stageRoot, "theme.json"), config.bytes);
   process.stdout.write(JSON.stringify({
     image: theme.image,
-    contentFingerprint: runtimeThemeContentFingerprint(theme, image.bytes, safeCss?.bytes ?? null),
+    contentFingerprint: runtimeThemeContentFingerprint(
+      theme,
+      image.bytes,
+      safeCss?.bytes ?? null,
+      icons,
+    ),
   }));
 }
 

--- a/macos/scripts/switch-theme-macos.sh
+++ b/macos/scripts/switch-theme-macos.sh
@@ -13,6 +13,7 @@ LOCK_TOKEN=""
 APPLY_NOW="true"
 OPERATION_TOKEN=""
 stage=""
+theme_files=()
 
 finish_switch() {
   local code="$1"
@@ -142,7 +143,9 @@ SAFE_CSS_NAME=""
 progress "Publishing validated theme..."
 for entry in "$stage/"*; do
   [ -f "$entry" ] || continue
-  [ "$(/usr/bin/basename "$entry")" = "theme.json" ] && continue
+  entry_name="$(/usr/bin/basename "$entry")"
+  [ "$entry_name" = "theme.json" ] && continue
+  theme_files+=("$entry_name")
   /bin/mv -f "$entry" "$THEME_DIR/"
 done
 # A legacy theme has no Safe CSS. Remove the previous theme's CSS before the
@@ -151,13 +154,16 @@ done
 # theme.json is the commit marker: the watcher never observes a config that
 # references a partially copied image.
 /bin/mv -f "$stage/theme.json" "$THEME_DIR/theme.json"
-if [ -n "$SAFE_CSS_NAME" ]; then
-  /usr/bin/find "$THEME_DIR" -maxdepth 1 -type f \
-    ! -name 'theme.json' ! -name "$THEME_IMAGE" ! -name 'theme.css' -delete
-else
-  /usr/bin/find "$THEME_DIR" -maxdepth 1 -type f \
-    ! -name 'theme.json' ! -name "$THEME_IMAGE" -delete
-fi
+for entry in "$THEME_DIR/"*; do
+  [ -f "$entry" ] || continue
+  entry_name="$(/usr/bin/basename "$entry")"
+  [ "$entry_name" = "theme.json" ] && continue
+  keep="false"
+  for expected in "${theme_files[@]}"; do
+    if [ "$entry_name" = "$expected" ]; then keep="true"; break; fi
+  done
+  [ "$keep" = "true" ] || /bin/rm -f "$entry"
+done
 /bin/rm -rf "$stage"
 stage=""
 

--- a/macos/scripts/theme-content-fingerprint.mjs
+++ b/macos/scripts/theme-content-fingerprint.mjs
@@ -7,7 +7,12 @@ function updateFramed(hash, label, bytes) {
   hash.update(labelBytes).update("\0").update(length).update(bytes);
 }
 
-export function runtimeThemeContentFingerprint(theme, imageBytes, cssBytes = null) {
+export function runtimeThemeContentFingerprint(
+  theme,
+  imageBytes,
+  cssBytes = null,
+  auxiliaryFiles = [],
+) {
   const hash = createHash("sha256");
   hash.update("dreamskin-runtime-theme/1\0");
   updateFramed(hash, "theme.json", Buffer.from(JSON.stringify(theme), "utf8"));
@@ -16,6 +21,10 @@ export function runtimeThemeContentFingerprint(theme, imageBytes, cssBytes = nul
     updateFramed(hash, "theme.css", cssBytes);
   } else {
     hash.update("theme.css\0absent\0");
+  }
+  for (const entry of [...auxiliaryFiles].sort((left, right) =>
+    String(left.name).localeCompare(String(right.name), "en"))) {
+    updateFramed(hash, `asset:${entry.name}`, entry.bytes);
   }
   return hash.digest("hex");
 }

--- a/macos/tests/payload-template-integrity.test.mjs
+++ b/macos/tests/payload-template-integrity.test.mjs
@@ -161,6 +161,61 @@ test("a benign theme name is unaffected by the substitution fix", async () => {
   assert.doesNotThrow(() => new vm.Script(loaded.payload));
 });
 
+test("theme-local UI icons are validated, deduplicated, and embedded in the payload", async () => {
+  const { directory } = await makeThemeDir({
+    ui: {
+      composerPlaceholder: "财神在此，有求必应…",
+      sidebar: {
+        newTask: { label: "开工接财", icon: "icon-ui.png" },
+        sites: { glyph: "🏮" },
+      },
+      projectIcons: {
+        closed: { icon: "icon-ui.png" },
+        open: { icon: "icon-open.png" },
+      },
+    },
+  });
+  const sharedIcon = tinyPng(32, 32);
+  const openIcon = tinyPng(48, 48);
+  await fs.writeFile(path.join(directory, "icon-ui.png"), sharedIcon);
+  await fs.writeFile(path.join(directory, "icon-open.png"), openIcon);
+
+  const loaded = await loadPayload(directory);
+  const captured = readPayloadArguments(loaded.payload);
+  assert.equal(loaded.uiIconBytes, sharedIcon.length + openIcon.length);
+  assert.equal(captured.themeConfig.ui.sidebar.newTask.label, "开工接财");
+  assert.match(
+    captured.themeConfig.ui.sidebar.newTask.iconDataUrl,
+    /^data:image\/png;base64,/,
+  );
+  assert.equal(
+    captured.themeConfig.ui.sidebar.newTask.iconDataUrl,
+    captured.themeConfig.ui.projectIcons.closed.iconDataUrl,
+    "one referenced PNG must be loaded once and reused",
+  );
+  assert.match(captured.themeConfig.ui.projectIcons.open.iconDataUrl, /^data:image\/png;base64,/);
+  assert.equal(captured.themeConfig.ui.sidebar.sites.glyph, "🏮");
+  assert.equal(captured.themeConfig.ui.composerPlaceholder, "财神在此，有求必应…");
+});
+
+test("theme-local UI icon paths and dimensions fail closed", async () => {
+  const traversal = await makeThemeDir({
+    ui: { sidebar: { newTask: { icon: "../outside.png" } } },
+  });
+  await assert.rejects(loadPayload(traversal.directory), /must be a PNG filename/);
+
+  const missing = await makeThemeDir({
+    ui: { sidebar: { newTask: { icon: "missing.png" } } },
+  });
+  await assert.rejects(loadPayload(missing.directory), /Theme UI icon is missing/);
+
+  const oversized = await makeThemeDir({
+    ui: { projectIcons: { closed: { icon: "oversized.png" } } },
+  });
+  await fs.writeFile(path.join(oversized.directory, "oversized.png"), tinyPng(513, 1));
+  await assert.rejects(loadPayload(oversized.directory), /no larger than 512px per side/);
+});
+
 test("payload byte length does not drift with $ constructs", async () => {
   // Corruption showed up as a payload that grew by the whole template or lost
   // bytes. Identical-length names must produce identical-length payloads.

--- a/macos/tests/theme-stage.test.mjs
+++ b/macos/tests/theme-stage.test.mjs
@@ -33,9 +33,21 @@ try {
   await fs.mkdir(source, { recursive: true });
   await fs.mkdir(stage);
   await fs.copyFile(fixtureAsset, path.join(source, "background-a.png"));
+  const iconBytes = Buffer.from("89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489", "hex");
+  await fs.writeFile(path.join(source, "icon-new-task.png"), iconBytes);
+  await fs.writeFile(path.join(source, "icon-folder.png"), iconBytes);
   await fs.writeFile(
     path.join(source, "theme.json"),
-    `${JSON.stringify({ schemaVersion: 1, id: "preset-race", name: "A", image: "background-a.png" })}\n`,
+    `${JSON.stringify({
+      schemaVersion: 1,
+      id: "preset-race",
+      name: "A",
+      image: "background-a.png",
+      ui: {
+        sidebar: { newTask: { icon: "icon-new-task.png" } },
+        projectIcons: { closed: { icon: "icon-folder.png" } },
+      },
+    })}\n`,
   );
 
   const stagedIdentity = JSON.parse(await runStage(source, stage));
@@ -44,6 +56,8 @@ try {
   const stagedConfig = JSON.parse(await fs.readFile(path.join(stage, "theme.json"), "utf8"));
   assert.equal(stagedConfig.image, "background-a.png");
   const stagedBeforeMutation = await fs.readFile(path.join(stage, "background-a.png"));
+  assert.deepEqual(await fs.readFile(path.join(stage, "icon-new-task.png")), iconBytes);
+  assert.deepEqual(await fs.readFile(path.join(stage, "icon-folder.png")), iconBytes);
 
   // A source edit after staging must not change the pair that is about to be
   // published. This is the regression for switch-theme's old copy-after-
@@ -54,7 +68,9 @@ try {
     `${JSON.stringify({ schemaVersion: 1, id: "preset-race", name: "B", image: "background-b.png" })}\n`,
   );
   await fs.writeFile(path.join(source, "background-a.png"), Buffer.from("changed-after-stage"));
+  await fs.writeFile(path.join(source, "icon-new-task.png"), Buffer.from("changed-after-stage"));
   assert.deepEqual(await fs.readFile(path.join(stage, "background-a.png")), stagedBeforeMutation);
+  assert.deepEqual(await fs.readFile(path.join(stage, "icon-new-task.png")), iconBytes);
   assert.equal(JSON.parse(await fs.readFile(path.join(stage, "theme.json"), "utf8")).name, "A");
 
   const secondStage = path.join(tempRoot, "stage-second");
@@ -69,6 +85,21 @@ try {
   await fs.mkdir(cssStage);
   const cssIdentity = JSON.parse(await runStage(stage, cssStage));
   assert.notEqual(cssIdentity.contentFingerprint, stagedIdentity.contentFingerprint);
+
+  const changedIconSource = path.join(tempRoot, "changed-icon");
+  const changedIconStage = path.join(tempRoot, "changed-icon-stage");
+  await fs.cp(stage, changedIconSource, { recursive: true });
+  await fs.mkdir(changedIconStage);
+  await fs.writeFile(path.join(changedIconSource, "icon-new-task.png"), Buffer.concat([
+    iconBytes,
+    Buffer.from("different"),
+  ]));
+  const changedIconIdentity = JSON.parse(await runStage(changedIconSource, changedIconStage));
+  assert.notEqual(
+    changedIconIdentity.contentFingerprint,
+    stagedIdentity.contentFingerprint,
+    "theme icon bytes must be part of the switch fingerprint",
+  );
 
   const outside = path.join(tempRoot, "outside.png");
   await fs.copyFile(fixtureAsset, outside);
@@ -92,6 +123,23 @@ try {
   const symlinkStage = path.join(tempRoot, "symlink-stage");
   await fs.mkdir(symlinkStage);
   await assert.rejects(runStage(symlink, symlinkStage), /symbolic link/);
+
+  const linkedIcon = path.join(tempRoot, "linked-icon");
+  const linkedIconStage = path.join(tempRoot, "linked-icon-stage");
+  await fs.mkdir(linkedIcon);
+  await fs.mkdir(linkedIconStage);
+  await fs.copyFile(fixtureAsset, path.join(linkedIcon, "background.png"));
+  await fs.symlink(outside, path.join(linkedIcon, "icon.png"));
+  await fs.writeFile(
+    path.join(linkedIcon, "theme.json"),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      id: "bad-icon-link",
+      image: "background.png",
+      ui: { sidebar: { newTask: { icon: "icon.png" } } },
+    })}\n`,
+  );
+  await assert.rejects(runStage(linkedIcon, linkedIconStage), /symbolic link/);
 
   console.log("PASS: theme staging snapshots a matched pair and binds it to a stable content fingerprint.");
 } finally {

--- a/runtime/dream-skin.css
+++ b/runtime/dream-skin.css
@@ -262,6 +262,148 @@ html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ a:hover svg {
   color: var(--ds-accent) !important;
 }
 
+/* Theme navigation overrides remain visual-only: native text, aria labels,
+   click handlers, project names, and task names are never rewritten. */
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="nav-label"][data-dream-label],
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="section-label"][data-dream-label],
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="workspace-label"][data-dream-label] {
+  font-size: 0 !important;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="nav-label"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  color: inherit;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 590;
+  letter-spacing: 0;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="workspace-label"] {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="workspace-label"][data-dream-glyph]::before {
+  content: attr(data-dream-glyph);
+  flex: 0 0 auto;
+  font-size: 16px;
+  line-height: 1;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="workspace-label"][data-dream-icon-kind="image"]::before {
+  content: "";
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  background: var(--dream-skin-nav-image) center / contain no-repeat;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="workspace-label"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ds-text);
+  font-size: 17px;
+  line-height: 24px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="nav-icon"] {
+  display: grid !important;
+  flex: 0 0 18px;
+  width: 18px !important;
+  height: 18px !important;
+  place-items: center;
+  line-height: 0 !important;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="nav-icon"] svg,
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="project-icon"] svg {
+  display: none !important;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="nav-icon"][data-dream-glyph]::after {
+  content: attr(data-dream-glyph);
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  color: var(--ds-accent);
+  font-size: 15px;
+  line-height: 18px;
+  text-align: center;
+  transform: translateZ(0);
+  transition: transform .16s ease, filter .16s ease;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="nav-icon"][data-dream-icon-kind="image"]::after {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 18px;
+  background: var(--dream-skin-nav-image) center / contain no-repeat;
+  transform: translateZ(0);
+  transition: transform .16s ease, filter .16s ease;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="project-icon"] {
+  display: grid !important;
+  flex: 0 0 18px;
+  width: 18px !important;
+  height: 18px !important;
+  place-items: center;
+  line-height: 0 !important;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="project-icon"]::after {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 18px;
+  background: var(--dream-skin-project-image) center / 150% no-repeat;
+  filter: drop-shadow(0 1px 2px rgb(var(--ds-accent-rgb) / .18));
+  transform: translateZ(0);
+  transition: transform .16s ease, filter .16s ease;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-app-action-sidebar-project-row]:hover [data-dream-ui-role="project-icon"]::after,
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-button]:hover [data-dream-ui-role="nav-icon"]::after {
+  filter: drop-shadow(0 2px 4px rgb(var(--ds-accent-rgb) / .32));
+  transform: translateY(-1px);
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__
+  [data-dream-ui-role="section-label"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  color: rgb(var(--ds-muted-rgb) / .92);
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 720;
+  letter-spacing: .02em;
+}
+
 html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ button[aria-label^="切换模式"] {
   background: transparent !important;
   border: 0 !important;
@@ -1083,6 +1225,18 @@ html[data-dream-skin="active"] __DREAM_SELECTOR_COMPOSER_CHROME__ button:not([cl
 html[data-dream-skin="active"] __DREAM_SELECTOR_COMPOSER_CHROME__ p.placeholder::after {
   color: rgb(var(--ds-muted-rgb) / .82) !important;
   opacity: 1 !important;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_COMPOSER_CHROME__
+  p.placeholder[data-dream-ui-role="composer-placeholder"][data-dream-label] {
+  font-size: 0 !important;
+}
+
+html[data-dream-skin="active"] __DREAM_SELECTOR_COMPOSER_CHROME__
+  p.placeholder[data-dream-ui-role="composer-placeholder"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  font-size: 15px;
+  line-height: 1.5;
 }
 
 /* Search routes ship an opaque sticky band and input surface. Keep the

--- a/runtime/renderer-inject.js
+++ b/runtime/renderer-inject.js
@@ -18,6 +18,10 @@
   const PAYLOAD_REVISION = __DREAM_SKIN_PAYLOAD_REVISION_JSON__;
   const THEME = themeConfig && typeof themeConfig === "object" ? themeConfig : {};
   const ART = THEME.art && typeof THEME.art === "object" ? THEME.art : {};
+  const UI = THEME.ui && typeof THEME.ui === "object" ? THEME.ui : {};
+  const SIDEBAR_UI = UI.sidebar && typeof UI.sidebar === "object" ? UI.sidebar : {};
+  const PROJECT_ICONS = UI.projectIcons && typeof UI.projectIcons === "object"
+    ? UI.projectIcons : {};
   const ART_METADATA = THEME.artMetadata && typeof THEME.artMetadata === "object"
     ? THEME.artMetadata : null;
   const ANALYSIS_CACHE_KEY = "__CODEX_DREAM_SKIN_ANALYSIS_CACHE__";
@@ -569,6 +573,15 @@
   };
 
   const partNodes = new Set();
+  const uiNodes = new Set();
+  const UI_ATTRIBUTES = [
+    "data-dream-ui-role",
+    "data-dream-ui-button",
+    "data-dream-label",
+    "data-dream-glyph",
+    "data-dream-icon-kind",
+    "data-dream-project-state",
+  ];
   const queryAll = (selector) => {
     if (!selector) return [];
     try { return [...document.querySelectorAll(selector)]; } catch { return []; }
@@ -580,6 +593,137 @@
         desired.set(node, part);
       }
     }
+  };
+  const clearVisualNode = (node) => {
+    for (const attribute of UI_ATTRIBUTES) node.removeAttribute?.(attribute);
+    node.style?.removeProperty("--dream-skin-nav-image");
+    node.style?.removeProperty("--dream-skin-project-image");
+  };
+  const markVisualNode = (desired, node, attributes = {}, styles = {}) => {
+    if (!node) return;
+    desired.add(node);
+    for (const [name, value] of Object.entries(attributes)) {
+      if (typeof value === "string" && value) setAttribute(node, name, value);
+    }
+    for (const [name, value] of Object.entries(styles)) {
+      if (typeof value === "string" && value) setStyleProperty(node, name, value);
+    }
+  };
+  const normalizedNativeLabel = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const findButtonByNativeLabel = (buttons, labels) => buttons.find((button) =>
+    labels.includes(normalizedNativeLabel(button.textContent)));
+  const applySidebarButtonOverride = (desired, button, role, spec, workspace = false) => {
+    if (!button || !spec || typeof spec !== "object") return;
+    markVisualNode(desired, button, { "data-dream-ui-button": role });
+    const label = workspace
+      ? button.querySelector?.("span.truncate") || button.querySelector?.("span")
+      : button.querySelector?.(".text-fade-truncate");
+    if (spec.label) {
+      markVisualNode(desired, label, {
+        "data-dream-ui-role": workspace ? "workspace-label" : "nav-label",
+        "data-dream-label": spec.label,
+      });
+    }
+    if (spec.iconDataUrl) {
+      if (workspace) {
+        markVisualNode(desired, label, {
+          "data-dream-ui-role": "workspace-label",
+          "data-dream-icon-kind": "image",
+        }, {
+          "--dream-skin-nav-image": `url("${spec.iconDataUrl}")`,
+        });
+        return;
+      }
+      const icon = button.querySelector?.("svg")?.parentElement;
+      markVisualNode(desired, icon, {
+        "data-dream-ui-role": "nav-icon",
+        "data-dream-icon-kind": "image",
+      }, {
+        "--dream-skin-nav-image": `url("${spec.iconDataUrl}")`,
+      });
+      return;
+    }
+    if (!spec.glyph) return;
+    if (workspace) {
+      markVisualNode(desired, label, {
+        "data-dream-ui-role": "workspace-label",
+        "data-dream-glyph": spec.glyph,
+      });
+      return;
+    }
+    const icon = button.querySelector?.("svg")?.parentElement;
+    markVisualNode(desired, icon, {
+      "data-dream-ui-role": "nav-icon",
+      "data-dream-glyph": spec.glyph,
+    });
+  };
+  const refreshVisualOverrides = () => {
+    const desired = new Set();
+    const sidebar = selectorNodes("left-panel")[0];
+    if (sidebar && Object.keys(SIDEBAR_UI).length) {
+      const buttons = [...(sidebar.querySelectorAll?.("button") || [])];
+      const workspaceButton = buttons.find((button) => {
+        const label = normalizedNativeLabel(button.getAttribute?.("aria-label"));
+        return label.startsWith("切换模式") || label.toLowerCase().startsWith("switch mode");
+      });
+      applySidebarButtonOverride(
+        desired, workspaceButton, "workspace", SIDEBAR_UI.workspace, true,
+      );
+      for (const [role, labels] of [
+        ["newTask", ["新建任务", "New task", "New thread"]],
+        ["pullRequests", ["拉取请求", "Pull requests"]],
+        ["sites", ["站点", "Sites"]],
+        ["scheduled", ["已安排", "Scheduled"]],
+        ["plugins", ["插件", "Plugins"]],
+      ]) {
+        applySidebarButtonOverride(
+          desired,
+          findButtonByNativeLabel(buttons, labels),
+          role,
+          SIDEBAR_UI[role],
+        );
+      }
+      if (SIDEBAR_UI.pinned?.label) {
+        const toggles = [
+          ...(sidebar.querySelectorAll?.("button[data-app-action-sidebar-section-toggle]") || []),
+        ];
+        const pinnedLabel = findButtonByNativeLabel(toggles, ["置顶", "Pinned"])
+          ?.querySelector?.("span");
+        markVisualNode(desired, pinnedLabel, {
+          "data-dream-ui-role": "section-label",
+          "data-dream-label": SIDEBAR_UI.pinned.label,
+        });
+      }
+    }
+    if (sidebar && Object.keys(PROJECT_ICONS).length) {
+      for (const row of sidebar.querySelectorAll?.("[data-app-action-sidebar-project-row]") || []) {
+        const icon = row.querySelector?.('[data-sidebar-project-drop-zone="project-icon"]')
+          || row.querySelector?.(":scope > span:first-child");
+        if (!icon?.querySelector?.("svg")) continue;
+        const state = row.getAttribute?.("aria-expanded") === "true" ? "open" : "closed";
+        const spec = PROJECT_ICONS[state];
+        if (!spec?.iconDataUrl) continue;
+        markVisualNode(desired, icon, {
+          "data-dream-ui-role": "project-icon",
+          "data-dream-icon-kind": "image",
+          "data-dream-project-state": state,
+        }, {
+          "--dream-skin-project-image": `url("${spec.iconDataUrl}")`,
+        });
+      }
+    }
+    if (typeof UI.composerPlaceholder === "string" && UI.composerPlaceholder) {
+      const placeholder = selectorNodes("composer-chrome")[0]?.querySelector?.("p.placeholder");
+      markVisualNode(desired, placeholder, {
+        "data-dream-ui-role": "composer-placeholder",
+        "data-dream-label": UI.composerPlaceholder,
+      });
+    }
+    for (const node of uiNodes) {
+      if (!desired.has(node)) clearVisualNode(node);
+    }
+    uiNodes.clear();
+    for (const node of desired) uiNodes.add(node);
   };
   const refreshParts = () => {
     metrics.partPasses += 1;
@@ -612,12 +756,20 @@
       }
       partNodes.add(node);
     }
+    refreshVisualOverrides();
   };
 
   const removeParts = () => {
     for (const node of partNodes) node.removeAttribute?.(PART_ATTR);
     partNodes.clear();
     for (const node of queryAll(`[${PART_ATTR}]`)) node.removeAttribute?.(PART_ATTR);
+  };
+  const removeVisualOverrides = () => {
+    for (const node of uiNodes) clearVisualNode(node);
+    uiNodes.clear();
+    for (const node of queryAll("[data-dream-ui-role], [data-dream-ui-button]")) {
+      clearVisualNode(node);
+    }
   };
 
   const scopeMatches = (scope, baseState, overlay) => {
@@ -685,6 +837,7 @@
       }
     }
     removeParts();
+    removeVisualOverrides();
     state?.rootObserver?.disconnect();
     state?.partObserver?.disconnect();
     if (bodyReadyHandler && typeof document.removeEventListener === "function") {
@@ -791,7 +944,12 @@
   };
   const observePartTree = (node) => {
     if (!partObserver || !node) return;
-    partObserver.observe(node, { childList: true, subtree: true });
+    partObserver.observe(node, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["aria-expanded"],
+    });
   };
   observeAttributes(document.documentElement);
   const observeBody = () => {

--- a/tools/renderer-runtime.test.mjs
+++ b/tools/renderer-runtime.test.mjs
@@ -43,14 +43,24 @@ function makeFixture({ nativeAppearance = "dark", settings = false, adopted = tr
   let nextBlob = 0;
   const attributesFor = (values) => [...values].map(([name, value]) => ({ name, value }));
   const makeDomNode = (name, parentElement = null, values = new Map()) => {
+    const localSelectors = new Map();
     const node = {
       name,
       parentElement,
+      textContent: "",
+      style: styleDeclaration(),
+      children: [],
       get attributes() { return attributesFor(values); },
       getAttribute(attribute) { return values.get(attribute) ?? null; },
       setAttribute(attribute, value) { values.set(attribute, String(value)); },
       removeAttribute(attribute) { values.delete(attribute); },
-      appendChild(child) { child.parentElement = node; return child; },
+      appendChild(child) { child.parentElement = node; node.children.push(child); return child; },
+      querySelector(selector) { return (localSelectors.get(selector) || [])[0] || null; },
+      querySelectorAll(selector) { return [...(localSelectors.get(selector) || [])]; },
+      registerSelector(selector, ...registered) {
+        localSelectors.set(selector, registered);
+        return node;
+      },
     };
     domNodes.add(node);
     return node;
@@ -87,6 +97,55 @@ function makeFixture({ nativeAppearance = "dark", settings = false, adopted = tr
     partFixtures.message = makeDomNode("message", partFixtures.thread);
     partFixtures.composer = makeDomNode("composer", partFixtures.main);
     partFixtures.composerToolbar = makeDomNode("composer-toolbar", partFixtures.composer);
+    partFixtures.workspaceButton = makeDomNode(
+      "workspace-button",
+      partFixtures.sidebar,
+      new Map([["aria-label", "切换模式"]]),
+    );
+    partFixtures.workspaceLabel = makeDomNode("workspace-label", partFixtures.workspaceButton);
+    partFixtures.workspaceButton
+      .registerSelector("span.truncate", partFixtures.workspaceLabel)
+      .registerSelector("span", partFixtures.workspaceLabel);
+    partFixtures.newTaskButton = makeDomNode("new-task-button", partFixtures.sidebar);
+    partFixtures.newTaskButton.textContent = "新建任务";
+    partFixtures.newTaskLabel = makeDomNode("new-task-label", partFixtures.newTaskButton);
+    partFixtures.newTaskIcon = makeDomNode("new-task-icon", partFixtures.newTaskButton);
+    partFixtures.newTaskSvg = makeDomNode("new-task-svg", partFixtures.newTaskIcon);
+    partFixtures.newTaskButton
+      .registerSelector(".text-fade-truncate", partFixtures.newTaskLabel)
+      .registerSelector("svg", partFixtures.newTaskSvg);
+    partFixtures.pinnedButton = makeDomNode("pinned-button", partFixtures.sidebar);
+    partFixtures.pinnedButton.textContent = "置顶";
+    partFixtures.pinnedLabel = makeDomNode("pinned-label", partFixtures.pinnedButton);
+    partFixtures.pinnedButton.registerSelector("span", partFixtures.pinnedLabel);
+    partFixtures.projectRow = makeDomNode(
+      "project-row",
+      partFixtures.sidebar,
+      new Map([["aria-expanded", "false"]]),
+    );
+    partFixtures.projectIcon = makeDomNode("project-icon", partFixtures.projectRow);
+    partFixtures.projectSvg = makeDomNode("project-svg", partFixtures.projectIcon);
+    partFixtures.projectIcon.registerSelector("svg", partFixtures.projectSvg);
+    partFixtures.projectRow
+      .registerSelector(
+        '[data-sidebar-project-drop-zone="project-icon"]',
+        partFixtures.projectIcon,
+      )
+      .registerSelector(":scope > span:first-child", partFixtures.projectIcon);
+    partFixtures.placeholder = makeDomNode("composer-placeholder", partFixtures.composer);
+    partFixtures.composer.registerSelector("p.placeholder", partFixtures.placeholder);
+    partFixtures.sidebar
+      .registerSelector(
+        "button",
+        partFixtures.workspaceButton,
+        partFixtures.newTaskButton,
+        partFixtures.pinnedButton,
+      )
+      .registerSelector(
+        "button[data-app-action-sidebar-section-toggle]",
+        partFixtures.pinnedButton,
+      )
+      .registerSelector("[data-app-action-sidebar-project-row]", partFixtures.projectRow);
     register("aside.app-shell-left-panel", partFixtures.sidebar);
     register("main.main-surface", partFixtures.main);
     register("header.app-header-tint", partFixtures.header);
@@ -125,6 +184,11 @@ function makeFixture({ nativeAppearance = "dark", settings = false, adopted = tr
     querySelectorAll(selector) {
       if (selector === "[data-ds-part]") {
         return [...domNodes].filter((node) => node.getAttribute?.("data-ds-part") !== null);
+      }
+      if (selector === "[data-dream-ui-role], [data-dream-ui-button]") {
+        return [...domNodes].filter((node) =>
+          node.getAttribute?.("data-dream-ui-role") !== null
+          || node.getAttribute?.("data-dream-ui-button") !== null);
       }
       return [...(selectorNodes.get(selector) || [])];
     },
@@ -330,6 +394,59 @@ export async function runRendererRuntimeTest(assetRoot) {
   partObserver.callback([{ type: "childList" }]);
   home.flushTimers(80);
   assert.equal(dynamicMessage.getAttribute("data-ds-part"), "message");
+
+  const themedUi = makeFixture({ nativeAppearance: "dark" });
+  vm.runInNewContext(themedUi.payloadFor({
+    ui: {
+      composerPlaceholder: "财神在此，有求必应…",
+      sidebar: {
+        workspace: { label: "财神工位", iconDataUrl: "data:image/png;base64,d29ya3NwYWNl" },
+        newTask: { label: "开工接财", iconDataUrl: "data:image/png;base64,bmV3LXRhc2s=" },
+        pinned: { label: "财神置顶" },
+      },
+      projectIcons: {
+        closed: { iconDataUrl: "data:image/png;base64,Y2xvc2Vk" },
+        open: { iconDataUrl: "data:image/png;base64,b3Blbg==" },
+      },
+    },
+  }), themedUi.context);
+  const themedParts = themedUi.partFixtures;
+  assert.equal(themedParts.workspaceButton.getAttribute("data-dream-ui-button"), "workspace");
+  assert.equal(themedParts.workspaceLabel.getAttribute("data-dream-label"), "财神工位");
+  assert.equal(themedParts.workspaceLabel.getAttribute("data-dream-icon-kind"), "image");
+  assert.match(
+    themedParts.workspaceLabel.style.values.get("--dream-skin-nav-image"),
+    /d29ya3NwYWNl/,
+  );
+  assert.equal(themedParts.newTaskButton.getAttribute("data-dream-ui-button"), "newTask");
+  assert.equal(themedParts.newTaskLabel.getAttribute("data-dream-label"), "开工接财");
+  assert.equal(themedParts.newTaskIcon.getAttribute("data-dream-ui-role"), "nav-icon");
+  assert.equal(themedParts.pinnedLabel.getAttribute("data-dream-label"), "财神置顶");
+  assert.equal(themedParts.projectIcon.getAttribute("data-dream-project-state"), "closed");
+  assert.match(
+    themedParts.projectIcon.style.values.get("--dream-skin-project-image"),
+    /Y2xvc2Vk/,
+  );
+  assert.equal(themedParts.placeholder.getAttribute("data-dream-label"), "财神在此，有求必应…");
+
+  const themedPartObserver = themedUi.observers.find((observer) => observer.options?.childList);
+  assert.equal(
+    Array.from(themedPartObserver.options.attributeFilter).join(","),
+    "aria-expanded",
+    "project folder artwork must follow the native expanded state",
+  );
+  themedParts.projectRow.setAttribute("aria-expanded", "true");
+  themedPartObserver.callback([{ type: "attributes", attributeName: "aria-expanded" }]);
+  themedUi.flushTimers(80);
+  assert.equal(themedParts.projectIcon.getAttribute("data-dream-project-state"), "open");
+  assert.match(
+    themedParts.projectIcon.style.values.get("--dream-skin-project-image"),
+    /b3Blbg/,
+  );
+  assert.equal(themedUi.window.__CODEX_DREAM_SKIN_STATE__.cleanup(), true);
+  assert.equal(themedParts.newTaskLabel.getAttribute("data-dream-label"), null);
+  assert.equal(themedParts.projectIcon.getAttribute("data-dream-ui-role"), null);
+  assert.equal(themedParts.projectIcon.style.values.get("--dream-skin-project-image"), undefined);
 
   const full = makeFixture({ nativeAppearance: "dark" });
   vm.runInNewContext(full.payloadFor({ art: { taskMode: "full" } }), full.context);

--- a/windows/assets/dream-skin.css
+++ b/windows/assets/dream-skin.css
@@ -262,6 +262,148 @@ html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg {
   color: var(--ds-accent) !important;
 }
 
+/* Theme navigation overrides remain visual-only: native text, aria labels,
+   click handlers, project names, and task names are never rewritten. */
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-label"][data-dream-label],
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="section-label"][data-dream-label],
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"][data-dream-label] {
+  font-size: 0 !important;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-label"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  color: inherit;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 590;
+  letter-spacing: 0;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"] {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"][data-dream-glyph]::before {
+  content: attr(data-dream-glyph);
+  flex: 0 0 auto;
+  font-size: 16px;
+  line-height: 1;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"][data-dream-icon-kind="image"]::before {
+  content: "";
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  background: var(--dream-skin-nav-image) center / contain no-repeat;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="workspace-label"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ds-text);
+  font-size: 17px;
+  line-height: 24px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-icon"] {
+  display: grid !important;
+  flex: 0 0 18px;
+  width: 18px !important;
+  height: 18px !important;
+  place-items: center;
+  line-height: 0 !important;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-icon"] svg,
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="project-icon"] svg {
+  display: none !important;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-icon"][data-dream-glyph]::after {
+  content: attr(data-dream-glyph);
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  color: var(--ds-accent);
+  font-size: 15px;
+  line-height: 18px;
+  text-align: center;
+  transform: translateZ(0);
+  transition: transform .16s ease, filter .16s ease;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="nav-icon"][data-dream-icon-kind="image"]::after {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 18px;
+  background: var(--dream-skin-nav-image) center / contain no-repeat;
+  transform: translateZ(0);
+  transition: transform .16s ease, filter .16s ease;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="project-icon"] {
+  display: grid !important;
+  flex: 0 0 18px;
+  width: 18px !important;
+  height: 18px !important;
+  place-items: center;
+  line-height: 0 !important;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="project-icon"]::after {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 18px;
+  background: var(--dream-skin-project-image) center / 150% no-repeat;
+  filter: drop-shadow(0 1px 2px rgb(var(--ds-accent-rgb) / .18));
+  transform: translateZ(0);
+  transition: transform .16s ease, filter .16s ease;
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-app-action-sidebar-project-row]:hover [data-dream-ui-role="project-icon"]::after,
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-button]:hover [data-dream-ui-role="nav-icon"]::after {
+  filter: drop-shadow(0 2px 4px rgb(var(--ds-accent-rgb) / .32));
+  transform: translateY(-1px);
+}
+
+html[data-dream-skin="active"] aside.app-shell-left-panel
+  [data-dream-ui-role="section-label"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  color: rgb(var(--ds-muted-rgb) / .92);
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 720;
+  letter-spacing: .02em;
+}
+
 html[data-dream-skin="active"] aside.app-shell-left-panel button[aria-label^="切换模式"] {
   background: transparent !important;
   border: 0 !important;
@@ -1083,6 +1225,18 @@ html[data-dream-skin="active"] .composer-surface-chrome button:not([class~="bg-t
 html[data-dream-skin="active"] .composer-surface-chrome p.placeholder::after {
   color: rgb(var(--ds-muted-rgb) / .82) !important;
   opacity: 1 !important;
+}
+
+html[data-dream-skin="active"] .composer-surface-chrome
+  p.placeholder[data-dream-ui-role="composer-placeholder"][data-dream-label] {
+  font-size: 0 !important;
+}
+
+html[data-dream-skin="active"] .composer-surface-chrome
+  p.placeholder[data-dream-ui-role="composer-placeholder"][data-dream-label]::after {
+  content: attr(data-dream-label);
+  font-size: 15px;
+  line-height: 1.5;
 }
 
 /* Search routes ship an opaque sticky band and input surface. Keep the

--- a/windows/assets/renderer-inject.js
+++ b/windows/assets/renderer-inject.js
@@ -18,6 +18,10 @@
   const PAYLOAD_REVISION = __DREAM_SKIN_PAYLOAD_REVISION_JSON__;
   const THEME = themeConfig && typeof themeConfig === "object" ? themeConfig : {};
   const ART = THEME.art && typeof THEME.art === "object" ? THEME.art : {};
+  const UI = THEME.ui && typeof THEME.ui === "object" ? THEME.ui : {};
+  const SIDEBAR_UI = UI.sidebar && typeof UI.sidebar === "object" ? UI.sidebar : {};
+  const PROJECT_ICONS = UI.projectIcons && typeof UI.projectIcons === "object"
+    ? UI.projectIcons : {};
   const ART_METADATA = THEME.artMetadata && typeof THEME.artMetadata === "object"
     ? THEME.artMetadata : null;
   const ANALYSIS_CACHE_KEY = "__CODEX_DREAM_SKIN_ANALYSIS_CACHE__";
@@ -569,6 +573,15 @@
   };
 
   const partNodes = new Set();
+  const uiNodes = new Set();
+  const UI_ATTRIBUTES = [
+    "data-dream-ui-role",
+    "data-dream-ui-button",
+    "data-dream-label",
+    "data-dream-glyph",
+    "data-dream-icon-kind",
+    "data-dream-project-state",
+  ];
   const queryAll = (selector) => {
     if (!selector) return [];
     try { return [...document.querySelectorAll(selector)]; } catch { return []; }
@@ -580,6 +593,137 @@
         desired.set(node, part);
       }
     }
+  };
+  const clearVisualNode = (node) => {
+    for (const attribute of UI_ATTRIBUTES) node.removeAttribute?.(attribute);
+    node.style?.removeProperty("--dream-skin-nav-image");
+    node.style?.removeProperty("--dream-skin-project-image");
+  };
+  const markVisualNode = (desired, node, attributes = {}, styles = {}) => {
+    if (!node) return;
+    desired.add(node);
+    for (const [name, value] of Object.entries(attributes)) {
+      if (typeof value === "string" && value) setAttribute(node, name, value);
+    }
+    for (const [name, value] of Object.entries(styles)) {
+      if (typeof value === "string" && value) setStyleProperty(node, name, value);
+    }
+  };
+  const normalizedNativeLabel = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const findButtonByNativeLabel = (buttons, labels) => buttons.find((button) =>
+    labels.includes(normalizedNativeLabel(button.textContent)));
+  const applySidebarButtonOverride = (desired, button, role, spec, workspace = false) => {
+    if (!button || !spec || typeof spec !== "object") return;
+    markVisualNode(desired, button, { "data-dream-ui-button": role });
+    const label = workspace
+      ? button.querySelector?.("span.truncate") || button.querySelector?.("span")
+      : button.querySelector?.(".text-fade-truncate");
+    if (spec.label) {
+      markVisualNode(desired, label, {
+        "data-dream-ui-role": workspace ? "workspace-label" : "nav-label",
+        "data-dream-label": spec.label,
+      });
+    }
+    if (spec.iconDataUrl) {
+      if (workspace) {
+        markVisualNode(desired, label, {
+          "data-dream-ui-role": "workspace-label",
+          "data-dream-icon-kind": "image",
+        }, {
+          "--dream-skin-nav-image": `url("${spec.iconDataUrl}")`,
+        });
+        return;
+      }
+      const icon = button.querySelector?.("svg")?.parentElement;
+      markVisualNode(desired, icon, {
+        "data-dream-ui-role": "nav-icon",
+        "data-dream-icon-kind": "image",
+      }, {
+        "--dream-skin-nav-image": `url("${spec.iconDataUrl}")`,
+      });
+      return;
+    }
+    if (!spec.glyph) return;
+    if (workspace) {
+      markVisualNode(desired, label, {
+        "data-dream-ui-role": "workspace-label",
+        "data-dream-glyph": spec.glyph,
+      });
+      return;
+    }
+    const icon = button.querySelector?.("svg")?.parentElement;
+    markVisualNode(desired, icon, {
+      "data-dream-ui-role": "nav-icon",
+      "data-dream-glyph": spec.glyph,
+    });
+  };
+  const refreshVisualOverrides = () => {
+    const desired = new Set();
+    const sidebar = selectorNodes("left-panel")[0];
+    if (sidebar && Object.keys(SIDEBAR_UI).length) {
+      const buttons = [...(sidebar.querySelectorAll?.("button") || [])];
+      const workspaceButton = buttons.find((button) => {
+        const label = normalizedNativeLabel(button.getAttribute?.("aria-label"));
+        return label.startsWith("切换模式") || label.toLowerCase().startsWith("switch mode");
+      });
+      applySidebarButtonOverride(
+        desired, workspaceButton, "workspace", SIDEBAR_UI.workspace, true,
+      );
+      for (const [role, labels] of [
+        ["newTask", ["新建任务", "New task", "New thread"]],
+        ["pullRequests", ["拉取请求", "Pull requests"]],
+        ["sites", ["站点", "Sites"]],
+        ["scheduled", ["已安排", "Scheduled"]],
+        ["plugins", ["插件", "Plugins"]],
+      ]) {
+        applySidebarButtonOverride(
+          desired,
+          findButtonByNativeLabel(buttons, labels),
+          role,
+          SIDEBAR_UI[role],
+        );
+      }
+      if (SIDEBAR_UI.pinned?.label) {
+        const toggles = [
+          ...(sidebar.querySelectorAll?.("button[data-app-action-sidebar-section-toggle]") || []),
+        ];
+        const pinnedLabel = findButtonByNativeLabel(toggles, ["置顶", "Pinned"])
+          ?.querySelector?.("span");
+        markVisualNode(desired, pinnedLabel, {
+          "data-dream-ui-role": "section-label",
+          "data-dream-label": SIDEBAR_UI.pinned.label,
+        });
+      }
+    }
+    if (sidebar && Object.keys(PROJECT_ICONS).length) {
+      for (const row of sidebar.querySelectorAll?.("[data-app-action-sidebar-project-row]") || []) {
+        const icon = row.querySelector?.('[data-sidebar-project-drop-zone="project-icon"]')
+          || row.querySelector?.(":scope > span:first-child");
+        if (!icon?.querySelector?.("svg")) continue;
+        const state = row.getAttribute?.("aria-expanded") === "true" ? "open" : "closed";
+        const spec = PROJECT_ICONS[state];
+        if (!spec?.iconDataUrl) continue;
+        markVisualNode(desired, icon, {
+          "data-dream-ui-role": "project-icon",
+          "data-dream-icon-kind": "image",
+          "data-dream-project-state": state,
+        }, {
+          "--dream-skin-project-image": `url("${spec.iconDataUrl}")`,
+        });
+      }
+    }
+    if (typeof UI.composerPlaceholder === "string" && UI.composerPlaceholder) {
+      const placeholder = selectorNodes("composer-chrome")[0]?.querySelector?.("p.placeholder");
+      markVisualNode(desired, placeholder, {
+        "data-dream-ui-role": "composer-placeholder",
+        "data-dream-label": UI.composerPlaceholder,
+      });
+    }
+    for (const node of uiNodes) {
+      if (!desired.has(node)) clearVisualNode(node);
+    }
+    uiNodes.clear();
+    for (const node of desired) uiNodes.add(node);
   };
   const refreshParts = () => {
     metrics.partPasses += 1;
@@ -612,12 +756,20 @@
       }
       partNodes.add(node);
     }
+    refreshVisualOverrides();
   };
 
   const removeParts = () => {
     for (const node of partNodes) node.removeAttribute?.(PART_ATTR);
     partNodes.clear();
     for (const node of queryAll(`[${PART_ATTR}]`)) node.removeAttribute?.(PART_ATTR);
+  };
+  const removeVisualOverrides = () => {
+    for (const node of uiNodes) clearVisualNode(node);
+    uiNodes.clear();
+    for (const node of queryAll("[data-dream-ui-role], [data-dream-ui-button]")) {
+      clearVisualNode(node);
+    }
   };
 
   const scopeMatches = (scope, baseState, overlay) => {
@@ -685,6 +837,7 @@
       }
     }
     removeParts();
+    removeVisualOverrides();
     state?.rootObserver?.disconnect();
     state?.partObserver?.disconnect();
     if (bodyReadyHandler && typeof document.removeEventListener === "function") {
@@ -791,7 +944,12 @@
   };
   const observePartTree = (node) => {
     if (!partObserver || !node) return;
-    partObserver.observe(node, { childList: true, subtree: true });
+    partObserver.observe(node, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["aria-expanded"],
+    });
   };
   observeAttributes(document.documentElement);
   const observeBody = () => {


### PR DESCRIPTION
## Summary

- add visual-only sidebar labels, navigation icons, project-folder icons, and composer placeholder overrides for local macOS themes
- keep native text, accessibility labels, event handlers, project/task names, ordering, and expansion state unchanged
- stage referenced PNG assets atomically with the theme and include them in the runtime content fingerprint
- keep the canonical renderer attribute-only and synchronize the generated macOS/Windows runtime assets

## Why

The existing background theme contract could not preserve a complete visual pack when switching themes. Custom navigation and project-folder artwork had to be applied separately, and the pre-v1.5 implementation depended on retired renderer marker classes.

## Validation

- `node --test macos/tests/*.test.mjs windows/tests/*.test.mjs` — 76 passed
- macOS complete repository regression suite — passed
- macOS Swift build and XCTest — 10 passed
- both platform payload checks — passed
- shared runtime asset synchronization and `git diff --check` — passed

Signed-runtime integrations and Doctor were skipped using the same repository test mode as CI because they require an installed signed app/runtime.

## Scope notes

- generated images and screenshots under `output/` are intentionally not included
- official/simple ZIP import contracts remain unchanged; visual icon packs are currently supported in local macOS saved theme folders
- no version bump or release publication is included
