### PR TITLE
fix(runtime): resync image-metadata.mjs after #68

### DIFF
--- a/runtime/image-metadata.mjs
+++ b/runtime/image-metadata.mjs
@@ -119,13 +119,21 @@ export function classifyImageDimensions({ width, height }) {
   };
 }
 
-export function readImageMetadata(value, extension = "") {
+// Raw pixel dimensions straight from the container header — no decode, and no
+// safety-cap classification, so callers can reject oversized images *before*
+// anything rasterizes them. Returns null for formats this header parser does
+// not recognize (e.g. HEIC/TIFF).
+export function readRawDimensions(value, extension = "") {
   const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
   const normalized = extension.toLowerCase();
-  let dimensions = null;
-  if (normalized === ".png" || bytes[0] === 0x89) dimensions = pngDimensions(bytes);
-  else if (normalized === ".jpg" || normalized === ".jpeg" ||
-    (bytes[0] === 0xff && bytes[1] === 0xd8)) dimensions = jpegDimensions(bytes);
-  else if (normalized === ".webp" || ascii(bytes, 8, 4) === "WEBP") dimensions = webpDimensions(bytes);
+  if (normalized === ".png" || bytes[0] === 0x89) return pngDimensions(bytes);
+  if (normalized === ".jpg" || normalized === ".jpeg" ||
+    (bytes[0] === 0xff && bytes[1] === 0xd8)) return jpegDimensions(bytes);
+  if (normalized === ".webp" || ascii(bytes, 8, 4) === "WEBP") return webpDimensions(bytes);
+  return null;
+}
+
+export function readImageMetadata(value, extension = "") {
+  const dimensions = readRawDimensions(value, extension);
   return dimensions ? classifyImageDimensions(dimensions) : null;
 }

--- a/windows/scripts/image-metadata.mjs
+++ b/windows/scripts/image-metadata.mjs
@@ -123,14 +123,22 @@ export function classifyImageDimensions({ width, height }) {
   };
 }
 
-export function readImageMetadata(value, extension = "") {
+// Raw pixel dimensions straight from the container header — no decode, and no
+// safety-cap classification, so callers can reject oversized images *before*
+// anything rasterizes them. Returns null for formats this header parser does
+// not recognize (e.g. HEIC/TIFF).
+export function readRawDimensions(value, extension = "") {
   const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
   const normalized = extension.toLowerCase();
-  let dimensions = null;
-  if (normalized === ".png" || bytes[0] === 0x89) dimensions = pngDimensions(bytes);
-  else if (normalized === ".jpg" || normalized === ".jpeg" ||
-    (bytes[0] === 0xff && bytes[1] === 0xd8)) dimensions = jpegDimensions(bytes);
-  else if (normalized === ".webp" || ascii(bytes, 8, 4) === "WEBP") dimensions = webpDimensions(bytes);
+  if (normalized === ".png" || bytes[0] === 0x89) return pngDimensions(bytes);
+  if (normalized === ".jpg" || normalized === ".jpeg" ||
+    (bytes[0] === 0xff && bytes[1] === 0xd8)) return jpegDimensions(bytes);
+  if (normalized === ".webp" || ascii(bytes, 8, 4) === "WEBP") return webpDimensions(bytes);
+  return null;
+}
+
+export function readImageMetadata(value, extension = "") {
+  const dimensions = readRawDimensions(value, extension);
   return dimensions ? classifyImageDimensions(dimensions) : null;
 }
 


### PR DESCRIPTION
## Summary
`#68` (merged) added `readRawDimensions()` directly to the generated `macos/scripts/image-metadata.mjs` without updating the canonical `runtime/image-metadata.mjs` source that `tools/sync-runtime-assets.mjs` generates it from. Result:
- `node tools/sync-runtime-assets.mjs --check` fails on current `main` (`out-of-date=macos/scripts/image-metadata.mjs`), and `macos/tests/run-tests.sh` exits 1.
- `windows/scripts/image-metadata.mjs` never picked up `readRawDimensions` at all — cross-platform drift.

## Fix
Port the same `readRawDimensions` split into `runtime/image-metadata.mjs` (the actual source of truth) and regenerate both platform outputs via `node tools/sync-runtime-assets.mjs`.

## Verification
- `node tools/sync-runtime-assets.mjs --check` → exit 0 (clean)
- `NODE=$(which node) bash macos/tests/run-tests.sh` → full suite passes (previously failed at the image-metadata drift check)