### PR TITLE
fix(macos): resync renderer-verification test fixtures with runtime contract

### DIFF
--- a/macos/scripts/injector.mjs
+++ b/macos/scripts/injector.mjs
@@ -43,7 +43,11 @@ const stableTestidLiteral = (testid) => {
   }
   return JSON.stringify(`[data-testid="${testid}"]`);
 };
-export const SKIN_VERSION = "1.5.11";
+const SKIN_VERSION = "1.5.11";
+// .github/workflows/ci.yml's version-consistency check greps this file for a
+// literal `const SKIN_VERSION = "...";` line, so the export stays a separate
+// statement rather than an inline `export const`.
+export { SKIN_VERSION };
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
 const CDP_ID_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
 const MAX_ART_BYTES = 10 * 1024 * 1024;

--- a/macos/scripts/injector.mjs
+++ b/macos/scripts/injector.mjs
@@ -43,7 +43,7 @@ const stableTestidLiteral = (testid) => {
   }
   return JSON.stringify(`[data-testid="${testid}"]`);
 };
-const SKIN_VERSION = "1.5.11";
+export const SKIN_VERSION = "1.5.11";
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
 const CDP_ID_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
 const MAX_ART_BYTES = 10 * 1024 * 1024;

--- a/macos/tests/renderer-verification.test.mjs
+++ b/macos/tests/renderer-verification.test.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import vm from "node:vm";
-import { verifySession, waitForVerifiedSession } from "../scripts/injector.mjs";
+import { SKIN_VERSION, verifySession, waitForVerifiedSession } from "../scripts/injector.mjs";
 
+// Mirrors macos/assets/selectors.json — keep these in sync when that file's
+// selector strings change, since this mock's querySelector matches by exact
+// string equality and silently returns null on drift.
 const selectors = {
-  shell: "main.main-surface",
+  shell: 'main:is(.main-surface, [data-app-shell-main-surface], [class*="_MainContentSurface_"])',
   sidebar: "aside.app-shell-left-panel",
   composer: ".composer-surface-chrome",
   home: '[role="main"]:has([data-testid="home-icon"])',
@@ -47,7 +50,7 @@ function makeElement({
 }
 
 function makeDomFixture({
-  scope = { level: "L1", baseState: "thread" },
+  scope = { level: "L1", baseState: "thread", missingL1: [] },
   shell = makeElement(),
   sidebar = makeElement(),
   composer = makeElement(),
@@ -82,7 +85,7 @@ function makeDomFixture({
   };
   const window = {
     __CODEX_DREAM_SKIN_STATE__: {
-      version: "1.5.6",
+      version: SKIN_VERSION,
       themeId: "fixture-theme",
       revision: "fixture-revision",
       styleMode: "style",


### PR DESCRIPTION
## Problem
\`Static checks\` CI (\`node --test macos/tests/*.test.mjs\`) is currently red on \`main\` — 3 tests in \`renderer-verification.test.mjs\` fail against current main HEAD directly, unrelated to any specific recent PR. Confirmed by running the exact CI command against \`main\` before any of this fix.

## Root cause
The test's hand-rolled DOM mock had drifted from the real runtime contract in three independent ways, each silent (no crash, just wrong booleans) because the mock matches by exact string/shape equality:

1. \`selectors.shell\` was still the pre-26.727 \`main.main-surface\` selector. \`assets/selectors.json\`'s \`shell-main\` entry is now \`main:is(.main-surface, [data-app-shell-main-surface], [class*="_MainContentSurface_"])\`. Mismatch → mock \`querySelector\` returns \`null\` → \`result.shell\` is \`null\`.
2. \`makeDomFixture\`'s default \`scope\` omitted \`missingL1\`, which \`assessRendererVerification\` requires as an array before it'll consider L1 structure checks passable. Sibling test file \`window-readiness.test.mjs\` already carries this field correctly — this file just never got the same update.
3. The mock runtime state hardcoded \`version: "1.5.6"\` against the real \`SKIN_VERSION\` constant, currently \`"1.5.11"\`.

## Fix
- Export \`SKIN_VERSION\` from \`injector.mjs\` and import it in the test instead of re-hardcoding a version string that will drift again on the next release.
- Update the \`shell\` selector literal and default \`scope\` to match the current contract, with a comment noting the mock has to track \`selectors.json\`.

## Verification
- \`node --test macos/tests/renderer-verification.test.mjs\` → 4/4 pass (was 1/4)
- \`node --test macos/tests/*.test.mjs windows/tests/*.test.mjs tools/*.test.mjs\` → 93/93 pass
- \`macos/tests/run-tests.sh\`, and both \`injector.mjs --check-payload\` invocations → pass
- This replicates every step of CI's \`Static checks\` and \`macOS repository regressions\` jobs locally.