### PR TITLE
[codex] bilingual client and Windows Unicode installer validation

### DIFF
--- a/docs/pr-351-windows-validation.md
+++ b/docs/pr-351-windows-validation.md
@@ -1,0 +1,248 @@
+# PR #351 Windows Validation
+
+This is the complete Windows handoff for
+[PR #351](https://github.com/Fei-Away/Codex-Dream-Skin/pull/351). A Windows
+agent should pull that PR and validate the exact PR head. Do not test the
+published v1.5.12 installer: it predates every change in this PR.
+
+The PR combines three related candidate areas that need one real-Windows pass:
+
+1. Windows client localization and language persistence (`System`, `English`,
+   and `中文`), including tray actions, dialogs, notifications, installer
+   payload repair, update checks, theme import/apply, and restore paths.
+2. Shared renderer/runtime changes used by both macOS and Windows.
+3. Issue #337: PowerShell 5.1 must preserve a bundled Node executable path
+   when Inno Setup extracts it below a non-ASCII temporary directory. The old
+   failure text was `Node.js executable path could not be validated`.
+
+This document authorizes validation only. The Windows agent must not merge the
+PR, bump a version, create a tag or Release, publish an installer, upload its
+local build, edit WindowsApps ACLs, modify `app.asar`, disable Defender, or use
+`ExecutionPolicy Bypass`.
+
+## 1. Check Out The Exact PR Head
+
+Use a fresh clone or a clean worktree. These commands deliberately detach at
+the current PR head so the tested commit cannot move locally during the run:
+
+```powershell
+git fetch origin pull/351/head
+git switch --detach FETCH_HEAD
+
+$candidateSha = (git rev-parse HEAD).Trim()
+$onlineSha = (gh pr view 351 --repo Fei-Away/Codex-Dream-Skin `
+  --json headRefOid --jq .headRefOid).Trim()
+if ($candidateSha -cne $onlineSha) {
+  throw "PR head changed during checkout: local=$candidateSha online=$onlineSha"
+}
+if (git status --porcelain) {
+  throw 'The validation worktree is dirty.'
+}
+"CANDIDATE_SHA=$candidateSha"
+```
+
+Record the printed full SHA. Before sending the final report, run the online
+SHA comparison again. If the PR moved, stop and rerun against its new head.
+
+## 2. Record The Host
+
+Use a real Windows 10/11 x64 host with the official Microsoft Store Codex
+package installed for the current user. Record:
+
+```powershell
+$PSVersionTable | Format-List PSVersion, PSEdition, OS, OSVersion
+[Environment]::OSVersion.Version
+node --version
+git --version
+gh --version
+Get-AppxPackage OpenAI.Codex | Select-Object Name, Version, Architecture
+```
+
+Windows PowerShell 5.1 is mandatory. PowerShell 7 is an additional gate when
+available; it cannot replace the 5.1 result.
+
+## 3. Run Automated Gates
+
+Run from the repository root. Every command must exit `0`:
+
+```powershell
+node .\tools\sync-runtime-assets.mjs --check
+
+$portableTests = @(
+  Get-ChildItem .\macos\tests\*.test.mjs,
+    .\windows\tests\*.test.mjs,
+    .\tools\*.test.mjs
+) | ForEach-Object FullName
+node --test @portableTests
+
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
+  -File .\windows\tests\run-tests.ps1
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
+  -File .\windows\tests\installer-static.tests.ps1
+```
+
+When `pwsh.exe` is installed, rerun both PowerShell test entry points with it:
+
+```powershell
+pwsh.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
+  -File .\windows\tests\run-tests.ps1
+pwsh.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
+  -File .\windows\tests\installer-static.tests.ps1
+```
+
+Preserve full output for any failure. Do not weaken or skip a failing test.
+
+## 4. Build The Candidate Setup
+
+Use Inno Setup 6.7.1. Confirm `ISCC.exe` exists, then build from this exact
+detached PR tree:
+
+```powershell
+$iscc = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'
+if (-not (Test-Path -LiteralPath $iscc -PathType Leaf)) {
+  $iscc = Join-Path $env:ProgramFiles 'Inno Setup 6\ISCC.exe'
+}
+if (-not (Test-Path -LiteralPath $iscc -PathType Leaf)) {
+  throw 'Install official Inno Setup 6.7.1 before continuing.'
+}
+
+$candidateOutput = Join-Path $env:LOCALAPPDATA 'DreamSkin-PR351-Build'
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
+  -File .\windows\installer\build-release.ps1 `
+  -OutputDirectory $candidateOutput -IsccPath $iscc
+
+$candidateSetup = Join-Path $candidateOutput 'CodexDreamSkin-Setup-v1.5.12.exe'
+if (-not (Test-Path -LiteralPath $candidateSetup -PathType Leaf) -or
+    (Get-Item -LiteralPath $candidateSetup).Length -le 0) {
+  throw 'The candidate Setup.exe was not built.'
+}
+Get-FileHash -LiteralPath $candidateSetup -Algorithm SHA256
+```
+
+The `v1.5.12` filename identifies the unchanged candidate base only. This
+local file is not the public v1.5.12 asset and must not be distributed.
+
+## 5. Exercise Issue #337 With A Real CJK Temp Path
+
+Exit Codex and the Dream Skin tray. Start the candidate Setup from a process
+whose real `TEMP` and `TMP` point to a CJK path. Keep the Inno log for evidence:
+
+```powershell
+$cjkTemp = Join-Path $env:LOCALAPPDATA 'DreamSkin-验证-临时目录'
+$setupLog = Join-Path $env:LOCALAPPDATA 'DreamSkin-PR351-Setup.log'
+New-Item -ItemType Directory -Path $cjkTemp -Force | Out-Null
+$oldTemp = $env:TEMP
+$oldTmp = $env:TMP
+try {
+  $env:TEMP = $cjkTemp
+  $env:TMP = $cjkTemp
+  $process = Start-Process -FilePath $candidateSetup `
+    -ArgumentList "/LOG=$setupLog" -Wait -PassThru
+  if ($process.ExitCode -ne 0) {
+    throw "Candidate Setup exited with $($process.ExitCode)."
+  }
+} finally {
+  $env:TEMP = $oldTemp
+  $env:TMP = $oldTmp
+}
+```
+
+In the GUI, complete a normal current-user install. Pass only when all of these
+are true:
+
+- Setup reaches completion without
+  `Node.js executable path could not be validated`.
+- The sanitized Inno log proves its temporary extraction path was below the
+  exact CJK directory above. If it used another directory, this test did not
+  exercise #337 and must be repeated.
+- No administrator elevation, ACL change, security bypass, or untrusted Node
+  fallback was needed.
+- The installed engine contains the exact PR sources below:
+
+```powershell
+$sourceRoot = (Resolve-Path .\windows).Path
+$engineRoot = Join-Path $env:LOCALAPPDATA 'CodexDreamSkin\engine'
+foreach ($relative in @(
+  'VERSION',
+  'assets\renderer-inject.js',
+  'scripts\common-windows.ps1',
+  'scripts\localization-windows.ps1',
+  'scripts\injector.mjs',
+  'scripts\theme-windows.ps1',
+  'scripts\tray-dream-skin.ps1'
+)) {
+  $source = Join-Path $sourceRoot $relative
+  $installed = Join-Path $engineRoot $relative
+  if (-not (Test-Path -LiteralPath $installed -PathType Leaf)) {
+    throw "Installed engine is missing: $relative"
+  }
+  if ((Get-FileHash -LiteralPath $source -Algorithm SHA256).Hash -cne
+      (Get-FileHash -LiteralPath $installed -Algorithm SHA256).Hash) {
+    throw "Installed engine differs from PR head: $relative"
+  }
+}
+'ENGINE_HASH_BINDING=PASS'
+```
+
+## 6. Validate The Windows Language Workflows
+
+Use the tray UI for the primary test. Do not substitute an environment
+variable for the menu selection.
+
+1. Select `Language / 语言` -> `English`. Close and reopen the tray. Confirm the
+   checked selection persists and the status, apply/reapply, pause/resume,
+   background, import, saved themes, links, update, restore, and exit labels
+   are English.
+2. Select `Language / 语言` -> `中文`. Reopen the tray and repeat the same check
+   in Chinese.
+3. Select `System / 系统`. Reopen the tray and confirm it follows Windows UI
+   culture. The preference override must be removed when System is selected.
+4. In both English and Chinese, exercise apply/reapply, pause/resume, background
+   picker cancellation, invalid-image failure, theme ZIP import, duplicate or
+   update result, save/switch theme, update check, and restore cancellation.
+5. Confirm cancellation is never reported as success and a failure does not
+   leave a false active state. Machine-readable status/state JSON must remain
+   unchanged; only human-facing copy is localized.
+
+Also test one normal apply and one restore against the real Store Codex app.
+Run the installed verifier on Home and one normal task route:
+
+```powershell
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy RemoteSigned `
+  -File "$engineRoot\scripts\verify-dream-skin.ps1" `
+  -ScreenshotPath "$env:TEMP\dreamskin-pr351-real-codex.png"
+```
+
+Pass only with `scope.level=L1`, an empty `missingL1`, an interactive real
+`app://` Codex renderer, no horizontal overflow, and no console/runtime error
+introduced by this PR. The screenshot must be from the real installed Codex
+app, not a fixture.
+
+## 7. Return One Result
+
+Return exactly one consolidated report to the PR owner:
+
+```text
+PR: #351
+CANDIDATE_SHA: <40-character SHA>
+HOST: <Windows edition/build; x64>
+CODEX: <Store package version>
+POWERSHELL_5_1: PASS|FAIL <version>
+POWERSHELL_7: PASS|FAIL|NOT_INSTALLED <version>
+PORTABLE_TESTS: PASS|FAIL <count>
+INSTALLER_STATIC: PASS|FAIL
+SETUP_BUILD: PASS|FAIL <SHA-256>
+CJK_TEMP_SETUP_337: PASS|FAIL
+ENGINE_HASH_BINDING: PASS|FAIL
+LANGUAGE_SYSTEM: PASS|FAIL
+LANGUAGE_ENGLISH: PASS|FAIL
+LANGUAGE_CHINESE: PASS|FAIL
+REAL_CODEX_L1: PASS|FAIL <scope.level; missingL1>
+SCREENSHOT: <local path>
+SANITIZED_FAILURES: <none or exact excerpts without private paths/tokens>
+FINAL: PASS|FAIL
+```
+
+Any mandatory failure makes `FINAL: FAIL`. Include sanitized excerpts from the
+Setup log and `%LOCALAPPDATA%\CodexDreamSkin\logs` for failures, but redact user
+names and private paths. Do not post secrets or upload the locally built Setup.

--- a/docs/pr-351-windows-validation.md
+++ b/docs/pr-351-windows-validation.md
@@ -203,6 +203,11 @@ variable for the menu selection.
 5. Confirm cancellation is never reported as success and a failure does not
    leave a false active state. Machine-readable status/state JSON must remain
    unchanged; only human-facing copy is localized.
+6. Apply one test theme with an explicit white accent and one with an explicit
+   black accent. On both light and dark Codex appearances, accent-filled
+   controls must remain readable: black text on white and white text on black.
+   Reapply an adaptive/default accent afterward and confirm no stale explicit
+   foreground remains.
 
 Also test one normal apply and one restore against the real Store Codex app.
 Run the installed verifier on Home and one normal task route:

--- a/macos/assets/renderer-inject.js
+++ b/macos/assets/renderer-inject.js
@@ -173,9 +173,9 @@
     if (!foreground) return background;
     const alpha = clamp(foreground.alpha ?? 1, 0, 1);
     return {
-      r: foreground.r * alpha + background.r * (1 - alpha),
-      g: foreground.g * alpha + background.g * (1 - alpha),
-      b: foreground.b * alpha + background.b * (1 - alpha),
+      r: clamp(foreground.r, 0, 255) * alpha + background.r * (1 - alpha),
+      g: clamp(foreground.g, 0, 255) * alpha + background.g * (1 - alpha),
+      b: clamp(foreground.b, 0, 255) * alpha + background.b * (1 - alpha),
     };
   };
 

--- a/macos/assets/renderer-inject.js
+++ b/macos/assets/renderer-inject.js
@@ -168,10 +168,10 @@
     return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
   };
 
-  const compositeColor = (value, background) => {
+  const compositeColor = (value, background, alphaOverride = null) => {
     const foreground = parseRgb(value);
     if (!foreground) return background;
-    const alpha = clamp(foreground.alpha ?? 1, 0, 1);
+    const alpha = clamp(alphaOverride ?? foreground.alpha ?? 1, 0, 1);
     return {
       r: clamp(foreground.r, 0, 255) * alpha + background.r * (1 - alpha),
       g: clamp(foreground.g, 0, 255) * alpha + background.g * (1 - alpha),
@@ -179,16 +179,20 @@
     };
   };
 
-  const readableAccentInk = (accent, panel, background, shell) => {
-    let rendered = shell === "light"
-      ? { r: 250, g: 251, b: 251 }
-      : { r: 17, g: 19, b: 24 };
-    rendered = compositeColor(background, rendered);
-    rendered = compositeColor(panel, rendered);
-    rendered = compositeColor(accent, rendered);
-    const luminance = relativeLuminance(rendered);
-    const whiteContrast = 1.05 / (luminance + 0.05);
-    const blackContrast = (luminance + 0.05) / 0.05;
+  const readableAccentInk = (accent, panel) => {
+    // The send button sits on the composer surface, which renders panel RGB
+    // at 94% regardless of the panel color's declared alpha. Compare against
+    // both possible backdrop extremes so artwork cannot flip the decision.
+    const luminances = [0, 255].map((backdrop) => {
+      const surface = compositeColor(
+        panel,
+        { r: backdrop, g: backdrop, b: backdrop },
+        0.94,
+      );
+      return relativeLuminance(compositeColor(accent, surface));
+    });
+    const whiteContrast = Math.min(...luminances.map((value) => 1.05 / (value + 0.05)));
+    const blackContrast = Math.min(...luminances.map((value) => (value + 0.05) / 0.05));
     return whiteContrast >= blackContrast ? "rgb(255 255 255)" : "rgb(0 0 0)";
   };
 
@@ -320,8 +324,6 @@
       const accentInk = readableAccentInk(
         accent,
         variables["--ds-panel"],
-        variables["--ds-bg"],
-        shell,
       );
       if (accentInk) setStyleProperty(root, "--ds-on-accent", accentInk);
     }

--- a/macos/assets/renderer-inject.js
+++ b/macos/assets/renderer-inject.js
@@ -118,15 +118,31 @@
     if (!value || value === "transparent") return null;
     const hex = String(value).trim().match(/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i);
     if (hex) {
-      const rgbHex = hex[1].length <= 4
-        ? hex[1].slice(0, 3).split("").map((digit) => `${digit}${digit}`).join("")
-        : hex[1].slice(0, 6);
+      const digits = hex[1];
+      const rgbHex = digits.length <= 4
+        ? digits.slice(0, 3).split("").map((digit) => `${digit}${digit}`).join("")
+        : digits.slice(0, 6);
+      const alphaHex = digits.length === 4
+        ? `${digits[3]}${digits[3]}`
+        : digits.length === 8 ? digits.slice(6, 8) : "ff";
       const number = Number.parseInt(rgbHex, 16);
-      return { r: number >> 16, g: (number >> 8) & 255, b: number & 255 };
+      return {
+        r: number >> 16,
+        g: (number >> 8) & 255,
+        b: number & 255,
+        alpha: Number.parseInt(alphaHex, 16) / 255,
+      };
     }
-    const m = String(value).match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i);
+    const m = String(value).trim().match(
+      /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i,
+    );
     if (!m) return null;
-    return { r: Number(m[1]), g: Number(m[2]), b: Number(m[3]) };
+    return {
+      r: Number(m[1]),
+      g: Number(m[2]),
+      b: Number(m[3]),
+      alpha: m[4] === undefined ? 1 : Math.min(1, Math.max(0, Number(m[4]))),
+    };
   };
 
   const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
@@ -152,10 +168,25 @@
     return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
   };
 
-  const readableAccentInk = (accent) => {
-    const rgb = parseRgb(accent);
-    if (!rgb) return null;
-    const luminance = relativeLuminance(rgb);
+  const compositeColor = (value, background) => {
+    const foreground = parseRgb(value);
+    if (!foreground) return background;
+    const alpha = clamp(foreground.alpha ?? 1, 0, 1);
+    return {
+      r: foreground.r * alpha + background.r * (1 - alpha),
+      g: foreground.g * alpha + background.g * (1 - alpha),
+      b: foreground.b * alpha + background.b * (1 - alpha),
+    };
+  };
+
+  const readableAccentInk = (accent, panel, background, shell) => {
+    let rendered = shell === "light"
+      ? { r: 250, g: 251, b: 251 }
+      : { r: 17, g: 19, b: 24 };
+    rendered = compositeColor(background, rendered);
+    rendered = compositeColor(panel, rendered);
+    rendered = compositeColor(accent, rendered);
+    const luminance = relativeLuminance(rendered);
     const whiteContrast = 1.05 / (luminance + 0.05);
     const blackContrast = (luminance + 0.05) / 0.05;
     return whiteContrast >= blackContrast ? "rgb(255 255 255)" : "rgb(0 0 0)";
@@ -286,7 +317,12 @@
       if (typeof value === "string" && value) setStyleProperty(root, name, value);
     }
     if (explicit.has("accent")) {
-      const accentInk = readableAccentInk(accent);
+      const accentInk = readableAccentInk(
+        accent,
+        variables["--ds-panel"],
+        variables["--ds-bg"],
+        shell,
+      );
       if (accentInk) setStyleProperty(root, "--ds-on-accent", accentInk);
     }
     const publicColors = {

--- a/macos/assets/renderer-inject.js
+++ b/macos/assets/renderer-inject.js
@@ -22,7 +22,7 @@
     ? THEME.artMetadata : null;
   const ANALYSIS_CACHE_KEY = "__CODEX_DREAM_SKIN_ANALYSIS_CACHE__";
   const THEME_VARIABLES = [
-    "--ds-bg", "--ds-panel", "--ds-panel-2", "--ds-green", "--ds-lime",
+    "--ds-bg", "--ds-panel", "--ds-panel-2", "--ds-green", "--ds-lime", "--ds-on-accent",
     "--ds-cyan", "--ds-purple", "--ds-text", "--ds-muted", "--ds-line",
     "--ds-bg-rgb", "--ds-panel-rgb", "--ds-panel-2-rgb", "--ds-accent-rgb",
     "--ds-accent-alt-rgb", "--ds-secondary-rgb", "--ds-highlight-rgb",
@@ -141,6 +141,25 @@
   const rgbToHex = ({ r, g, b }) => `#${[r, g, b]
     .map((value) => clamp(Math.round(value), 0, 255).toString(16).padStart(2, "0"))
     .join("")}`;
+
+  const relativeLuminance = ({ r, g, b }) => {
+    const channels = [r, g, b].map((value) => {
+      const normalized = clamp(value, 0, 255) / 255;
+      return normalized <= 0.04045
+        ? normalized / 12.92
+        : ((normalized + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  };
+
+  const readableAccentInk = (accent) => {
+    const rgb = parseRgb(accent);
+    if (!rgb) return null;
+    const luminance = relativeLuminance(rgb);
+    const whiteContrast = 1.05 / (luminance + 0.05);
+    const blackContrast = (luminance + 0.05) / 0.05;
+    return whiteContrast >= blackContrast ? "rgb(255 255 255)" : "rgb(0 0 0)";
+  };
 
   const rgbToHsl = ({ r, g, b }) => {
     const values = [r, g, b].map((value) => value / 255);
@@ -265,6 +284,10 @@
 
     for (const [name, value] of Object.entries(variables)) {
       if (typeof value === "string" && value) setStyleProperty(root, name, value);
+    }
+    if (explicit.has("accent")) {
+      const accentInk = readableAccentInk(accent);
+      if (accentInk) setStyleProperty(root, "--ds-on-accent", accentInk);
     }
     const publicColors = {
       "--ds-theme-color-background": variables["--ds-bg"],

--- a/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
+++ b/macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift
@@ -59,6 +59,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     "scripts/injector.mjs",
     "scripts/install-dream-skin-macos.sh",
     "scripts/load-image-theme-macos.sh",
+    "scripts/localization-macos.sh",
     "scripts/pause-dream-skin-macos.sh",
     "scripts/publish-theme-import.mjs",
     "scripts/recover-theme-imports-macos.sh",
@@ -108,6 +109,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
   }
 
+  private var selectedLanguage: DreamSkinLanguage {
+    get { DreamSkinLanguage.stored() }
+    set { UserDefaults.standard.set(newValue.rawValue, forKey: DreamSkinLanguage.defaultsKey) }
+  }
+
+  private var copy: DreamSkinCopy {
+    DreamSkinCopy(language: selectedLanguage)
+  }
+
   func applicationDidFinishLaunching(_ notification: Notification) {
     NSApp.setActivationPolicy(.accessory)
     configureStatusItem()
@@ -150,8 +160,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
     guard !operationInFlight, !engineInstallInFlight, !themeRecoveryInFlight, !snapshot.busy else {
       showError(
-        title: "操作仍在进行",
-        message: "请等待当前下载、导入、应用或恢复完成后再退出，以免留下未完成的主题状态。"
+        title: copy.text(.busyTitle),
+        message: copy.text(.busyMessage)
       )
       return .terminateCancel
     }
@@ -162,8 +172,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     guard urls.count == 1,
           let versionID = CommunityThemeContract.versionID(from: urls[0]) else {
       showError(
-        title: "一键换肤链接无效",
-        message: "只接受 DreamSkin.cc 生成的主题版本链接；不会打开链接中的任意网址或文件。"
+        title: copy.text(.invalidLinkTitle),
+        message: copy.text(.invalidLinkMessage)
       )
       return
     }
@@ -218,7 +228,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
         )
         try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
       } catch {
-        showError(title: "无法准备用户目录", message: error.localizedDescription)
+        showError(title: copy.text(.prepareDirectoryTitle), message: error.localizedDescription)
         break
       }
     }
@@ -264,28 +274,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
 
   private func rebuildMenu() {
     menu.removeAllItems()
-    addDisabledItem(snapshot.title)
+    addDisabledItem(copy.statusTitle(session: snapshot.session, operation: snapshot.operation))
     if !snapshot.appliedThemeName.isEmpty && snapshot.session == "active" {
-      addDisabledItem("已应用：\(cleanMenuText(snapshot.appliedThemeName))")
+      addDisabledItem(copy.format(.appliedTheme, cleanMenuText(snapshot.appliedThemeName)))
     }
     if !snapshot.themeName.isEmpty && snapshot.themeName != snapshot.appliedThemeName {
-      addDisabledItem("已选主题：\(cleanMenuText(snapshot.themeName))（待应用）")
+      addDisabledItem(copy.format(.selectedThemePending, cleanMenuText(snapshot.themeName)))
     } else if snapshot.appliedThemeName.isEmpty && !snapshot.themeName.isEmpty {
-      addDisabledItem("已选主题：\(cleanMenuText(snapshot.themeName))")
+      addDisabledItem(copy.format(.selectedTheme, cleanMenuText(snapshot.themeName)))
     }
-    addDisabledItem(snapshot.codexRunning ? "ChatGPT：已打开" : "ChatGPT：未打开")
+    addDisabledItem(copy.text(snapshot.codexRunning ? .codexOpen : .codexClosed))
     if !snapshot.operationMessage.isEmpty {
       addDisabledItem(cleanMenuText(snapshot.operationMessage))
     }
     if !communityStageMessage.isEmpty {
       addDisabledItem(cleanMenuText(communityStageMessage))
     }
-    addDisabledItem("版本：v\(appVersion)")
+    addDisabledItem(copy.format(.version, appVersion))
 
     menu.addItem(.separator())
     if let availableUpdate {
       addActionItem(
-        "🆕 发现新版本 \(availableUpdate.version)",
+        copy.format(.newVersion, availableUpdate.version),
         action: #selector(openAvailableUpdate)
       )
       menu.addItem(.separator())
@@ -295,86 +305,113 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
 
     let applyTitle: String
     switch snapshot.session {
-    case "active": applyTitle = "重新应用皮肤"
-    case "stale", "unknown": applyTitle = "修复并应用"
-    default: applyTitle = "应用皮肤"
+    case "active": applyTitle = copy.text(.reapply)
+    case "stale", "unknown": applyTitle = copy.text(.repairApply)
+    default: applyTitle = copy.text(.apply)
     }
     addActionItem(applyTitle, action: #selector(applySkin), enabled: !busy)
     if snapshot.session == "active" || snapshot.session == "applying" {
-      addActionItem("暂停皮肤", action: #selector(pauseSkin), enabled: !busy)
+      addActionItem(copy.text(.pause), action: #selector(pauseSkin), enabled: !busy)
     }
-    addActionItem("打开 ChatGPT", action: #selector(openCodex), enabled: !busy)
+    addActionItem(copy.text(.openChatGPT), action: #selector(openCodex), enabled: !busy)
 
     menu.addItem(.separator())
     addThemeMenu(enabled: !busy)
     addLinksMenu()
 
     menu.addItem(.separator())
-    let loginItem = addActionItem("登录时启动", action: #selector(toggleLoginItem))
+    addLanguageMenu()
+    let loginItem = addActionItem(copy.text(.loginAtStartup), action: #selector(toggleLoginItem))
     loginItem.state = SMAppService.mainApp.status == .enabled ? .on : .off
     addMaintenanceMenu(enabled: !busy, needsEngineInstall: needsEngineInstall)
 
     menu.addItem(.separator())
-    addActionItem("退出", action: #selector(quit), enabled: !busy)
+    addActionItem(copy.text(.quit), action: #selector(quit), enabled: !busy)
   }
 
   private func addThemeMenu(enabled: Bool) {
-    let root = NSMenuItem(title: "主题", action: nil, keyEquivalent: "")
-    let submenu = NSMenu(title: "主题")
+    let root = NSMenuItem(title: copy.text(.themeMenu), action: nil, keyEquivalent: "")
+    let submenu = NSMenu(title: copy.text(.themeMenu))
     submenu.autoenablesItems = false
-    addActionItem("换一张背景图…", action: #selector(chooseBackgroundImage), enabled: enabled, to: submenu)
-    addActionItem("导入主题 ZIP…", action: #selector(chooseThemeArchive), enabled: enabled, to: submenu)
+    addActionItem(copy.text(.changeBackground), action: #selector(chooseBackgroundImage), enabled: enabled, to: submenu)
+    addActionItem(copy.text(.importZip), action: #selector(chooseThemeArchive), enabled: enabled, to: submenu)
     addSavedThemesMenu(enabled: enabled, to: submenu)
     submenu.addItem(.separator())
-    addActionItem("打开主题文件夹", action: #selector(openThemesFolder), to: submenu)
-    addActionItem("打开图片文件夹", action: #selector(openImagesFolder), to: submenu)
+    addActionItem(copy.text(.openThemes), action: #selector(openThemesFolder), to: submenu)
+    addActionItem(copy.text(.openImages), action: #selector(openImagesFolder), to: submenu)
     root.submenu = submenu
     menu.addItem(root)
   }
 
   private func addLinksMenu() {
-    let root = NSMenuItem(title: "链接", action: nil, keyEquivalent: "")
-    let submenu = NSMenu(title: "链接")
+    let root = NSMenuItem(title: copy.text(.linksMenu), action: nil, keyEquivalent: "")
+    let submenu = NSMenu(title: copy.text(.linksMenu))
     submenu.autoenablesItems = false
-    addActionItem("主题库 Gallery", action: #selector(openThemeGallery), to: submenu)
-    addActionItem("在线 Studio", action: #selector(openOnlineStudio), to: submenu)
-    addActionItem("打开 DreamSkin.cc", action: #selector(openDreamSkinWebsite), to: submenu)
+    addActionItem(copy.text(.gallery), action: #selector(openThemeGallery), to: submenu)
+    addActionItem(copy.text(.studio), action: #selector(openOnlineStudio), to: submenu)
+    addActionItem(copy.text(.openSite), action: #selector(openDreamSkinWebsite), to: submenu)
     root.submenu = submenu
     menu.addItem(root)
   }
 
   private func addMaintenanceMenu(enabled: Bool, needsEngineInstall: Bool) {
-    let root = NSMenuItem(title: "维护", action: nil, keyEquivalent: "")
-    let submenu = NSMenu(title: "维护")
+    let root = NSMenuItem(title: copy.text(.maintenanceMenu), action: nil, keyEquivalent: "")
+    let submenu = NSMenu(title: copy.text(.maintenanceMenu))
     submenu.autoenablesItems = false
     if engineInstallInFlight {
-      addDisabledItem("正在安装引擎…", to: submenu)
+      addDisabledItem(copy.text(.installingEngine), to: submenu)
     } else {
       addActionItem(
-        needsEngineInstall ? "安装 / 升级引擎…" : "修复 / 重新安装引擎…",
+        copy.text(needsEngineInstall ? .installEngine : .repairEngine),
         action: #selector(reinstallEngine),
         enabled: enabled,
         to: submenu
       )
     }
     addActionItem(
-      "立即检查更新",
+      copy.text(.checkUpdate),
       action: #selector(checkForUpdates),
       enabled: !operationInFlight && !updateCheckInFlight,
       to: submenu
     )
     if !legacyPluginURLs().isEmpty {
-      addActionItem("停用旧 SwiftBar 菜单…", action: #selector(disableLegacySwiftBarFromMenu), to: submenu)
+      addActionItem(copy.text(.disableSwiftBar), action: #selector(disableLegacySwiftBarFromMenu), to: submenu)
     }
     submenu.addItem(.separator())
     addActionItem(
-      "恢复原状并卸载…",
+      copy.text(.restoreUninstall),
       action: #selector(restoreAndUninstall),
       enabled: enabled,
       to: submenu
     )
     root.submenu = submenu
     menu.addItem(root)
+  }
+
+  private func addLanguageMenu() {
+    let root = NSMenuItem(title: copy.text(.languageMenu), action: nil, keyEquivalent: "")
+    let submenu = NSMenu(title: copy.text(.languageMenu))
+    submenu.autoenablesItems = false
+    for language in DreamSkinLanguage.allCases {
+      let item = addActionItem(
+        language.displayName,
+        action: #selector(selectLanguage(_:)),
+        to: submenu
+      )
+      item.representedObject = language.rawValue
+      item.state = language == selectedLanguage ? .on : .off
+    }
+    root.submenu = submenu
+    menu.addItem(root)
+  }
+
+  @objc private func selectLanguage(_ sender: NSMenuItem) {
+    guard let raw = sender.representedObject as? String,
+          let language = DreamSkinLanguage(rawValue: raw) else { return }
+    selectedLanguage = language
+    communityStageMessage = ""
+    refreshStatus()
+    rebuildMenu()
   }
 
   @discardableResult
@@ -398,12 +435,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   }
 
   private func addSavedThemesMenu(enabled: Bool, to destination: NSMenu? = nil) {
-    let root = NSMenuItem(title: "已保存的主题", action: nil, keyEquivalent: "")
-    let submenu = NSMenu(title: "已保存的主题")
+    let root = NSMenuItem(title: copy.text(.savedThemes), action: nil, keyEquivalent: "")
+    let submenu = NSMenu(title: copy.text(.savedThemes))
     submenu.autoenablesItems = false
     let themes = savedThemes()
     if themes.isEmpty {
-      addDisabledItem("还没有保存的主题", to: submenu)
+      addDisabledItem(copy.text(.noSavedThemes), to: submenu)
     } else {
       for theme in themes {
         let item = addActionItem(
@@ -515,7 +552,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       if result.succeeded,
          let parsed = StatusSnapshot(jsonData: Data(result.output.utf8)) {
         self.snapshot = parsed
-        self.statusItem.button?.toolTip = "Codex Dream Skin · \(parsed.title)"
+        self.statusItem.button?.toolTip = "Codex Dream Skin · \(self.copy.statusTitle(session: parsed.session, operation: parsed.operation))"
         self.statusItem.button?.appearsDisabled = parsed.session == "unknown" || parsed.session == "stale"
         self.rebuildMenu()
       }
@@ -523,11 +560,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   }
 
   @objc private func applySkin() {
-    runInstalledScript(named: "apply-from-menubar-macos.sh", operation: "应用皮肤")
+    runInstalledScript(named: "apply-from-menubar-macos.sh", operation: copy.text(.apply))
   }
 
   @objc private func pauseSkin() {
-    runInstalledScript(named: "pause-dream-skin-macos.sh", operation: "暂停皮肤")
+    runInstalledScript(named: "pause-dream-skin-macos.sh", operation: copy.text(.pause))
   }
 
   @objc private func reinstallEngine() {
@@ -537,8 +574,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
 
   @objc private func chooseBackgroundImage() {
     let panel = NSOpenPanel()
-    panel.title = "选择 Dream Skin 背景图"
-    panel.prompt = "选择"
+    panel.title = copy.text(.changeBackground)
+    panel.prompt = copy.resolvedLanguage == .chinese ? "选择" : "Choose"
     panel.canChooseDirectories = false
     panel.canChooseFiles = true
     panel.allowsMultipleSelection = false
@@ -548,14 +585,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     runInstalledScript(
       named: "load-image-theme-macos.sh",
       arguments: ["--file", imageURL.path],
-      operation: "更换背景图"
+      operation: copy.text(.changeBackground).replacingOccurrences(of: "…", with: "")
     )
   }
 
   @objc private func chooseThemeArchive() {
     let panel = NSOpenPanel()
-    panel.title = "选择 Dream Skin 主题 ZIP"
-    panel.prompt = "导入"
+    panel.title = copy.text(.importZip)
+    panel.prompt = copy.resolvedLanguage == .chinese ? "导入" : "Import"
     panel.canChooseDirectories = false
     panel.canChooseFiles = true
     panel.allowsMultipleSelection = false
@@ -567,7 +604,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
 
   private func beginCommunityThemeApply(versionID: String) {
     guard !operationInFlight, !snapshot.busy else {
-      showError(title: "暂时无法换肤", message: "Dream Skin 正在执行其他操作，请稍后再点一次。")
+      showError(title: copy.text(.cannotApplyTitle), message: copy.text(.cannotApplyMessage))
       return
     }
     if engineInstallInFlight {
@@ -580,16 +617,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       return
     }
     guard let metadataURL = CommunityThemeContract.metadataURL(for: versionID) else {
-      showError(title: "一键换肤链接无效", message: "主题版本标识不符合安全规则。")
+      showError(title: copy.text(.invalidLinkTitle), message: copy.text(.invalidThemeMessage))
       return
     }
     guard let statusScript = installedScript(named: "status-dream-skin-macos.sh") else {
-      showError(title: "引擎尚未安装", message: "请先选择“安装 / 升级引擎”，再使用一键换肤。")
+      showError(title: copy.text(.missingEngineTitle), message: copy.text(.missingEngineCommunityMessage))
       return
     }
 
     operationInFlight = true
-    updateCommunityStage("正在确认当前皮肤可安全回滚…")
+    updateCommunityStage(copy.resolvedLanguage == .chinese
+      ? "正在确认当前皮肤可安全回滚…"
+      : "Checking that the current skin can be safely restored…")
     ScriptRunner.run(script: statusScript, arguments: ["--json", "--deep"]) { [weak self] result in
       guard let self else { return }
       guard result.succeeded,
@@ -597,8 +636,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
             current.isReadyForCommunityApply else {
         self.finishThemeOperation()
         self.showError(
-          title: "当前皮肤还不能安全换肤",
-          message: "请先从菜单栏应用当前皮肤，确认状态为 Skin ON 且没有“待应用”主题，再回到网页重试。这样失败时才能恢复并验证点击前真正显示的主题。"
+          title: self.copy.text(.baselineTitle),
+          message: self.copy.text(.baselineMessage)
         )
         return
       }
@@ -608,7 +647,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   }
 
   private func fetchCommunityThemeMetadata(versionID: String, metadataURL: URL) {
-    updateCommunityStage("正在读取已审核主题信息…")
+    updateCommunityStage(copy.resolvedLanguage == .chinese
+      ? "正在读取已审核主题信息…"
+      : "Loading approved theme metadata…")
     communityHTTP.get(
       metadataURL,
       accept: "application/json",
@@ -621,8 +662,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
               !payload.body.isEmpty else {
           self.finishThemeOperation()
           self.showError(
-            title: "无法读取主题信息",
-            message: "DreamSkin.cc 没有返回可验证的已审核主题，请稍后重试。"
+            title: self.copy.text(.readThemeTitle),
+            message: self.copy.text(.readThemeMessage)
           )
           return
         }
@@ -633,7 +674,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
         } catch {
           self.finishThemeOperation()
           self.showError(
-            title: "主题信息未通过校验",
+            title: self.copy.text(.validationTitle),
             message: error.localizedDescription
           )
         }
@@ -642,21 +683,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   }
 
   private func confirmCommunityThemeApply(_ metadata: CommunityThemeMetadata) {
-    updateCommunityStage("等待确认：\(cleanMenuText(metadata.name))")
+    updateCommunityStage(copy.resolvedLanguage == .chinese
+      ? "等待确认：\(cleanMenuText(metadata.name))"
+      : "Waiting for confirmation: \(cleanMenuText(metadata.name))")
     let size = ByteCountFormatter.string(fromByteCount: metadata.packageBytes, countStyle: .file)
     let alert = NSAlert()
-    alert.messageText = "从 DreamSkin.cc 应用“\(cleanMenuText(metadata.name))”？"
-    alert.informativeText = """
-    作者：\(cleanMenuText(metadata.authorDisplayName))
-    版本：\(metadata.version) · \(size)
-    SHA-256：\(metadata.packageSha256)
+    let name = cleanMenuText(metadata.name)
+    let author = cleanMenuText(metadata.authorDisplayName)
+    if copy.resolvedLanguage == .chinese {
+      alert.messageText = "从 DreamSkin.cc 应用“\(name)”？"
+      alert.informativeText = """
+      作者：\(author)
+      版本：\(metadata.version) · \(size)
+      SHA-256：\(metadata.packageSha256)
 
-    客户端会从固定官方 API 下载，核对完整哈希，并重新执行 ZIP、清单与 Safe CSS 校验。导入和应用前不会运行主题中的任意命令。
+      客户端会从固定官方 API 下载，核对完整哈希，并重新执行 ZIP、清单与 Safe CSS 校验。导入和应用前不会运行主题中的任意命令。
 
-    如果 ChatGPT 当前没有安全调试连接，应用时会重启 ChatGPT；请先保存未发送的输入。
-    """
-    alert.addButton(withTitle: "下载并应用")
-    alert.addButton(withTitle: "取消")
+      如果 ChatGPT 当前没有安全调试连接，应用时会重启 ChatGPT；请先保存未发送的输入。
+      """
+    } else {
+      alert.messageText = "Apply “\(name)” from DreamSkin.cc?"
+      alert.informativeText = """
+      Author: \(author)
+      Version: \(metadata.version) · \(size)
+      SHA-256: \(metadata.packageSha256)
+
+      The client downloads from the fixed official API, verifies the full hash, and reruns the ZIP, manifest, and Safe CSS checks. It does not execute commands from the theme before importing or applying it.
+
+      ChatGPT may restart if no safe debug connection is active. Save any unsent input first.
+      """
+    }
+    alert.addButton(withTitle: copy.resolvedLanguage == .chinese ? "下载并应用" : "Download and apply")
+    alert.addButton(withTitle: copy.resolvedLanguage == .chinese ? "取消" : "Cancel")
     activateForUserInteraction()
     guard alert.runModal() == .alertFirstButtonReturn else {
       finishThemeOperation()
@@ -668,10 +726,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   private func downloadCommunityTheme(_ metadata: CommunityThemeMetadata) {
     guard let downloadURL = CommunityThemeContract.downloadURL(for: metadata.id) else {
       finishThemeOperation()
-      showError(title: "无法下载主题", message: "主题下载地址无法由版本标识安全构造。")
+      showError(title: copy.text(.downloadThemeTitle), message: copy.text(.downloadThemeMessage))
       return
     }
-    updateCommunityStage("正在下载主题包…")
+    updateCommunityStage(copy.resolvedLanguage == .chinese ? "正在下载主题包…" : "Downloading theme package…")
     communityHTTP.get(
       downloadURL,
       accept: "application/zip",
@@ -712,7 +770,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
           throw CommunityThemeContractError.invalidPackageIdentity
         }
         DispatchQueue.main.async {
-          self.updateCommunityStage("下载完成，正在执行严格导入校验…")
+          self.updateCommunityStage(self.copy.resolvedLanguage == .chinese
+            ? "下载完成，正在执行严格导入校验…"
+            : "Download complete; running strict import validation…")
           self.performThemeImport(
             archiveURL,
             cleanupRoot: root,
@@ -727,8 +787,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
         DispatchQueue.main.async {
           self.finishThemeOperation()
           self.showError(
-            title: "主题包未通过下载校验",
-            message: "下载已丢弃，没有导入或应用任何内容。\n\n\(error.localizedDescription)"
+            title: self.copy.text(.downloadValidationTitle),
+            message: self.copy.format(.downloadValidationMessage, error.localizedDescription)
           )
         }
       }
@@ -769,7 +829,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   ) {
     guard let script = installedScript(named: "import-theme-zip-macos.sh") else {
       finishThemeOperation(cleanupRoot: cleanupRoot)
-      showError(title: "引擎尚未安装", message: "请先选择“安装 / 升级引擎”，再导入主题。")
+      showError(title: copy.text(.missingEngineTitle), message: copy.text(.missingEngineImportMessage))
       return
     }
     var importArguments = ["--file", archiveURL.path]
@@ -790,8 +850,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
             let rawID = value["id"] as? String else {
         self.finishThemeOperation(cleanupRoot: cleanupRoot)
         self.showError(
-          title: "导入主题失败",
-          message: self.conciseOutput(result.output, fallback: "主题 ZIP 未通过安全或内容校验。")
+          title: self.copy.text(.importFailedTitle),
+          message: self.conciseOutput(result.output, fallback: self.copy.text(.invalidZipMessage))
         )
         return
       }
@@ -811,8 +871,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
               ) != nil else {
           self.finishThemeOperation(cleanupRoot: cleanupRoot)
           self.showError(
-            title: "主题已下载，但没有应用",
-            message: "主题包没有完成严格 ZIP 与 Safe CSS 导入校验。"
+            title: self.copy.text(.downloadedNotAppliedTitle),
+            message: self.copy.text(.downloadedNotAppliedMessage)
           )
           return
         }
@@ -827,16 +887,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
         return
       }
       if status == "duplicate" {
-        var details = "“\(name)”与已保存主题完全相同，没有重复写入。"
+        var details = self.copy.format(.duplicateBase, name)
         if safeCssStatus == "validated" {
-          details += "\n包内 theme.css 已通过本机 Safe CSS 校验，切换到该主题时会一并生效。"
+          details += self.copy.text(.duplicateCSS)
         }
         if signatureIgnored {
-          details += "\n包内 manifest.sig 是预留文件，当前版本已忽略。"
+          details += self.copy.text(.signatureIgnored)
         }
         self.finishThemeOperation(cleanupRoot: cleanupRoot)
         self.showInfo(
-          title: "主题已经存在",
+          title: self.copy.text(.duplicateTitle),
           message: details
         )
         return
@@ -845,25 +905,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       let replaced = value["replaced"] as? Bool ?? false
       let nameCollision = value["nameCollision"] as? Bool ?? false
       var details = replaced
-        ? "已更新“\(name)”的已保存版本，当前正在使用的主题没有改变。"
-        : "已把“\(name)”加入“已保存的主题”，当前正在使用的主题没有改变。"
+        ? self.copy.format(.importedUpdated, name)
+        : self.copy.format(.importedAdded, name)
       if renamed {
-        details += "\n为避免覆盖同 ID 主题，已使用新标识：\(id)。"
+        details += self.copy.format(.renamed, id)
       }
       if nameCollision {
-        details += "\n主题库中已有同名主题，可在菜单中按需要选择。"
+        details += self.copy.text(.nameCollision)
       }
       if safeCssStatus == "validated" {
-        details += "\ntheme.css 已通过本机 Safe CSS 校验，切换到该主题时会一并生效。"
+        details += self.copy.text(.cssValidated)
       }
       if signatureIgnored {
-        details += "\n包内 manifest.sig 是预留文件，当前版本已忽略。"
+        details += self.copy.text(.signatureIgnored)
       }
       if cleanupWarning {
-        details += "\n主题已成功保存，但旧备份目录未能自动清理；新主题不会因此回滚。请稍后重启客户端并查看日志。"
+        details += self.copy.text(.cleanupWarning)
       }
       self.finishThemeOperation(cleanupRoot: cleanupRoot)
-      self.showInfo(title: "主题导入完成", message: details)
+      self.showInfo(title: self.copy.text(.importCompleteTitle), message: details)
     }
   }
 
@@ -886,13 +946,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
           let transactionScript = installedScript(named: "apply-community-theme-macos.sh") else {
       finishThemeOperation(cleanupRoot: cleanupRoot)
       showError(
-        title: "主题已导入，但没有应用",
-        message: "客户端无法启动带回滚保护的一键换肤事务。当前主题没有改变。"
+        title: copy.text(.importedApplyTitle),
+        message: copy.text(.importedApplyMessage)
       )
       return
     }
     reactivateCodexBeforeTransaction()
-    updateCommunityStage("正在保存当前主题、应用新主题并验证渲染…")
+    updateCommunityStage(copy.resolvedLanguage == .chinese
+      ? "正在保存当前主题、应用新主题并验证渲染…"
+      : "Saving the current theme, applying the new theme, and verifying rendering…")
     ScriptRunner.run(
       script: transactionScript,
       arguments: [
@@ -910,39 +972,59 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
         cleanupRoot: rollbackRetention.requiresOperationRoot ? nil : cleanupRoot
       )
       if result.succeeded {
-        var details = "“\(name)”已通过下载、SHA-256、主题包、Safe CSS 和可见渲染校验，并已切换到客户端。"
+        var details = self.copy.format(.appliedMessage, name)
         if cleanupWarning {
-          details += "\n\n主题已成功应用，但旧备份目录未能自动清理；新主题不会因此回滚。请稍后重启客户端并查看日志。"
+          details += "\n" + self.copy.text(.cleanupWarning)
         }
         self.showInfo(
-          title: "主题已应用",
+          title: self.copy.text(.appliedTitle),
           message: details
         )
       } else if result.exitCode == 20 {
         self.showError(
-          title: "新主题应用失败，原主题已恢复",
-          message: "换肤前的精确主题快照已重新应用，并通过可见渲染验证。\n\n\(self.conciseOutput(result.output, fallback: "新主题仍保存在主题库中。"))"
+          title: self.copy.text(.rollbackTitle),
+          message: self.copy.format(
+            .rollbackMessage,
+            self.conciseOutput(
+              result.output,
+              fallback: self.copy.resolvedLanguage == .chinese
+                ? "新主题仍保存在主题库中。"
+                : "The new theme remains in Saved themes."
+            )
+          )
         )
       } else {
         var details = self.conciseOutput(
           result.output,
-          fallback: "请从已保存主题中重新选择一个主题。"
+          fallback: self.copy.resolvedLanguage == .chinese
+            ? "请从已保存主题中重新选择一个主题。"
+            : "Choose a theme again from Saved themes."
         )
         let title: String
         switch rollbackRetention {
         case let .preserved(recoveryURL):
-          title = "自动恢复未完成，原主题快照已保留"
-          details += "\n\n换肤前的精确主题快照已移入私有恢复目录：\n\(recoveryURL.path)\n该快照尚未通过恢复验证，请不要把“已保留”理解为已经恢复。"
+          title = self.copy.resolvedLanguage == .chinese
+            ? "自动恢复未完成，原主题快照已保留"
+            : "Automatic recovery did not finish; original snapshot retained"
+          details += self.copy.resolvedLanguage == .chinese
+            ? "\n\n换肤前的精确主题快照已移入私有恢复目录：\n\(recoveryURL.path)\n该快照尚未通过恢复验证，请不要把“已保留”理解为已经恢复。"
+            : "\n\nThe exact pre-apply snapshot was moved to this private recovery folder:\n\(recoveryURL.path)\nThe snapshot has not passed restore verification; retained does not mean restored."
         case let .retainedInOperationRoot(snapshotURL):
-          title = "自动恢复未完成，快照仍在事务目录"
-          details += "\n\n客户端无法把快照提升到 recovery 目录，但已停止清理原事务目录，并检测到快照仍位于：\n\(snapshotURL.path)\n该快照尚未通过恢复验证，请不要继续切换主题。"
+          title = self.copy.resolvedLanguage == .chinese
+            ? "自动恢复未完成，快照仍在事务目录"
+            : "Automatic recovery did not finish; snapshot remains in transaction folder"
+          details += self.copy.resolvedLanguage == .chinese
+            ? "\n\n客户端无法把快照提升到 recovery 目录，但已停止清理原事务目录，并检测到快照仍位于：\n\(snapshotURL.path)\n该快照尚未通过恢复验证，请不要继续切换主题。"
+            : "\n\nThe client could not move the snapshot into the recovery folder, so it stopped cleaning the transaction folder. The snapshot remains at:\n\(snapshotURL.path)\nIt has not passed restore verification. Do not switch themes again yet."
         case .unavailable:
-          title = "主题已导入，但应用状态未确认"
-          details += "\n\n客户端没有确认到可保留的换肤前快照，不能承诺可自动恢复。请不要继续切换主题，并查看 Dream Skin 日志。"
+          title = self.copy.text(.unconfirmedTitle)
+          details += self.copy.resolvedLanguage == .chinese
+            ? "\n\n客户端没有确认到可保留的换肤前快照，不能承诺可自动恢复。请不要继续切换主题，并查看 Dream Skin 日志。"
+            : "\n\nThe client could not confirm a retainable pre-apply snapshot, so automatic recovery cannot be promised. Do not switch themes again; check the Dream Skin logs."
         }
         self.showError(
           title: title,
-          message: "当前可见主题状态未能确认。\n\n\(details)"
+          message: self.copy.format(.unconfirmedMessage, details)
         )
       }
     }
@@ -987,13 +1069,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   @objc private func switchSavedTheme(_ sender: NSMenuItem) {
     guard let id = sender.representedObject as? String,
           id.range(of: #"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$"#, options: .regularExpression) != nil else {
-      showError(title: "主题无效", message: "主题标识不符合安全规则。")
+      showError(title: copy.text(.invalidThemeTitle), message: copy.text(.invalidThemeMessage))
       return
     }
     runInstalledScript(
       named: "switch-theme-macos.sh",
       arguments: ["--id", id],
-      operation: "切换主题"
+      operation: copy.resolvedLanguage == .chinese ? "切换主题" : "Switch theme"
     )
   }
 
@@ -1009,7 +1091,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
 
   @objc private func openCodex() {
     guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.openai.codex") else {
-      showError(title: "未找到 ChatGPT", message: "请先安装并至少启动一次官方 ChatGPT / Codex 桌面应用。")
+      showError(title: copy.text(.notFoundTitle), message: copy.text(.notFoundMessage))
       return
     }
     guard !operationInFlight else { return }
@@ -1019,7 +1101,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, error in
         if let error {
           DispatchQueue.main.async {
-            self.showError(title: "无法打开 ChatGPT", message: error.localizedDescription)
+            self.showError(title: self.copy.text(.openFailedTitle), message: error.localizedDescription)
           }
         }
       }
@@ -1034,8 +1116,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       self.rebuildMenu()
       if !result.succeeded {
         self.showError(
-          title: "无法打开 ChatGPT",
-          message: self.conciseOutput(result.output, fallback: "请检查 ChatGPT 是否已安装，并重试。")
+          title: self.copy.text(.openFailedTitle),
+          message: self.conciseOutput(result.output, fallback: self.copy.text(.openFailedMessage))
         )
       }
     }
@@ -1060,7 +1142,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     guard !operationInFlight, !updateCheckInFlight else { return }
     guard let script = installedScript(named: "check-update-macos.sh")
       ?? bundledScript(named: "check-update-macos.sh") else {
-      showError(title: "无法检查更新", message: "更新检查脚本缺失，请重新安装应用。")
+      showError(title: copy.text(.updateMissingTitle), message: copy.text(.updateMissingMessage))
       return
     }
     operationInFlight = true
@@ -1079,24 +1161,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
             let latest = value["latestVersion"] as? String,
             let available = value["updateAvailable"] as? Bool else {
         self.showError(
-          title: "检查更新失败",
-          message: self.conciseOutput(result.output, fallback: "无法连接 GitHub，请稍后重试。")
+          title: self.copy.text(.updateFailedTitle),
+          message: self.conciseOutput(result.output, fallback: self.copy.text(.updateFailedMessage))
         )
         return
       }
       if available {
         let alert = NSAlert()
-        alert.messageText = "发现新版本 \(latest)"
-        alert.informativeText = "当前版本为 \(current)。是否前往 GitHub Releases 下载？"
-        alert.addButton(withTitle: "前往下载")
-        alert.addButton(withTitle: "稍后")
+        alert.messageText = self.copy.format(.newVersionTitle, latest)
+        alert.informativeText = self.copy.format(.newVersionMessage, current)
+        alert.addButton(withTitle: self.copy.text(.downloadNow))
+        alert.addButton(withTitle: self.copy.text(.later))
         self.activateForUserInteraction()
         if alert.runModal() == .alertFirstButtonReturn,
            let url = URL(string: "https://github.com/Fei-Away/Codex-Dream-Skin/releases/latest") {
           NSWorkspace.shared.open(url)
         }
       } else {
-        self.showInfo(title: "已是最新版本", message: "当前安装的是 \(current)。")
+        self.showInfo(
+          title: self.copy.text(.upToDateTitle),
+          message: self.copy.format(.upToDateMessage, current)
+        )
       }
     }
   }
@@ -1141,8 +1226,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
 
   private func postUpdateAvailableNotification(version: String, releaseURL: String) {
     let content = UNMutableNotificationContent()
-    content.title = "Codex Dream Skin 有新版本"
-    content.body = "\(version) 已发布，点按前往下载页面。"
+    if copy.resolvedLanguage == .chinese {
+      content.title = "Codex Dream Skin 有新版本"
+      content.body = "\(version) 已发布，点按前往下载页面。"
+    } else {
+      content.title = "Codex Dream Skin update available"
+      content.body = "\(version) is available. Click to open the download page."
+    }
     content.sound = .default
     content.userInfo = ["releaseURL": releaseURL]
     let request = UNNotificationRequest(
@@ -1189,14 +1279,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       rebuildMenu()
       if SMAppService.mainApp.status == .requiresApproval {
         showInfo(
-          title: "需要系统确认",
-          message: "请在“系统设置 → 通用 → 登录项”中允许 Codex Dream Skin。"
+          title: copy.text(.loginApprovalTitle),
+          message: copy.text(.loginApprovalMessage)
         )
       }
     } catch {
       showError(
-        title: "无法修改登录启动",
-        message: "请先把 App 拖到“应用程序”文件夹，再重试。\n\n\(error.localizedDescription)"
+        title: copy.text(.loginStartFailedTitle),
+        message: copy.format(.loginStartFailedMessage, error.localizedDescription)
       )
     }
   }
@@ -1208,17 +1298,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   @objc private func restoreAndUninstall() {
     let alert = NSAlert()
     alert.alertStyle = .warning
-    alert.messageText = "恢复原状并卸载 Dream Skin？"
-    alert.informativeText = "将停止皮肤、恢复 ChatGPT 外观、删除本地引擎并关闭本应用。你的图片和已保存主题会保留。"
-    alert.addButton(withTitle: "恢复并卸载")
-    alert.addButton(withTitle: "取消")
+    alert.messageText = copy.text(.restoreConfirmTitle)
+    alert.informativeText = copy.text(.restoreConfirmMessage)
+    alert.addButton(withTitle: copy.text(.restoreAndUninstall))
+    alert.addButton(withTitle: copy.resolvedLanguage == .chinese ? "取消" : "Cancel")
     activateForUserInteraction()
     guard alert.runModal() == .alertFirstButtonReturn else { return }
 
     let script = installedScript(named: "restore-dream-skin-macos.sh")
       ?? bundledScript(named: "restore-dream-skin-macos.sh")
     guard let script else {
-      showError(title: "无法恢复", message: "恢复脚本缺失；没有删除任何文件。")
+      showError(
+        title: copy.resolvedLanguage == .chinese ? "无法恢复" : "Could not restore",
+        message: copy.resolvedLanguage == .chinese
+          ? "恢复脚本缺失；没有删除任何文件。"
+          : "The restore script is missing. No files were removed."
+      )
       return
     }
     operationInFlight = true
@@ -1232,8 +1327,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       guard result.succeeded else {
         self.rebuildMenu()
         self.showError(
-          title: "恢复未完成",
-          message: self.conciseOutput(result.output, fallback: "引擎和设置均已保留，请处理错误后重试。")
+          title: self.copy.text(.restoreFailedTitle),
+          message: self.conciseOutput(result.output, fallback: self.copy.text(.restoreFailedMessage))
         )
         return
       }
@@ -1247,14 +1342,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       } catch {
         self.rebuildMenu()
         self.showError(
-          title: "恢复完成，但清理失败",
-          message: "ChatGPT 已恢复，部分安装文件未能删除：\n\n\(error.localizedDescription)"
+          title: self.copy.text(.restoreCleanupFailedTitle),
+          message: self.copy.format(.restoreCleanupFailedMessage, error.localizedDescription)
         )
         return
       }
       self.showInfo(
-        title: "恢复完成",
-        message: "本地引擎和登录启动已移除。最后请把“Codex Dream Skin.app”移到废纸篓。"
+        title: self.copy.text(.restoreDoneTitle),
+        message: self.copy.text(.restoreDoneMessage)
       )
       NSApp.terminate(nil)
     }
@@ -1262,7 +1357,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
 
   @objc private func quit() {
     guard !operationInFlight, !engineInstallInFlight, !snapshot.busy else {
-      showError(title: "操作仍在进行", message: "请等待当前操作完成后再退出。")
+      showError(
+        title: copy.text(.busyTitle),
+        message: copy.resolvedLanguage == .chinese
+          ? "请等待当前操作完成后再退出。"
+          : "Wait for the current operation to finish before quitting."
+      )
       return
     }
     NSApp.terminate(nil)
@@ -1275,7 +1375,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
   ) {
     guard !operationInFlight else { return }
     guard let script = installedScript(named: name) else {
-      showError(title: "引擎尚未安装", message: "请先选择“安装 / 升级引擎”，再重试。")
+      showError(title: copy.text(.missingEngineTitle), message: copy.text(.missingEngineRetryMessage))
       return
     }
     operationInFlight = true
@@ -1287,8 +1387,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       self.rebuildMenu()
       if !result.succeeded {
         self.showError(
-          title: "\(operation)失败",
-          message: self.conciseOutput(result.output, fallback: "请检查 ChatGPT 是否已安装，并重试。")
+          title: self.copy.operationFailed(operation),
+          message: self.conciseOutput(result.output, fallback: self.copy.text(.openFailedMessage))
         )
       }
     }
@@ -1309,21 +1409,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     }
     guard let bundledVersion = version(at: bundledEngineURL?.appendingPathComponent("VERSION")) else {
       pendingCommunityVersionID = nil
-      showError(title: "安装资源损坏", message: "App 内的版本信息无效，请重新下载。")
+      showError(title: copy.text(.installCorruptTitle), message: copy.text(.installVersionInvalid))
       return
     }
     if let installedVersion = version(at: installedEngineURL.appendingPathComponent("VERSION")),
        installedVersion > bundledVersion {
       pendingCommunityVersionID = nil
       showError(
-        title: "已安装更新版本",
-        message: "本机引擎 v\(installedVersion) 比当前 App 的 v\(bundledVersion) 更新。请下载相同或更新版本的 DMG，不会执行降级。"
+        title: copy.text(.installedNewerTitle),
+        message: copy.format(.installedNewerMessage, installedVersion.description, bundledVersion.description)
       )
       return
     }
     guard let script = bundledScript(named: "install-dream-skin-macos.sh") else {
       pendingCommunityVersionID = nil
-      showError(title: "安装资源损坏", message: "App 内没有找到 Dream Skin 引擎。请重新下载。")
+      showError(title: copy.text(.installCorruptTitle), message: copy.text(.installMissingEngine))
       return
     }
     engineInstallInFlight = true
@@ -1348,10 +1448,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       } else {
         self.pendingCommunityVersionID = nil
         self.showError(
-          title: "引擎安装未完成",
+          title: self.copy.text(.installFailedTitle),
           message: self.conciseOutput(
             result.output,
-            fallback: "安装脚本返回了错误，请重试；如果问题持续，请查看 Dream Skin 日志。"
+            fallback: self.copy.text(.installFailedMessage)
           )
         )
       }
@@ -1365,8 +1465,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     }
     guard let script = installedScript(named: "recover-theme-imports-macos.sh") else {
       showError(
-        title: "主题恢复组件缺失",
-        message: "本地引擎不完整，未继续待执行的换肤操作。请先选择“修复 / 重新安装引擎…”。"
+        title: copy.text(.recoveryMissingTitle),
+        message: copy.text(.recoveryMissingMessage)
       )
       completion?(false)
       return
@@ -1382,8 +1482,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
           self.conciseOutput(result.output, fallback: "unknown recovery failure")
         )
         self.showError(
-          title: "主题恢复未完成",
-          message: "已保留恢复记录，未继续待执行的换肤操作。请先选择“修复 / 重新安装引擎…”；如果仍失败，请附上日志反馈。"
+          title: self.copy.text(.recoveryFailedTitle),
+          message: self.copy.text(.recoveryFailedMessage)
         )
       }
       self.rebuildMenu()
@@ -1472,10 +1572,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     guard !plugins.isEmpty else { return }
     if confirmFirst {
       let alert = NSAlert()
-      alert.messageText = "停用旧 SwiftBar 菜单？"
-      alert.informativeText = "已检测到旧版 Dream Skin SwiftBar 插件。停用后可避免菜单栏出现两个图标；插件会改名保留，不会直接删除。"
-      alert.addButton(withTitle: "停用旧插件")
-      alert.addButton(withTitle: "稍后")
+      alert.messageText = copy.text(.legacyConfirmTitle)
+      alert.informativeText = copy.text(.legacyConfirmMessage)
+      alert.addButton(withTitle: copy.text(.legacyDisable))
+      alert.addButton(withTitle: copy.text(.later))
       activateForUserInteraction()
       guard alert.runModal() == .alertFirstButtonReturn else { return }
     }
@@ -1495,9 +1595,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
       NSWorkspace.shared.open(refreshURL)
     }
     if failures.isEmpty {
-      showInfo(title: "旧菜单已停用", message: "SwiftBar 插件已安全改名保留。")
+      showInfo(title: copy.text(.legacyDisabledTitle), message: copy.text(.legacyDisabledMessage))
     } else {
-      showError(title: "部分旧插件未能停用", message: failures.joined(separator: "\n"))
+      showError(title: copy.text(.legacyPartialTitle), message: failures.joined(separator: "\n"))
     }
   }
 
@@ -1528,7 +1628,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     let alert = NSAlert()
     alert.messageText = title
     alert.informativeText = message
-    alert.addButton(withTitle: "好")
+    alert.addButton(withTitle: copy.text(.ok))
     activateForUserInteraction()
     alert.runModal()
   }
@@ -1538,7 +1638,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     alert.alertStyle = .warning
     alert.messageText = title
     alert.informativeText = message
-    alert.addButton(withTitle: "好")
+    alert.addButton(withTitle: copy.text(.ok))
     activateForUserInteraction()
     alert.runModal()
   }

--- a/macos/menubar-app/Sources/CodexDreamSkinMenuBar/ScriptRunner.swift
+++ b/macos/menubar-app/Sources/CodexDreamSkinMenuBar/ScriptRunner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import DreamSkinCore
 
 struct ScriptResult {
   let exitCode: Int32
@@ -22,6 +23,7 @@ enum ScriptRunner {
       var environment = ProcessInfo.processInfo.environment
       environment["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
       environment["LC_ALL"] = "en_US.UTF-8"
+      environment["DREAMSKIN_LANG"] = DreamSkinLanguage.stored().environmentValue
       process.environment = environment
       process.standardOutput = pipe
       process.standardError = pipe

--- a/macos/menubar-app/Sources/DreamSkinCore/Localization.swift
+++ b/macos/menubar-app/Sources/DreamSkinCore/Localization.swift
@@ -1,0 +1,343 @@
+import Foundation
+
+public enum DreamSkinLanguage: String, CaseIterable, Codable, Sendable {
+  case system
+  case english
+  case chinese
+
+  public static let defaultsKey = "dreamskin.language"
+
+  public var displayName: String {
+    switch self {
+    case .system: return "System / 系统"
+    case .english: return "English"
+    case .chinese: return "中文"
+    }
+  }
+
+  public var environmentValue: String {
+    switch resolved() {
+    case .chinese: return "zh-CN"
+    case .english, .system: return "en-US"
+    }
+  }
+
+  public func resolved(preferredLanguages: [String] = Locale.preferredLanguages) -> DreamSkinLanguage {
+    switch self {
+    case .english, .chinese:
+      return self
+    case .system:
+      let preferred = preferredLanguages.first?.lowercased() ?? ""
+      return preferred.hasPrefix("zh") ? .chinese : .english
+    }
+  }
+
+  public static func stored(
+    defaults: UserDefaults = .standard
+  ) -> DreamSkinLanguage {
+    guard let raw = defaults.string(forKey: defaultsKey),
+          let value = DreamSkinLanguage(rawValue: raw) else {
+      return .system
+    }
+    return value
+  }
+}
+
+public struct DreamSkinCopy: Sendable {
+  public enum Key: String, Sendable {
+    case statusApplying
+    case statusPausing
+    case statusOnFailed
+    case statusOn
+    case statusOffFailed
+    case statusOff
+    case statusUnknown
+    case appliedTheme
+    case selectedThemePending
+    case selectedTheme
+    case codexOpen
+    case codexClosed
+    case version
+    case newVersion
+    case themeMenu
+    case linksMenu
+    case maintenanceMenu
+    case languageMenu
+    case apply
+    case reapply
+    case repairApply
+    case pause
+    case openChatGPT
+    case loginAtStartup
+    case quit
+    case changeBackground
+    case importZip
+    case savedThemes
+    case noSavedThemes
+    case openThemes
+    case openImages
+    case gallery
+    case studio
+    case openSite
+    case installEngine
+    case repairEngine
+    case installingEngine
+    case checkUpdate
+    case disableSwiftBar
+    case restoreUninstall
+    case busyTitle
+    case busyMessage
+    case invalidLinkTitle
+    case invalidLinkMessage
+    case prepareDirectoryTitle
+    case cannotApplyTitle
+    case cannotApplyMessage
+    case missingEngineTitle
+    case missingEngineCommunityMessage
+    case missingEngineImportMessage
+    case missingEngineRetryMessage
+    case invalidThemeTitle
+    case invalidThemeMessage
+    case baselineTitle
+    case baselineMessage
+    case readThemeTitle
+    case readThemeMessage
+    case validationTitle
+    case downloadThemeTitle
+    case downloadThemeMessage
+    case downloadValidationTitle
+    case downloadValidationMessage
+    case importFailedTitle
+    case invalidZipMessage
+    case downloadedNotAppliedTitle
+    case downloadedNotAppliedMessage
+    case duplicateTitle
+    case duplicateBase
+    case duplicateCSS
+    case signatureIgnored
+    case importedUpdated
+    case importedAdded
+    case renamed
+    case nameCollision
+    case cssValidated
+    case cleanupWarning
+    case importCompleteTitle
+    case importedApplyTitle
+    case importedApplyMessage
+    case appliedTitle
+    case appliedMessage
+    case rollbackTitle
+    case rollbackMessage
+    case unconfirmedTitle
+    case unconfirmedMessage
+    case notFoundTitle
+    case notFoundMessage
+    case openFailedTitle
+    case openFailedMessage
+    case updateMissingTitle
+    case updateMissingMessage
+    case updateFailedTitle
+    case updateFailedMessage
+    case newVersionTitle
+    case newVersionMessage
+    case downloadNow
+    case later
+    case upToDateTitle
+    case upToDateMessage
+    case loginApprovalTitle
+    case loginApprovalMessage
+    case loginStartFailedTitle
+    case loginStartFailedMessage
+    case restoreConfirmTitle
+    case restoreConfirmMessage
+    case restoreAndUninstall
+    case restoreFailedTitle
+    case restoreFailedMessage
+    case restoreCleanupFailedTitle
+    case restoreCleanupFailedMessage
+    case restoreDoneTitle
+    case restoreDoneMessage
+    case installCorruptTitle
+    case installVersionInvalid
+    case installedNewerTitle
+    case installedNewerMessage
+    case installMissingEngine
+    case installFailedTitle
+    case installFailedMessage
+    case recoveryMissingTitle
+    case recoveryMissingMessage
+    case recoveryFailedTitle
+    case recoveryFailedMessage
+    case legacyConfirmTitle
+    case legacyConfirmMessage
+    case legacyDisable
+    case legacyDisabledTitle
+    case legacyDisabledMessage
+    case legacyPartialTitle
+    case ok
+    }
+
+  public let language: DreamSkinLanguage
+
+  public init(language: DreamSkinLanguage) {
+    self.language = language
+  }
+
+  public var resolvedLanguage: DreamSkinLanguage {
+    language.resolved()
+  }
+
+  public func text(_ key: Key) -> String {
+    let chinese = resolvedLanguage == .chinese
+    switch key {
+    case .statusApplying: return chinese ? "Skin 应用中" : "Skin applying"
+    case .statusPausing: return chinese ? "Skin 暂停中" : "Skin pausing"
+    case .statusOnFailed: return chinese ? "Skin ON · 操作失败" : "Skin ON · operation failed"
+    case .statusOn: return "Skin ON"
+    case .statusOffFailed: return chinese ? "Skin OFF · 操作失败" : "Skin OFF · operation failed"
+    case .statusOff: return "Skin OFF"
+    case .statusUnknown: return chinese ? "Skin 异常" : "Skin unavailable"
+    case .appliedTheme: return chinese ? "已应用：%@" : "Applied: %@"
+    case .selectedThemePending: return chinese ? "已选主题：%@（待应用）" : "Selected: %@ (pending apply)"
+    case .selectedTheme: return chinese ? "已选主题：%@" : "Selected: %@"
+    case .codexOpen: return chinese ? "ChatGPT：已打开" : "ChatGPT: Open"
+    case .codexClosed: return chinese ? "ChatGPT：未打开" : "ChatGPT: Closed"
+    case .version: return chinese ? "版本：v%@" : "Version: v%@"
+    case .newVersion: return chinese ? "🆕 发现新版本 %@" : "🆕 New version %@ available"
+    case .themeMenu: return chinese ? "主题" : "Themes"
+    case .linksMenu: return chinese ? "链接" : "Links"
+    case .maintenanceMenu: return chinese ? "维护" : "Maintenance"
+    case .languageMenu: return chinese ? "语言" : "Language"
+    case .apply: return chinese ? "应用皮肤" : "Apply skin"
+    case .reapply: return chinese ? "重新应用皮肤" : "Reapply skin"
+    case .repairApply: return chinese ? "修复并应用" : "Repair and apply"
+    case .pause: return chinese ? "暂停皮肤" : "Pause skin"
+    case .openChatGPT: return chinese ? "打开 ChatGPT" : "Open ChatGPT"
+    case .loginAtStartup: return chinese ? "登录时启动" : "Launch at login"
+    case .quit: return chinese ? "退出" : "Quit"
+    case .changeBackground: return chinese ? "换一张背景图…" : "Choose background image…"
+    case .importZip: return chinese ? "导入主题 ZIP…" : "Import theme ZIP…"
+    case .savedThemes: return chinese ? "已保存的主题" : "Saved themes"
+    case .noSavedThemes: return chinese ? "还没有保存的主题" : "No saved themes yet"
+    case .openThemes: return chinese ? "打开主题文件夹" : "Open themes folder"
+    case .openImages: return chinese ? "打开图片文件夹" : "Open images folder"
+    case .gallery: return chinese ? "主题库 Gallery" : "Theme Gallery"
+    case .studio: return chinese ? "在线 Studio" : "Online Studio"
+    case .openSite: return chinese ? "打开 DreamSkin.cc" : "Open DreamSkin.cc"
+    case .installEngine: return chinese ? "安装 / 升级引擎…" : "Install / upgrade engine…"
+    case .repairEngine: return chinese ? "修复 / 重新安装引擎…" : "Repair / reinstall engine…"
+    case .installingEngine: return chinese ? "正在安装引擎…" : "Installing engine…"
+    case .checkUpdate: return chinese ? "立即检查更新" : "Check for updates now"
+    case .disableSwiftBar: return chinese ? "停用旧 SwiftBar 菜单…" : "Disable old SwiftBar menu…"
+    case .restoreUninstall: return chinese ? "恢复原状并卸载…" : "Restore and uninstall…"
+    case .busyTitle: return chinese ? "操作仍在进行" : "Operation in progress"
+    case .busyMessage: return chinese ? "请等待当前下载、导入、应用或恢复完成后再退出，以免留下未完成的主题状态。" : "Wait for the current download, import, apply, or restore to finish before quitting so the theme state stays recoverable."
+    case .invalidLinkTitle: return chinese ? "一键换肤链接无效" : "Invalid one-click theme link"
+    case .invalidLinkMessage: return chinese ? "只接受 DreamSkin.cc 生成的主题版本链接；不会打开链接中的任意网址或文件。" : "Only theme-version links generated by DreamSkin.cc are accepted. The app will not open arbitrary URLs or files from a link."
+    case .prepareDirectoryTitle: return chinese ? "无法准备用户目录" : "Could not prepare the user folders"
+    case .cannotApplyTitle: return chinese ? "暂时无法换肤" : "Cannot apply a theme right now"
+    case .cannotApplyMessage: return chinese ? "Dream Skin 正在执行其他操作，请稍后再点一次。" : "Dream Skin is busy with another operation. Try again in a moment."
+    case .missingEngineTitle: return chinese ? "引擎尚未安装" : "Engine is not installed"
+    case .missingEngineCommunityMessage: return chinese ? "请先选择“安装 / 升级引擎”，再使用一键换肤。" : "Choose “Install / upgrade engine” before using one-click theme apply."
+    case .missingEngineImportMessage: return chinese ? "请先选择“安装 / 升级引擎”，再导入主题。" : "Choose “Install / upgrade engine” before importing a theme."
+    case .missingEngineRetryMessage: return chinese ? "请先选择“安装 / 升级引擎”，再重试。" : "Choose “Install / upgrade engine” and try again."
+    case .invalidThemeTitle: return chinese ? "主题无效" : "Invalid theme"
+    case .invalidThemeMessage: return chinese ? "主题标识不符合安全规则。" : "The theme identifier does not meet the safety rules."
+    case .baselineTitle: return chinese ? "当前皮肤还不能安全换肤" : "The current skin is not ready for a safe replacement"
+    case .baselineMessage: return chinese ? "请先从菜单栏应用当前皮肤，确认状态为 Skin ON 且没有“待应用”主题，再回到网页重试。这样失败时才能恢复并验证点击前真正显示的主题。" : "Apply the current skin from the menu bar first. Confirm it says Skin ON with no pending theme, then retry from the website. This lets the app restore and verify exactly what was visible before the click if the new apply fails."
+    case .readThemeTitle: return chinese ? "无法读取主题信息" : "Could not read theme metadata"
+    case .readThemeMessage: return chinese ? "DreamSkin.cc 没有返回可验证的已审核主题，请稍后重试。" : "DreamSkin.cc did not return a verifiable approved theme. Try again later."
+    case .validationTitle: return chinese ? "主题信息未通过校验" : "Theme metadata failed validation"
+    case .downloadThemeTitle: return chinese ? "无法下载主题" : "Could not download the theme"
+    case .downloadThemeMessage: return chinese ? "主题下载地址无法由版本标识安全构造。" : "A safe download URL could not be constructed from the version identifier."
+    case .downloadValidationTitle: return chinese ? "主题包未通过下载校验" : "Theme package failed download validation"
+    case .downloadValidationMessage: return chinese ? "下载已丢弃，没有导入或应用任何内容。\n\n%@" : "The download was discarded. Nothing was imported or applied.\n\n%@"
+    case .importFailedTitle: return chinese ? "导入主题失败" : "Theme import failed"
+    case .invalidZipMessage: return chinese ? "主题 ZIP 未通过安全或内容校验。" : "The theme ZIP failed the safety or content validation."
+    case .downloadedNotAppliedTitle: return chinese ? "主题已下载，但没有应用" : "Theme downloaded but not applied"
+    case .downloadedNotAppliedMessage: return chinese ? "主题包没有完成严格 ZIP 与 Safe CSS 导入校验。" : "The package did not complete the strict ZIP and Safe CSS import checks."
+    case .duplicateTitle: return chinese ? "主题已经存在" : "Theme already exists"
+    case .duplicateBase: return chinese ? "“%@”与已保存主题完全相同，没有重复写入。" : "“%@” is identical to a saved theme, so no duplicate was written."
+    case .duplicateCSS: return chinese ? "\n包内 theme.css 已通过本机 Safe CSS 校验，切换到该主题时会一并生效。" : "\nThe bundled theme.css passed local Safe CSS validation and will be applied when you switch to this theme."
+    case .signatureIgnored: return chinese ? "\n包内 manifest.sig 是预留文件，当前版本已忽略。" : "\nmanifest.sig is reserved for a future version and is ignored by this release."
+    case .importedUpdated: return chinese ? "已更新“%@”的已保存版本，当前正在使用的主题没有改变。" : "The saved version of “%@” was updated. The currently active theme did not change."
+    case .importedAdded: return chinese ? "已把“%@”加入“已保存的主题”，当前正在使用的主题没有改变。" : "“%@” was added to Saved themes. The currently active theme did not change."
+    case .renamed: return chinese ? "\n为避免覆盖同 ID 主题，已使用新标识：%@。" : "\nA new identifier was used to avoid overwriting a theme with the same ID: %@."
+    case .nameCollision: return chinese ? "\n主题库中已有同名主题，可在菜单中按需要选择。" : "\nA theme with the same name already exists; choose the one you want from the menu."
+    case .cssValidated: return chinese ? "\ntheme.css 已通过本机 Safe CSS 校验，切换到该主题时会一并生效。" : "\ntheme.css passed local Safe CSS validation and will be applied when you switch to this theme."
+    case .cleanupWarning: return chinese ? "\n主题已成功保存，但旧备份目录未能自动清理；新主题不会因此回滚。请稍后重启客户端并查看日志。" : "\nThe theme was saved, but an old backup folder could not be cleaned up. The new theme will not roll back because of this. Restart the client later and check its logs."
+    case .importCompleteTitle: return chinese ? "主题导入完成" : "Theme import complete"
+    case .importedApplyTitle: return chinese ? "主题已导入，但没有应用" : "Theme imported but not applied"
+    case .importedApplyMessage: return chinese ? "客户端无法启动带回滚保护的一键换肤事务。当前主题没有改变。" : "The client could not start the rollback-protected one-click apply transaction. The current theme was not changed."
+    case .appliedTitle: return chinese ? "主题已应用" : "Theme applied"
+    case .appliedMessage: return chinese ? "“%@”已通过下载、SHA-256、主题包、Safe CSS 和可见渲染校验，并已切换到客户端。" : "“%@” passed the download, SHA-256, package, Safe CSS, and visible-render checks and is now active."
+    case .rollbackTitle: return chinese ? "新主题应用失败，原主题已恢复" : "New theme failed; original theme restored"
+    case .rollbackMessage: return chinese ? "换肤前的精确主题快照已重新应用，并通过可见渲染验证。\n\n%@" : "The exact pre-apply theme snapshot was reapplied and passed visible-render verification.\n\n%@"
+    case .unconfirmedTitle: return chinese ? "主题已导入，但应用状态未确认" : "Theme imported but apply state is unconfirmed"
+    case .unconfirmedMessage: return chinese ? "当前可见主题状态未能确认。\n\n%@" : "The currently visible theme state could not be confirmed.\n\n%@"
+    case .notFoundTitle: return chinese ? "未找到 ChatGPT" : "ChatGPT was not found"
+    case .notFoundMessage: return chinese ? "请先安装并至少启动一次官方 ChatGPT / Codex 桌面应用。" : "Install and launch the official ChatGPT / Codex desktop app at least once first."
+    case .openFailedTitle: return chinese ? "无法打开 ChatGPT" : "Could not open ChatGPT"
+    case .openFailedMessage: return chinese ? "请检查 ChatGPT 是否已安装，并重试。" : "Check that ChatGPT is installed and try again."
+    case .updateMissingTitle: return chinese ? "无法检查更新" : "Could not check for updates"
+    case .updateMissingMessage: return chinese ? "更新检查脚本缺失，请重新安装应用。" : "The update checker is missing. Reinstall the app."
+    case .updateFailedTitle: return chinese ? "检查更新失败" : "Update check failed"
+    case .updateFailedMessage: return chinese ? "无法连接 GitHub，请稍后重试。" : "Could not connect to GitHub. Try again later."
+    case .newVersionTitle: return chinese ? "发现新版本 %@" : "New version %@ available"
+    case .newVersionMessage: return chinese ? "当前版本为 %@。是否前往 GitHub Releases 下载？" : "You are running %@. Open GitHub Releases to download the update?"
+    case .downloadNow: return chinese ? "前往下载" : "Download"
+    case .later: return chinese ? "稍后" : "Later"
+    case .upToDateTitle: return chinese ? "已是最新版本" : "You are up to date"
+    case .upToDateMessage: return chinese ? "当前安装的是 %@。" : "You are running %@."
+    case .loginApprovalTitle: return chinese ? "需要系统确认" : "System confirmation required"
+    case .loginApprovalMessage: return chinese ? "请在“系统设置 → 通用 → 登录项”中允许 Codex Dream Skin。" : "Allow Codex Dream Skin in System Settings → General → Login Items."
+    case .loginStartFailedTitle: return chinese ? "无法修改登录启动" : "Could not change launch-at-login"
+    case .loginStartFailedMessage: return chinese ? "请先把 App 拖到“应用程序”文件夹，再重试。\n\n%@" : "Move the app to the Applications folder and try again.\n\n%@"
+    case .restoreConfirmTitle: return chinese ? "恢复原状并卸载 Dream Skin？" : "Restore the original appearance and uninstall Dream Skin?"
+    case .restoreConfirmMessage: return chinese ? "将停止皮肤、恢复 ChatGPT 外观、删除本地引擎并关闭本应用。你的图片和已保存主题会保留。" : "This stops the skin, restores ChatGPT's appearance, removes the local engine, and closes this app. Your images and saved themes will be kept."
+    case .restoreAndUninstall: return chinese ? "恢复并卸载" : "Restore and uninstall"
+    case .restoreFailedTitle: return chinese ? "恢复未完成" : "Restore did not finish"
+    case .restoreFailedMessage: return chinese ? "引擎和设置均已保留，请处理错误后重试。" : "The engine and settings were kept. Resolve the error and try again."
+    case .restoreCleanupFailedTitle: return chinese ? "恢复完成，但清理失败" : "Restored, but cleanup failed"
+    case .restoreCleanupFailedMessage: return chinese ? "ChatGPT 已恢复，部分安装文件未能删除：\n\n%@" : "ChatGPT was restored, but some installation files could not be removed:\n\n%@"
+    case .restoreDoneTitle: return chinese ? "恢复完成" : "Restore complete"
+    case .restoreDoneMessage: return chinese ? "本地引擎和登录启动已移除。最后请把“Codex Dream Skin.app”移到废纸篓。" : "The local engine and launch-at-login entry were removed. Move “Codex Dream Skin.app” to the Trash to finish."
+    case .installCorruptTitle: return chinese ? "安装资源损坏" : "Installation resources are damaged"
+    case .installVersionInvalid: return chinese ? "App 内的版本信息无效，请重新下载。" : "The version information inside the app is invalid. Download the app again."
+    case .installedNewerTitle: return chinese ? "已安装更新版本" : "A newer engine is already installed"
+    case .installedNewerMessage: return chinese ? "本机引擎 v%@ 比当前 App 的 v%@ 更新。请下载相同或更新版本的 DMG，不会执行降级。" : "The local engine v%@ is newer than this app's v%@. Download the same or a newer DMG; the app will not downgrade it."
+    case .installMissingEngine: return chinese ? "App 内没有找到 Dream Skin 引擎。请重新下载。" : "The Dream Skin engine is missing from the app. Download the app again."
+    case .installFailedTitle: return chinese ? "引擎安装未完成" : "Engine installation did not finish"
+    case .installFailedMessage: return chinese ? "安装脚本返回了错误，请重试；如果问题持续，请查看 Dream Skin 日志。" : "The installer returned an error. Try again; if it persists, check the Dream Skin logs."
+    case .recoveryMissingTitle: return chinese ? "主题恢复组件缺失" : "Theme recovery component is missing"
+    case .recoveryMissingMessage: return chinese ? "本地引擎不完整，未继续待执行的换肤操作。请先选择“修复 / 重新安装引擎…”。" : "The local engine is incomplete, so the pending theme operation was not resumed. Choose “Repair / reinstall engine…” first."
+    case .recoveryFailedTitle: return chinese ? "主题恢复未完成" : "Theme recovery did not finish"
+    case .recoveryFailedMessage: return chinese ? "已保留恢复记录，未继续待执行的换肤操作。请先选择“修复 / 重新安装引擎…”；如果仍失败，请附上日志反馈。" : "The recovery record was kept and the pending theme operation was not resumed. Choose “Repair / reinstall engine…” first; if it still fails, include the logs when reporting it."
+    case .legacyConfirmTitle: return chinese ? "停用旧 SwiftBar 菜单？" : "Disable the old SwiftBar menu?"
+    case .legacyConfirmMessage: return chinese ? "已检测到旧版 Dream Skin SwiftBar 插件。停用后可避免菜单栏出现两个图标；插件会改名保留，不会直接删除。" : "An older Dream Skin SwiftBar plugin was found. Disabling it prevents two menu-bar icons; the plugin will be renamed and kept, not deleted."
+    case .legacyDisable: return chinese ? "停用旧插件" : "Disable old plugin"
+    case .legacyDisabledTitle: return chinese ? "旧菜单已停用" : "Old menu disabled"
+    case .legacyDisabledMessage: return chinese ? "SwiftBar 插件已安全改名保留。" : "The SwiftBar plugin was safely renamed and kept."
+    case .legacyPartialTitle: return chinese ? "部分旧插件未能停用" : "Some old plugins could not be disabled"
+    case .ok: return chinese ? "好" : "OK"
+    }
+  }
+
+  public func format(_ key: Key, _ arguments: CVarArg...) -> String {
+    String(format: text(key), arguments: arguments)
+  }
+
+  public func statusTitle(session: String, operation: String) -> String {
+    if operation == "applying" { return text(.statusApplying) }
+    if operation == "pausing" { return text(.statusPausing) }
+    switch session {
+    case "active": return operation == "failed" ? text(.statusOnFailed) : text(.statusOn)
+    case "off", "paused": return operation == "failed" ? text(.statusOffFailed) : text(.statusOff)
+    default: return text(.statusUnknown)
+    }
+  }
+
+  public func operationFailed(_ operation: String) -> String {
+    resolvedLanguage == .chinese ? "\(operation)失败" : "\(operation) failed"
+  }
+}

--- a/macos/menubar-app/Tests/DreamSkinCoreTests/CoreTests.swift
+++ b/macos/menubar-app/Tests/DreamSkinCoreTests/CoreTests.swift
@@ -2,6 +2,45 @@ import XCTest
 @testable import DreamSkinCore
 
 final class CoreTests: XCTestCase {
+  func testLanguageSelectionResolvesSystemAndPersistsOverrides() throws {
+    XCTAssertEqual(
+      DreamSkinLanguage.system.resolved(preferredLanguages: ["zh-Hans-CN"]),
+      .chinese
+    )
+    XCTAssertEqual(
+      DreamSkinLanguage.system.resolved(preferredLanguages: ["en-HK", "zh-Hans"]),
+      .english
+    )
+    XCTAssertEqual(
+      DreamSkinLanguage.system.resolved(preferredLanguages: ["fr-FR"]),
+      .english
+    )
+
+    let suiteName = "DreamSkinCoreTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    XCTAssertEqual(DreamSkinLanguage.stored(defaults: defaults), .system)
+    defaults.set(DreamSkinLanguage.chinese.rawValue, forKey: DreamSkinLanguage.defaultsKey)
+    XCTAssertEqual(DreamSkinLanguage.stored(defaults: defaults), .chinese)
+    defaults.set("unsupported", forKey: DreamSkinLanguage.defaultsKey)
+    XCTAssertEqual(DreamSkinLanguage.stored(defaults: defaults), .system)
+  }
+
+  func testLocalizedCopyKeepsStateSemanticsStable() {
+    let english = DreamSkinCopy(language: .english)
+    let chinese = DreamSkinCopy(language: .chinese)
+
+    XCTAssertEqual(english.text(.apply), "Apply skin")
+    XCTAssertEqual(chinese.text(.apply), "应用皮肤")
+    XCTAssertEqual(english.statusTitle(session: "active", operation: ""), "Skin ON")
+    XCTAssertEqual(chinese.statusTitle(session: "active", operation: "failed"), "Skin ON · 操作失败")
+    XCTAssertEqual(english.statusTitle(session: "paused", operation: "pausing"), "Skin pausing")
+    XCTAssertEqual(english.format(.selectedThemePending, "Paper"), "Selected: Paper (pending apply)")
+    XCTAssertEqual(chinese.format(.selectedThemePending, "纸面"), "已选主题：纸面（待应用）")
+    XCTAssertEqual(english.operationFailed("Apply skin"), "Apply skin failed")
+    XCTAssertEqual(chinese.operationFailed("应用皮肤"), "应用皮肤失败")
+  }
+
   func testSemanticVersionParsingAndComparison() throws {
     XCTAssertEqual(SemanticVersion("v1.3")?.description, "1.3.0")
     XCTAssertEqual(SemanticVersion(" 2.0.1\n")?.description, "2.0.1")

--- a/macos/scripts/apply-from-menubar-macos.sh
+++ b/macos/scripts/apply-from-menubar-macos.sh
@@ -6,6 +6,7 @@ set +e
 export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:${PATH:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+. "$SCRIPT_DIR/localization-macos.sh"
 STATE_ROOT="${HOME}/Library/Application Support/CodexDreamSkinStudio"
 LOG_OUT="${STATE_ROOT}/menubar-apply.log"
 
@@ -36,21 +37,23 @@ APPLESCRIPT
 
 confirm() {
   local message="$1"
-  local ok_label="${2:-继续}"
-  /usr/bin/osascript - "$message" "$ok_label" >/dev/null 2>&1 <<'APPLESCRIPT'
+  local ok_label="${2:-$(dreamskin_text continue)}"
+  local cancel_label="$(dreamskin_text cancel)"
+  /usr/bin/osascript - "$message" "$ok_label" "$cancel_label" >/dev/null 2>&1 <<'APPLESCRIPT'
 on run argv
   set promptText to item 1 of argv
   set okLabel to item 2 of argv
-  display dialog promptText buttons {"取消", okLabel} default button okLabel with title "ChatGPT Dream Skin"
+  set cancelLabel to item 3 of argv
+  display dialog promptText buttons {cancelLabel, okLabel} default button okLabel cancel button cancelLabel with title "ChatGPT Dream Skin"
 end run
 APPLESCRIPT
 }
 
-progress "已收到点击…"
+progress "$(dreamskin_text click_received)"
 
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/common-macos.sh" >>"$LOG_OUT" 2>&1 || {
-  alert "无法加载引擎脚本"
+  alert "$(dreamskin_text engine_script_missing)"
   exit 1
 }
 # common-macos.sh enables errexit for engine entry points. This wrapper needs
@@ -71,64 +74,89 @@ if [ -x "$SCRIPT_DIR/status-dream-skin-macos.sh" ]; then
     esac
   done < <("$SCRIPT_DIR/status-dream-skin-macos.sh" 2>/dev/null)
 fi
-[ -n "$THEME_NAME" ] || THEME_NAME="已选主题"
+[ -n "$THEME_NAME" ] || THEME_NAME="$(dreamskin_text selected_theme)"
 
-if [ "$CHEAP_RUNNING" = "false" ]; then
-  PROMPT="打开 ChatGPT 并应用「${THEME_NAME}」？
+if [ "$(dreamskin_language)" = "zh" ]; then
+  if [ "$CHEAP_RUNNING" = "false" ]; then
+    PROMPT="打开 ChatGPT 并应用「${THEME_NAME}」？
 首次启动通常需要 10–30 秒。"
-  OK_LABEL="打开并应用"
-elif [ "$SESSION" = "active" ]; then
-  PROMPT="重新应用「${THEME_NAME}」？
+  elif [ "$SESSION" = "active" ]; then
+    PROMPT="重新应用「${THEME_NAME}」？
 ChatGPT 无需重启，适合界面未更新时使用。"
-  OK_LABEL="重新应用"
-elif [ "$SESSION" = "stale" ] || [ "$SESSION" = "unknown" ]; then
-  PROMPT="修复连接并应用「${THEME_NAME}」？
+  elif [ "$SESSION" = "stale" ] || [ "$SESSION" = "unknown" ]; then
+    PROMPT="修复连接并应用「${THEME_NAME}」？
 ChatGPT 无需重启，通常几秒完成。"
-  OK_LABEL="修复并应用"
+  else
+    PROMPT="将「${THEME_NAME}」应用到 ChatGPT？
+ChatGPT 无需重启，通常几秒完成。"
+  fi
 else
-  PROMPT="将「${THEME_NAME}」应用到 ChatGPT？
-ChatGPT 无需重启，通常几秒完成。"
-  OK_LABEL="应用"
+  if [ "$CHEAP_RUNNING" = "false" ]; then
+    PROMPT="Open ChatGPT and apply “${THEME_NAME}”?
+The first launch usually takes 10–30 seconds."
+  elif [ "$SESSION" = "active" ]; then
+    PROMPT="Reapply “${THEME_NAME}”?
+ChatGPT does not need to restart. Use this when the interface did not update."
+  elif [ "$SESSION" = "stale" ] || [ "$SESSION" = "unknown" ]; then
+    PROMPT="Repair the connection and apply “${THEME_NAME}”?
+ChatGPT does not need to restart; this usually takes a few seconds."
+  else
+    PROMPT="Apply “${THEME_NAME}” to ChatGPT?
+ChatGPT does not need to restart; this usually takes a few seconds."
+  fi
+fi
+if [ "$CHEAP_RUNNING" = "false" ]; then
+  OK_LABEL="$(dreamskin_text open_and_apply)"
+elif [ "$SESSION" = "active" ]; then
+  OK_LABEL="$(dreamskin_text reapply)"
+elif [ "$SESSION" = "stale" ] || [ "$SESSION" = "unknown" ]; then
+  OK_LABEL="$(dreamskin_text repair_and_apply)"
+else
+  OK_LABEL="$(dreamskin_text apply)"
 fi
 
 if ! confirm "$PROMPT" "$OK_LABEL"; then
   OPERATION_TOKEN="$(new_operation_token)"
-  if write_operation_state cancelled "操作已取消，原皮肤保持不变" \
+  if write_operation_state cancelled "$(dreamskin_text cancelled_unchanged)" \
     "$OPERATION_TOKEN" idle; then
     (
       ensure_node_runtime
-      finish_client_operation "$PORT" cancelled "操作已取消，原皮肤保持不变" \
+      finish_client_operation "$PORT" cancelled "$(dreamskin_text cancelled_unchanged)" \
         "$OPERATION_TOKEN" 1500 >/dev/null 2>&1
     ) >/dev/null 2>&1 || true
   fi
-  progress "已取消，原皮肤保持不变"
+  progress "$(dreamskin_text cancelled_progress)"
   exit 0
 fi
 
 if [ "$CHEAP_RUNNING" = "false" ]; then
-  notify_progress "正在打开 ChatGPT 并应用皮肤…"
+  notify_progress "$(dreamskin_text opening_and_applying)"
 fi
 
-progress "检查 ChatGPT…"
+progress "$(dreamskin_text checking_chatgpt)"
 ensure_state_root
-progress "尝试热重载皮肤…"
+progress "$(dreamskin_text hot_reload)"
 
 if hot_reapply_theme "$PORT" 8000; then
-  progress "完成：皮肤已应用"
+  progress "$(dreamskin_text apply_complete)"
   exit 0
 fi
 
-progress "启动/连接调试口…"
+progress "$(dreamskin_text connecting_debug)"
 
 "$SCRIPT_DIR/start-dream-skin-macos.sh" --restart-existing >>"$LOG_OUT" 2>&1
 code=$?
 
 if [ "$code" -eq 0 ]; then
-  progress "完成：皮肤已应用"
+  progress "$(dreamskin_text apply_complete)"
   exit 0
 fi
 
 detail="$(/usr/bin/tail -n 5 "$LOG_OUT" 2>/dev/null | /usr/bin/tr '\n' ' ' | /usr/bin/cut -c1-350)"
-alert "应用失败（${code}）。$detail"
-progress "应用失败"
+if [ "$(dreamskin_language)" = "zh" ]; then
+  alert "应用失败（${code}）。$detail"
+else
+  alert "Apply failed (exit ${code}). $detail"
+fi
+progress "$(dreamskin_text apply_failed)"
 exit "$code"

--- a/macos/scripts/build-dmg.sh
+++ b/macos/scripts/build-dmg.sh
@@ -81,7 +81,7 @@ MOUNTED_ENGINE="$MOUNTED_APP/Contents/Resources/engine"
 [ -f "$MOUNTED_ENGINE/assets/selectors.json" ] \
   || { printf 'Mounted app is missing the selector contract.\n' >&2; exit 1; }
 for runtime_script in apply-community-theme-macos.sh snapshot-active-theme-macos.sh \
-  theme-switch-lock-macos.sh; do
+  theme-switch-lock-macos.sh localization-macos.sh; do
   [ -x "$MOUNTED_ENGINE/scripts/$runtime_script" ] \
     || { printf 'Mounted runtime script is missing or not executable: %s\n' "$runtime_script" >&2; exit 1; }
 done

--- a/macos/scripts/build-menubar-app.sh
+++ b/macos/scripts/build-menubar-app.sh
@@ -98,6 +98,7 @@ RUNTIME_SCRIPTS=(
   injector.mjs
   install-dream-skin-macos.sh
   load-image-theme-macos.sh
+  localization-macos.sh
   pause-dream-skin-macos.sh
   publish-theme-import.mjs
   recover-theme-imports-macos.sh

--- a/macos/scripts/check-update-macos.sh
+++ b/macos/scripts/check-update-macos.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+. "$ROOT/scripts/localization-macos.sh"
 VERSION_PATH="$ROOT/VERSION"
 REPOSITORY="Fei-Away/Codex-Dream-Skin"
 RELEASE_URL="https://github.com/$REPOSITORY/releases/latest"
@@ -89,20 +90,39 @@ fi
 
 if [ "$INTERACTIVE" = "true" ]; then
   if [ "$UPDATE_AVAILABLE" = "true" ]; then
-    if /usr/bin/osascript - "v$LATEST_VERSION" "v$CURRENT_VERSION" <<'APPLESCRIPT' >/dev/null
+    if [ "$(dreamskin_language)" = "zh" ]; then
+      UPDATE_MESSAGE="发现新版本 v${LATEST_VERSION}
+
+当前版本为 v${CURRENT_VERSION}。"
+      DOWNLOAD_LABEL="前往下载"
+      LATER_LABEL="稍后"
+    else
+      UPDATE_MESSAGE="New version v${LATEST_VERSION} is available.
+
+You are running v${CURRENT_VERSION}."
+      DOWNLOAD_LABEL="Download"
+      LATER_LABEL="Later"
+    fi
+    if /usr/bin/osascript - "$UPDATE_MESSAGE" "$LATER_LABEL" "$DOWNLOAD_LABEL" <<'APPLESCRIPT' >/dev/null
 on run argv
-  display dialog "发现新版本 " & (item 1 of argv) & return & return & \
-    "当前版本为 " & (item 2 of argv) & "。" buttons {"稍后", "前往下载"} \
-    default button "前往下载" with title "Codex Dream Skin"
+  set promptText to item 1 of argv
+  set laterLabel to item 2 of argv
+  set downloadLabel to item 3 of argv
+  display dialog promptText buttons {laterLabel, downloadLabel} default button downloadLabel cancel button laterLabel with title "Codex Dream Skin"
 end run
 APPLESCRIPT
     then
       /usr/bin/open "$RELEASE_URL"
     fi
   else
-    /usr/bin/osascript - "v$CURRENT_VERSION" <<'APPLESCRIPT' >/dev/null
+    if [ "$(dreamskin_language)" = "zh" ]; then
+      CURRENT_MESSAGE="当前已是最新版本 v${CURRENT_VERSION}"
+    else
+      CURRENT_MESSAGE="Codex Dream Skin v${CURRENT_VERSION} is up to date."
+    fi
+    /usr/bin/osascript - "$CURRENT_MESSAGE" "$(dreamskin_text ok 2>/dev/null || /usr/bin/printf OK)" <<'APPLESCRIPT' >/dev/null
 on run argv
-  display alert "Codex Dream Skin" message "当前已是最新版本 " & (item 1 of argv) buttons {"好"}
+  display alert "Codex Dream Skin" message (item 1 of argv) buttons {(item 2 of argv)}
 end run
 APPLESCRIPT
   fi

--- a/macos/scripts/common-macos.sh
+++ b/macos/scripts/common-macos.sh
@@ -10,6 +10,7 @@ if [ -z "${HOME:-}" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+. "$SCRIPT_DIR/localization-macos.sh"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 INJECTOR="$SCRIPT_DIR/injector.mjs"
 INSTALL_ROOT="$HOME/.codex/codex-dream-skin-studio"
@@ -793,7 +794,7 @@ hot_reapply_theme() {
   ensure_node_runtime || return 1
   verified_cdp_endpoint "$port" || return 1
   [ -n "$operation_token" ] || operation_token="$(new_operation_token)"
-  write_operation_state applying "正在应用已选主题" "$operation_token" || return 1
+  write_operation_state applying "$(dreamskin_text applying_selected_theme)" "$operation_token" || return 1
   operation_args=(--operation-token "$operation_token")
 
   injector_protocol="$(state_field injectorProtocol 2>/dev/null || true)"
@@ -812,7 +813,7 @@ hot_reapply_theme() {
   if [ -n "$inj_pid" ] && /bin/kill -0 "$inj_pid" 2>/dev/null \
     && [ "$injector_mode" != "control" ]; then
     mark_state_active || return 1
-    write_operation_state success "皮肤已应用" "$operation_token" || return 1
+    write_operation_state success "$(dreamskin_text skin_applied)" "$operation_token" || return 1
     return 0
   fi
   stop_recorded_injector 2>/dev/null || return 1
@@ -822,7 +823,7 @@ hot_reapply_theme() {
   codex_pid="$(codex_main_pids 2>/dev/null | /usr/bin/head -n 1)"
   [ -n "$started_at" ] || started_at="$(/bin/date)"
   write_state "$port" "$inj_pid" "$started_at" "${codex_pid:-0}" active
-  write_operation_state success "皮肤已应用" "$operation_token" || return 1
+  write_operation_state success "$(dreamskin_text skin_applied)" "$operation_token" || return 1
   return 0
 }
 

--- a/macos/scripts/customize-theme-macos.sh
+++ b/macos/scripts/customize-theme-macos.sh
@@ -36,7 +36,17 @@ if [ "$RESET_DEMO" = "true" ]; then
   "$NODE" "$SCRIPT_DIR/write-theme.mjs" reset-demo --output-dir "$THEME_DIR"
 else
   if [ -z "$IMAGE" ]; then
-    IMAGE="$(/usr/bin/osascript -e 'POSIX path of (choose file with prompt "选择一张主题图片（建议横向、宽度 2000px 以上）" of type {"public.image"})')" \
+    if [ "$(dreamskin_language)" = "zh" ]; then
+      IMAGE_PROMPT="选择一张主题图片（建议横向、宽度 2000px 以上）"
+    else
+      IMAGE_PROMPT="Choose a theme image (landscape, at least 2000 px wide recommended)"
+    fi
+    IMAGE="$(/usr/bin/osascript - "$IMAGE_PROMPT" <<'APPLESCRIPT'
+on run argv
+  POSIX path of (choose file with prompt (item 1 of argv) of type {"public.image"})
+end run
+APPLESCRIPT
+)" \
       || fail "Image selection was cancelled."
   fi
   [ -f "$IMAGE" ] || fail "Selected image does not exist: $IMAGE"
@@ -44,10 +54,33 @@ else
   [ "$SOURCE_BYTES" -le 52428800 ] || fail "Selected image is larger than 50 MB. Choose a smaller file."
 
   if [ -z "$THEME_NAME" ]; then
-    THEME_NAME="$(/usr/bin/osascript -e 'text returned of (display dialog "给这套主题起个名字" default answer "我的 Codex Dream Skin" buttons {"取消", "继续"} default button "继续")')" \
+    if [ "$(dreamskin_language)" = "zh" ]; then
+      NAME_PROMPT="给这套主题起个名字"
+      DEFAULT_NAME="我的 Codex Dream Skin"
+    else
+      NAME_PROMPT="Name this theme"
+      DEFAULT_NAME="My Codex Dream Skin"
+    fi
+    THEME_NAME="$(/usr/bin/osascript - "$NAME_PROMPT" "$DEFAULT_NAME" \
+      "$(dreamskin_text cancel)" "$(dreamskin_text continue)" <<'APPLESCRIPT'
+on run argv
+  set promptText to item 1 of argv
+  set defaultName to item 2 of argv
+  set cancelLabel to item 3 of argv
+  set continueLabel to item 4 of argv
+  text returned of (display dialog promptText default answer defaultName buttons {cancelLabel, continueLabel} default button continueLabel cancel button cancelLabel)
+end run
+APPLESCRIPT
+)" \
       || fail "Theme setup was cancelled."
   fi
-  if [ -z "$TAGLINE" ]; then TAGLINE="把喜欢的画面变成可交互的 Codex 工作台。"; fi
+  if [ -z "$TAGLINE" ]; then
+    if [ "$(dreamskin_language)" = "zh" ]; then
+      TAGLINE="把喜欢的画面变成可交互的 Codex 工作台。"
+    else
+      TAGLINE="Turn a favorite image into an interactive Codex workspace."
+    fi
+  fi
   if [ -z "$QUOTE" ]; then QUOTE="MAKE SOMETHING WONDERFUL"; fi
 
   /bin/mkdir -p "$THEME_DIR"

--- a/macos/scripts/load-image-theme-macos.sh
+++ b/macos/scripts/load-image-theme-macos.sh
@@ -64,7 +64,7 @@ if [ -z "$THEME_NAME" ]; then
   base="$(/usr/bin/basename "$IMAGE")"
   THEME_NAME="${base%.*}"
 fi
-[ -n "$THEME_NAME" ] || THEME_NAME="我的主题"
+[ -n "$THEME_NAME" ] || THEME_NAME="$(dreamskin_text default_theme_name)"
 
 theme_id="img-$(/bin/date '+%Y%m%d%H%M%S')-$$"
 
@@ -73,7 +73,7 @@ progress() {
   notify_user "$*"
 }
 
-progress "Loading image..."
+progress "$(dreamskin_text loading_image)"
 
 # Fast Node for write-theme (avoid full codesign when possible)
 ensure_node_runtime
@@ -136,7 +136,7 @@ if [ "$src_dir/$(/usr/bin/basename "$IMAGE")" != "$img_dir/$(/usr/bin/basename "
 fi
 
 if [ "$APPLY_NOW" != "true" ]; then
-  progress "Ready: ${THEME_NAME} (not applied)"
+  progress "$(dreamskin_text theme_ready_not_applied): ${THEME_NAME}"
   exit 0
 fi
 
@@ -146,17 +146,17 @@ if [ -f "$STATE_PATH" ]; then
   [ -n "${saved:-}" ] && PORT="$saved"
 fi
 
-progress "Hot reapply..."
+progress "$(dreamskin_text hot_reload)"
 if hot_reapply_theme "$PORT" 8000; then
-  progress "Done: ${THEME_NAME}"
+  progress "$(dreamskin_text skin_applied): ${THEME_NAME}"
   exit 0
 fi
 
-progress "CDP not ready, full start..."
+progress "$(dreamskin_text starting_chatgpt_for_apply)"
 if "$SCRIPT_DIR/start-dream-skin-macos.sh" --port "$PORT" --restart-existing; then
-  progress "Done: ${THEME_NAME}"
+  progress "$(dreamskin_text skin_applied): ${THEME_NAME}"
   exit 0
 fi
 
-alert_user "Image saved but inject failed. Click Apply Skin."
+alert_user "$(dreamskin_text image_saved_apply_failed)"
 exit 1

--- a/macos/scripts/localization-macos.sh
+++ b/macos/scripts/localization-macos.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# Shared user-facing language resolver for macOS runtime scripts. Callers may
+# set DREAMSKIN_LANG to zh-CN or en-US; otherwise the current macOS language is
+# used. Machine-readable output must never depend on these strings.
+
+dreamskin_language() {
+  if [ -n "${DREAMSKIN_RESOLVED_LANG:-}" ]; then
+    /usr/bin/printf '%s' "$DREAMSKIN_RESOLVED_LANG"
+    return 0
+  fi
+
+  local requested="${DREAMSKIN_LANG:-}"
+  local locale=""
+  case "$requested" in
+    zh|zh-*|zh_*|chinese) DREAMSKIN_RESOLVED_LANG="zh" ;;
+    en|en-*|en_*|english) DREAMSKIN_RESOLVED_LANG="en" ;;
+    *)
+      locale="${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}"
+      case "$locale" in
+        zh|zh-*|zh_*|Chinese*) DREAMSKIN_RESOLVED_LANG="zh" ;;
+        *)
+          if /usr/bin/defaults read -g AppleLanguages 2>/dev/null \
+            | /usr/bin/head -n 2 | /usr/bin/grep -Eiq '(^|[^A-Za-z])zh([-_]|[^A-Za-z]|$)'; then
+            DREAMSKIN_RESOLVED_LANG="zh"
+          else
+            DREAMSKIN_RESOLVED_LANG="en"
+          fi
+          ;;
+      esac
+      ;;
+  esac
+  /usr/bin/printf '%s' "$DREAMSKIN_RESOLVED_LANG"
+}
+
+dreamskin_text() {
+  local key="${1:-}"
+  local language=""
+  language="$(dreamskin_language)"
+  case "$language:$key" in
+    zh:operation_timeout) /usr/bin/printf '%s' '操作超时，请重试' ;;
+    en:operation_timeout) /usr/bin/printf '%s' 'Operation timed out. Try again.' ;;
+    zh:skin_applying_label) /usr/bin/printf '%s' 'Skin 应用中' ;;
+    en:skin_applying_label) /usr/bin/printf '%s' 'Skin applying' ;;
+    zh:skin_pausing_label) /usr/bin/printf '%s' 'Skin 暂停中' ;;
+    en:skin_pausing_label) /usr/bin/printf '%s' 'Skin pausing' ;;
+    zh:skin_unavailable) /usr/bin/printf '%s' 'Skin 异常' ;;
+    en:skin_unavailable) /usr/bin/printf '%s' 'Skin unavailable' ;;
+    zh:operation_failed_short) /usr/bin/printf '%s' '操作失败' ;;
+    en:operation_failed_short) /usr/bin/printf '%s' 'operation failed' ;;
+    zh:cancelled_short) /usr/bin/printf '%s' '已取消' ;;
+    en:cancelled_short) /usr/bin/printf '%s' 'cancelled' ;;
+    zh:applying_selected_theme) /usr/bin/printf '%s' '正在应用已选主题' ;;
+    en:applying_selected_theme) /usr/bin/printf '%s' 'Applying selected theme' ;;
+    zh:skin_applied) /usr/bin/printf '%s' '皮肤已应用' ;;
+    en:skin_applied) /usr/bin/printf '%s' 'Skin applied' ;;
+    zh:theme_switch_unconfirmed) /usr/bin/printf '%s' '主题切换未完成，应用结果未确认' ;;
+    en:theme_switch_unconfirmed) /usr/bin/printf '%s' 'Theme switch did not finish; the result is unconfirmed' ;;
+    zh:switching_theme) /usr/bin/printf '%s' '正在切换主题' ;;
+    en:switching_theme) /usr/bin/printf '%s' 'Switching theme' ;;
+    zh:apply_unconfirmed) /usr/bin/printf '%s' '应用失败，应用结果未确认' ;;
+    en:apply_unconfirmed) /usr/bin/printf '%s' 'Apply failed; the result is unconfirmed' ;;
+    zh:applying_skin) /usr/bin/printf '%s' '正在应用皮肤' ;;
+    en:applying_skin) /usr/bin/printf '%s' 'Applying skin' ;;
+    zh:cancelled_unchanged) /usr/bin/printf '%s' '操作已取消，原皮肤保持不变' ;;
+    en:cancelled_unchanged) /usr/bin/printf '%s' 'Operation cancelled; the previous skin is unchanged' ;;
+    zh:pause_failed) /usr/bin/printf '%s' '暂停失败，原状态可能未改变' ;;
+    en:pause_failed) /usr/bin/printf '%s' 'Pause failed; the previous state may be unchanged' ;;
+    zh:pause_failed_alert) /usr/bin/printf '%s' '暂停失败，请重新打开菜单查看状态。' ;;
+    en:pause_failed_alert) /usr/bin/printf '%s' 'Pause failed. Reopen the menu to check the current state.' ;;
+    zh:pausing_skin) /usr/bin/printf '%s' '正在暂停皮肤' ;;
+    en:pausing_skin) /usr/bin/printf '%s' 'Pausing skin' ;;
+    zh:skin_paused) /usr/bin/printf '%s' '皮肤已暂停' ;;
+    en:skin_paused) /usr/bin/printf '%s' 'Skin paused' ;;
+    zh:selected_theme) /usr/bin/printf '%s' '已选主题' ;;
+    en:selected_theme) /usr/bin/printf '%s' 'Selected theme' ;;
+    zh:continue) /usr/bin/printf '%s' '继续' ;;
+    en:continue) /usr/bin/printf '%s' 'Continue' ;;
+    zh:cancel) /usr/bin/printf '%s' '取消' ;;
+    en:cancel) /usr/bin/printf '%s' 'Cancel' ;;
+    zh:restart_prompt) /usr/bin/printf '%s' 'ChatGPT 需要重启一次才能启用皮肤。通常会在 10–30 秒内完成。' ;;
+    en:restart_prompt) /usr/bin/printf '%s' 'ChatGPT must restart once to enable the skin. This usually takes 10–30 seconds.' ;;
+    zh:restart_and_apply) /usr/bin/printf '%s' '重启并应用' ;;
+    en:restart_and_apply) /usr/bin/printf '%s' 'Restart and apply' ;;
+    zh:open_and_apply) /usr/bin/printf '%s' '打开并应用' ;;
+    en:open_and_apply) /usr/bin/printf '%s' 'Open and apply' ;;
+    zh:reapply) /usr/bin/printf '%s' '重新应用' ;;
+    en:reapply) /usr/bin/printf '%s' 'Reapply' ;;
+    zh:repair_and_apply) /usr/bin/printf '%s' '修复并应用' ;;
+    en:repair_and_apply) /usr/bin/printf '%s' 'Repair and apply' ;;
+    zh:apply) /usr/bin/printf '%s' '应用' ;;
+    en:apply) /usr/bin/printf '%s' 'Apply' ;;
+    zh:click_received) /usr/bin/printf '%s' '已收到点击…' ;;
+    en:click_received) /usr/bin/printf '%s' 'Request received…' ;;
+    zh:engine_script_missing) /usr/bin/printf '%s' '无法加载引擎脚本' ;;
+    en:engine_script_missing) /usr/bin/printf '%s' 'Could not load the engine script' ;;
+    zh:cancelled_progress) /usr/bin/printf '%s' '已取消，原皮肤保持不变' ;;
+    en:cancelled_progress) /usr/bin/printf '%s' 'Cancelled; the previous skin is unchanged' ;;
+    zh:opening_and_applying) /usr/bin/printf '%s' '正在打开 ChatGPT 并应用皮肤…' ;;
+    en:opening_and_applying) /usr/bin/printf '%s' 'Opening ChatGPT and applying the skin…' ;;
+    zh:checking_chatgpt) /usr/bin/printf '%s' '检查 ChatGPT…' ;;
+    en:checking_chatgpt) /usr/bin/printf '%s' 'Checking ChatGPT…' ;;
+    zh:hot_reload) /usr/bin/printf '%s' '尝试热重载皮肤…' ;;
+    en:hot_reload) /usr/bin/printf '%s' 'Trying a live skin reload…' ;;
+    zh:apply_complete) /usr/bin/printf '%s' '完成：皮肤已应用' ;;
+    en:apply_complete) /usr/bin/printf '%s' 'Complete: skin applied' ;;
+    zh:connecting_debug) /usr/bin/printf '%s' '启动/连接调试口…' ;;
+    en:connecting_debug) /usr/bin/printf '%s' 'Starting or connecting to the debug port…' ;;
+    zh:apply_failed) /usr/bin/printf '%s' '应用失败' ;;
+    en:apply_failed) /usr/bin/printf '%s' 'Apply failed' ;;
+    zh:default_theme_name) /usr/bin/printf '%s' '我的主题' ;;
+    en:default_theme_name) /usr/bin/printf '%s' 'My Theme' ;;
+    zh:loading_image) /usr/bin/printf '%s' '正在加载图片…' ;;
+    en:loading_image) /usr/bin/printf '%s' 'Loading image…' ;;
+    zh:theme_ready_not_applied) /usr/bin/printf '%s' '主题已就绪（未应用）' ;;
+    en:theme_ready_not_applied) /usr/bin/printf '%s' 'Theme ready (not applied)' ;;
+    zh:starting_chatgpt_for_apply) /usr/bin/printf '%s' '当前会话不可用，正在启动 ChatGPT 并应用主题…' ;;
+    en:starting_chatgpt_for_apply) /usr/bin/printf '%s' 'The current session is unavailable; starting ChatGPT and applying the theme…' ;;
+    zh:image_saved_apply_failed) /usr/bin/printf '%s' '图片已保存，但皮肤应用失败。请点“应用皮肤”重试。' ;;
+    en:image_saved_apply_failed) /usr/bin/printf '%s' 'The image was saved, but applying the skin failed. Click Apply Skin to retry.' ;;
+    zh:validating_theme_content) /usr/bin/printf '%s' '正在验证主题内容…' ;;
+    en:validating_theme_content) /usr/bin/printf '%s' 'Validating theme content…' ;;
+    zh:publishing_validated_theme) /usr/bin/printf '%s' '正在发布已验证的主题…' ;;
+    en:publishing_validated_theme) /usr/bin/printf '%s' 'Publishing the validated theme…' ;;
+    zh:applying_theme_to_chatgpt) /usr/bin/printf '%s' '正在将主题应用到 ChatGPT…' ;;
+    en:applying_theme_to_chatgpt) /usr/bin/printf '%s' 'Applying the theme to ChatGPT…' ;;
+    zh:verifying_rendered_theme) /usr/bin/printf '%s' '正在验证主题渲染…' ;;
+    en:verifying_rendered_theme) /usr/bin/printf '%s' 'Verifying the rendered theme…' ;;
+    zh:restarting_chatgpt_for_apply) /usr/bin/printf '%s' '正在重启 ChatGPT 并验证主题应用…' ;;
+    en:restarting_chatgpt_for_apply) /usr/bin/printf '%s' 'Restarting ChatGPT to apply and verify the theme…' ;;
+    zh:theme_switch_apply_failed) /usr/bin/printf '%s' '主题已切换，但皮肤应用失败。请点“应用皮肤”重试。' ;;
+    en:theme_switch_apply_failed) /usr/bin/printf '%s' 'The theme was switched, but applying the skin failed. Click Apply Skin to retry.' ;;
+    zh:ok) /usr/bin/printf '%s' '好' ;;
+    en:ok) /usr/bin/printf '%s' 'OK' ;;
+    *) return 1 ;;
+  esac
+}

--- a/macos/scripts/pause-dream-skin-macos.sh
+++ b/macos/scripts/pause-dream-skin-macos.sh
@@ -37,8 +37,8 @@ record_pause_error() {
       mark_state_stale 2>/dev/null || true
     fi
   fi
-  write_operation_state failed "暂停失败，原状态可能未改变" "${OPERATION_TOKEN:-}" 2>/dev/null || true
-  finish_client_operation "${PORT:-9341}" error "暂停失败，原状态可能未改变" \
+  write_operation_state failed "$(dreamskin_text pause_failed)" "${OPERATION_TOKEN:-}" 2>/dev/null || true
+  finish_client_operation "${PORT:-9341}" error "$(dreamskin_text pause_failed)" \
     "$OPERATION_TOKEN" 1500 >/dev/null 2>&1 || true
   if [ "$expect_recovery" = "true" ] \
     && wait_for_operation_ack "$OPERATION_TOKEN" "$recovery_pid" full 240 \
@@ -46,7 +46,7 @@ record_pause_error() {
       "$recovery_pid" "$recovery_start" "$recovery_node" "$recovery_path" "$recovery_port"; then
     mark_state_active 2>/dev/null || true
   fi
-  alert_user "暂停失败，请重新打开菜单查看状态。"
+  alert_user "$(dreamskin_text pause_failed_alert)"
 }
 trap 'record_pause_error "$?"' EXIT
 
@@ -92,7 +92,7 @@ done
 OPERATION_TOKEN="$(new_operation_token)"
 ensure_state_root
 /bin/rm -f "$OPERATION_ACK_PATH"
-write_operation_state pausing "正在暂停皮肤" "$OPERATION_TOKEN" \
+write_operation_state pausing "$(dreamskin_text pausing_skin)" "$OPERATION_TOKEN" \
   || fail "Could not publish the pause operation state."
 discover_codex_app
 require_signed_node_runtime
@@ -188,7 +188,7 @@ fi
   fs.writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
   fs.renameSync(temporary, file);
   ' "$STATE_PATH" "$PORT" "$THEME_DIR" "$PROJECT_ROOT" "$KEEP_CONTROL_WATCHER"
-write_operation_state paused "皮肤已暂停" "$OPERATION_TOKEN" \
+write_operation_state paused "$(dreamskin_text skin_paused)" "$OPERATION_TOKEN" \
   || fail "Could not publish the completed pause state."
 trap - EXIT
 

--- a/macos/scripts/start-dream-skin-macos.sh
+++ b/macos/scripts/start-dream-skin-macos.sh
@@ -25,8 +25,8 @@ record_start_exit() {
   fi
   printf '%s exit=%s line=%s\n' "$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')" "$code" "$line" \
     >> "$START_ERROR_LOG" 2>/dev/null || true
-  write_operation_state failed "应用失败，应用结果未确认" "${OPERATION_TOKEN:-}" 2>/dev/null || true
-  finish_client_operation "${PORT:-9341}" error "应用失败，应用结果未确认" \
+  write_operation_state failed "$(dreamskin_text apply_unconfirmed)" "${OPERATION_TOKEN:-}" 2>/dev/null || true
+  finish_client_operation "${PORT:-9341}" error "$(dreamskin_text apply_unconfirmed)" \
     "$OPERATION_TOKEN" 1500 >/dev/null 2>&1 || true
   printf 'ChatGPT Dream Skin: start failed at line %s (exit %s). See %s\n' "$line" "$code" "$START_ERROR_LOG" >&2
 }
@@ -52,7 +52,7 @@ case "$PORT" in ''|*[!0-9]*) fail "Invalid port: $PORT" ;; esac
 ensure_state_root
 if [ "$FOREGROUND_INJECTOR" != "true" ]; then
   OPERATION_TOKEN="$(new_operation_token)"
-  write_operation_state applying "正在应用皮肤" "$OPERATION_TOKEN" \
+  write_operation_state applying "$(dreamskin_text applying_skin)" "$OPERATION_TOKEN" \
     || fail "Could not publish the apply operation state."
 fi
 discover_codex_app
@@ -80,10 +80,19 @@ fi
 
 if codex_is_running && [ "$DEBUG_READY" = "false" ]; then
   if [ "$PROMPT_RESTART" = "true" ] && [ "$RESTART_EXISTING" = "false" ]; then
-    if ! /usr/bin/osascript -e 'display dialog "ChatGPT 需要重启一次才能启用皮肤。通常会在 10–30 秒内完成。" buttons {"取消", "重启并应用"} default button "重启并应用" with title "ChatGPT Dream Skin"' >/dev/null; then
-      write_operation_state cancelled "操作已取消，原皮肤保持不变" "$OPERATION_TOKEN" \
+    if ! /usr/bin/osascript - "$(dreamskin_text restart_prompt)" \
+      "$(dreamskin_text restart_and_apply)" "$(dreamskin_text cancel)" <<'APPLESCRIPT' >/dev/null
+on run argv
+  set promptText to item 1 of argv
+  set okLabel to item 2 of argv
+  set cancelLabel to item 3 of argv
+  display dialog promptText buttons {cancelLabel, okLabel} default button okLabel cancel button cancelLabel with title "ChatGPT Dream Skin"
+end run
+APPLESCRIPT
+    then
+      write_operation_state cancelled "$(dreamskin_text cancelled_unchanged)" "$OPERATION_TOKEN" \
         || fail "Could not publish the cancelled apply state."
-      finish_client_operation "$PORT" cancelled "操作已取消，原皮肤保持不变" \
+      finish_client_operation "$PORT" cancelled "$(dreamskin_text cancelled_unchanged)" \
         "$OPERATION_TOKEN" 1500 >/dev/null 2>&1 || true
       OPERATION_FINISHED="true"
       exit 0
@@ -180,7 +189,7 @@ fi
 cleanup_verify_output
 
 mark_state_active || fail "Could not commit the verified active skin state."
-write_operation_state success "皮肤已应用" "$OPERATION_TOKEN" \
+write_operation_state success "$(dreamskin_text skin_applied)" "$OPERATION_TOKEN" \
   || fail "Could not publish the completed apply state."
 OPERATION_FINISHED="true"
 printf 'ChatGPT Dream Skin %s is active on loopback port %s.\n' "$SKIN_VERSION" "$PORT"

--- a/macos/scripts/status-dream-skin-macos.sh
+++ b/macos/scripts/status-dream-skin-macos.sh
@@ -5,6 +5,9 @@
 set +e
 set -u
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+. "$SCRIPT_DIR/localization-macos.sh"
+
 SHORT="false"
 JSON="false"
 DEEP="false"
@@ -157,7 +160,7 @@ if [ -f "$OPERATION_STATE_PATH" ]; then
   elif { [ "$operation_status" = "applying" ] || [ "$operation_status" = "pausing" ]; } \
     && [ "$age" -ge 0 ] && [ "$age" -le $((ttl + 120)) ]; then
     OPERATION_STATUS="failed"
-    OPERATION_MESSAGE="操作超时，请重试"
+    OPERATION_MESSAGE="$(dreamskin_text operation_timeout)"
   fi
 fi
 
@@ -174,22 +177,22 @@ fi
 label="Skin"
 case "$SESSION" in
   active) label="Skin ON" ;;
-  applying) label="Skin 应用中" ;;
+  applying) label="$(dreamskin_text skin_applying_label)" ;;
   paused|off) label="Skin OFF" ;;
-  stale|unknown) label="Skin 异常" ;;
-  *) label="Skin 异常" ;;
+  stale|unknown) label="$(dreamskin_text skin_unavailable)" ;;
+  *) label="$(dreamskin_text skin_unavailable)" ;;
 esac
 case "$OPERATION_STATUS" in
-  applying) label="Skin 应用中" ;;
-  pausing) label="Skin 暂停中" ;;
+  applying) label="$(dreamskin_text skin_applying_label)" ;;
+  pausing) label="$(dreamskin_text skin_pausing_label)" ;;
   failed)
     case "$SESSION" in
-      active) label="Skin ON · 操作失败" ;;
-      paused|off) label="Skin OFF · 操作失败" ;;
-      *) label="Skin 异常 · 操作失败" ;;
+      active) label="Skin ON · $(dreamskin_text operation_failed_short)" ;;
+      paused|off) label="Skin OFF · $(dreamskin_text operation_failed_short)" ;;
+      *) label="$(dreamskin_text skin_unavailable) · $(dreamskin_text operation_failed_short)" ;;
     esac
     ;;
-  cancelled) label="$label · 已取消" ;;
+  cancelled) label="$label · $(dreamskin_text cancelled_short)" ;;
 esac
 
 if [ "$SHORT" = "true" ]; then

--- a/macos/scripts/switch-theme-macos.sh
+++ b/macos/scripts/switch-theme-macos.sh
@@ -19,8 +19,8 @@ finish_switch() {
   [ -z "${stage:-}" ] || /bin/rm -rf "$stage"
   release_theme_switch_lock
   if [ "$code" -ne 0 ] && [ -n "${OPERATION_TOKEN:-}" ]; then
-    write_operation_state failed "主题切换未完成，应用结果未确认" "$OPERATION_TOKEN" 2>/dev/null || true
-    finish_client_operation "${PORT:-9341}" error "主题切换未完成，应用结果未确认" \
+    write_operation_state failed "$(dreamskin_text theme_switch_unconfirmed)" "$OPERATION_TOKEN" 2>/dev/null || true
+    finish_client_operation "${PORT:-9341}" error "$(dreamskin_text theme_switch_unconfirmed)" \
       "$OPERATION_TOKEN" 1500 >/dev/null 2>&1 || true
   fi
 }
@@ -75,7 +75,7 @@ else
 fi
 if [ "$APPLY_NOW" = "true" ]; then
   OPERATION_TOKEN="$(new_operation_token)"
-  write_operation_state applying "正在切换主题" "$OPERATION_TOKEN" \
+  write_operation_state applying "$(dreamskin_text switching_theme)" "$OPERATION_TOKEN" \
     || fail "Could not publish the theme switch operation state."
 fi
 ensure_node_runtime
@@ -105,7 +105,7 @@ progress() {
   notify_user "$*"
 }
 
-progress "Validating theme content..."
+progress "$(dreamskin_text validating_theme_content)"
 
 stage="$(/usr/bin/mktemp -d "$STATE_ROOT/.theme-switch.XXXXXX")"
 /bin/mkdir -p "$THEME_DIR"
@@ -139,7 +139,7 @@ THEME_BYTES="$(/usr/bin/stat -f '%z' "$stage/$THEME_IMAGE")"
 SAFE_CSS_NAME=""
 [ ! -f "$stage/theme.css" ] || SAFE_CSS_NAME="theme.css"
 /bin/chmod 600 "$stage/"*
-progress "Publishing validated theme..."
+progress "$(dreamskin_text publishing_validated_theme)"
 for entry in "$stage/"*; do
   [ -f "$entry" ] || continue
   [ "$(/usr/bin/basename "$entry")" = "theme.json" ] && continue
@@ -165,26 +165,26 @@ THEME_NAME="$("$NODE" -e 'try{const t=JSON.parse(require("fs").readFileSync(proc
 [ -n "$THEME_NAME" ] || THEME_NAME="$THEME_ID"
 
 if [ "$APPLY_NOW" != "true" ]; then
-  progress "Ready: ${THEME_NAME} (not applied)"
+  progress "$(dreamskin_text theme_ready_not_applied): ${THEME_NAME}"
   exit 0
 fi
 
 # Hot path: CDP already open → seconds, not tens of seconds
-progress "Applying theme to ChatGPT..."
+progress "$(dreamskin_text applying_theme_to_chatgpt)"
 if hot_reapply_theme "$PORT" 8000 "$OPERATION_TOKEN"; then
-  progress "Verifying rendered theme..."
+  progress "$(dreamskin_text verifying_rendered_theme)"
   "$NODE" "$INJECTOR" --verify --port "$PORT" --theme-dir "$THEME_DIR" --timeout-ms 10000 >/dev/null \
     || fail "Theme injection completed but the visible renderer did not verify the exact active theme."
-  progress "Done: ${THEME_NAME}"
+  progress "$(dreamskin_text skin_applied): ${THEME_NAME}"
   exit 0
 fi
 
 # Cold path only when debug port is missing
-progress "Restarting ChatGPT for verified apply..."
+progress "$(dreamskin_text restarting_chatgpt_for_apply)"
 if "$SCRIPT_DIR/start-dream-skin-macos.sh" --port "$PORT" --restart-existing; then
-  progress "Done: ${THEME_NAME}"
+  progress "$(dreamskin_text skin_applied): ${THEME_NAME}"
   exit 0
 fi
 
-alert_user "Theme switched but inject failed. Click Apply Skin."
+alert_user "$(dreamskin_text theme_switch_apply_failed)"
 exit 1

--- a/macos/tests/localization-contract.test.mjs
+++ b/macos/tests/localization-contract.test.mjs
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const helper = readFileSync(join(root, "scripts", "localization-macos.sh"), "utf8");
+const status = readFileSync(join(root, "scripts", "status-dream-skin-macos.sh"), "utf8");
+const updateCheck = readFileSync(join(root, "scripts", "check-update-macos.sh"), "utf8");
+const applyFromMenubar = readFileSync(join(root, "scripts", "apply-from-menubar-macos.sh"), "utf8");
+const startScript = readFileSync(join(root, "scripts", "start-dream-skin-macos.sh"), "utf8");
+const customizeScript = readFileSync(join(root, "scripts", "customize-theme-macos.sh"), "utf8");
+const loadImageScript = readFileSync(join(root, "scripts", "load-image-theme-macos.sh"), "utf8");
+const switchThemeScript = readFileSync(join(root, "scripts", "switch-theme-macos.sh"), "utf8");
+const appDelegate = readFileSync(
+  join(root, "menubar-app", "Sources", "CodexDreamSkinMenuBar", "AppDelegate.swift"),
+  "utf8"
+);
+const scriptRunner = readFileSync(
+  join(root, "menubar-app", "Sources", "CodexDreamSkinMenuBar", "ScriptRunner.swift"),
+  "utf8"
+);
+const buildScript = readFileSync(join(root, "scripts", "build-menubar-app.sh"), "utf8");
+
+test("macOS shell catalogs keep matching English and Chinese keys", () => {
+  const matches = [...helper.matchAll(/\b(zh|en):([a-z][a-z0-9_]*)\)/g)];
+  const keys = { zh: new Set(), en: new Set() };
+  for (const [, language, key] of matches) keys[language].add(key);
+  assert.deepEqual([...keys.en].sort(), [...keys.zh].sort());
+  assert.ok(keys.en.size >= 35, "expected the primary script operation copy to be translated");
+  for (const required of [
+    "applying_skin",
+    "skin_applied",
+    "pausing_skin",
+    "skin_paused",
+    "restart_prompt",
+    "loading_image",
+    "validating_theme_content",
+    "theme_switch_apply_failed",
+    "cancel"
+  ]) {
+    assert.ok(keys.en.has(required), `missing shell localization key ${required}`);
+  }
+});
+
+test("macOS theme load and switch notifications use the localized catalog", () => {
+  for (const [name, source] of Object.entries({ loadImageScript, switchThemeScript })) {
+    assert.doesNotMatch(source, /^\s*(?:progress|alert_user)\s+"(?!\$\(dreamskin_text\b)/m,
+      `${name} still has a hard-coded user notification`);
+  }
+  assert.match(loadImageScript, /dreamskin_text loading_image/);
+  assert.match(loadImageScript, /dreamskin_text image_saved_apply_failed/);
+  assert.match(switchThemeScript, /dreamskin_text validating_theme_content/);
+  assert.match(switchThemeScript, /dreamskin_text theme_switch_apply_failed/);
+});
+
+test("macOS native language selection persists and reaches child scripts", () => {
+  assert.match(appDelegate, /DreamSkinLanguage\.stored\(\)/);
+  assert.match(appDelegate, /addLanguageMenu\(\)/);
+  assert.match(appDelegate, /UserDefaults\.standard\.set\(newValue\.rawValue/);
+  assert.match(scriptRunner, /import DreamSkinCore/);
+  assert.match(scriptRunner, /environment\["DREAMSKIN_LANG"\]\s*=\s*DreamSkinLanguage\.stored\(\)\.environmentValue/);
+  assert.match(buildScript, /\n\s*localization-macos\.sh\n/);
+});
+
+test("macOS localized status keeps the machine-readable JSON contract stable", () => {
+  assert.match(status, /\. "\$SCRIPT_DIR\/localization-macos\.sh"/);
+  assert.match(
+    status,
+    /\{"session":"%s","operation":"%s","operationMessage":"%s","port":%s,"injectorAlive":%s,"cdpOk":%s,"codexRunning":%s,"themeId":"%s","themeName":"%s","appliedThemeId":"%s","appliedThemeName":"%s"\}/
+  );
+  assert.doesNotMatch(status, /"(?:session|operation|port|themeId)"\s*:\s*"?\$\(dreamskin_text/);
+});
+
+test("macOS localized dialogs keep line breaks and explicit cancel semantics", () => {
+  assert.doesNotMatch(updateCheck, /UPDATE_MESSAGE=.*\\n/);
+  assert.match(updateCheck, /UPDATE_MESSAGE="发现新版本[^\n]*\n\n当前版本/);
+  assert.match(updateCheck, /UPDATE_MESSAGE="New version[^\n]*\n\nYou are running/);
+  assert.match(updateCheck, /default button downloadLabel cancel button laterLabel/);
+  assert.match(applyFromMenubar, /default button okLabel cancel button cancelLabel/);
+  assert.match(startScript, /default button okLabel cancel button cancelLabel/);
+  assert.match(customizeScript, /default button continueLabel cancel button cancelLabel/);
+
+  for (const [name, source] of Object.entries({
+    applyFromMenubar,
+    startScript,
+    updateCheck,
+    customizeScript
+  })) {
+    const blocks = [...source.matchAll(/<<'APPLESCRIPT'[^\n]*\n([\s\S]*?)\nAPPLESCRIPT/g)];
+    assert.ok(blocks.length > 0, `${name} has no AppleScript block to validate`);
+    for (const [, block] of blocks) {
+      assert.doesNotMatch(block, /\\\s*$/m, `${name} uses a shell continuation inside AppleScript`);
+    }
+  }
+});

--- a/macos/tests/run-tests.sh
+++ b/macos/tests/run-tests.sh
@@ -17,6 +17,19 @@ while IFS= read -r file; do "$NODE" --check "$file" >/dev/null; done < <(
 # the real failure behind a bogus "unbound variable" (#251).
 "$NODE" "$ROOT/tests/shell-braced-vars-before-cjk.test.mjs"
 
+ZH_COPY="$(DREAMSKIN_LANG=zh-CN /bin/bash -c '
+  . "$1/scripts/localization-macos.sh"
+  printf "%s|%s|%s" "$(dreamskin_language)" "$(dreamskin_text apply)" "$(dreamskin_text skin_applied)"
+' _ "$ROOT")"
+EN_COPY="$(DREAMSKIN_LANG=en-US /bin/bash -c '
+  . "$1/scripts/localization-macos.sh"
+  printf "%s|%s|%s" "$(dreamskin_language)" "$(dreamskin_text apply)" "$(dreamskin_text skin_applied)"
+' _ "$ROOT")"
+[ "$ZH_COPY" = 'zh|应用|皮肤已应用' ] \
+  || { printf 'Chinese runtime localization contract failed: %s\n' "$ZH_COPY" >&2; exit 1; }
+[ "$EN_COPY" = 'en|Apply|Skin applied' ] \
+  || { printf 'English runtime localization contract failed: %s\n' "$EN_COPY" >&2; exit 1; }
+
 if /usr/bin/grep -R -n -E 'dream-skin-skin|DREAM_SKIN_SKIN|1\.0\.0-rc2' \
   "$ROOT/scripts" "$ROOT/assets" >/dev/null; then
   printf 'Legacy release-candidate identifiers remain in runtime files.\n' >&2
@@ -77,7 +90,7 @@ fi
   "$ROOT/scripts/switch-theme-macos.sh"
 /usr/bin/grep -F -q 'CFBundleURLTypes.0.CFBundleURLSchemes.0' "$ROOT/scripts/build-dmg.sh"
 for required_runtime in apply-community-theme-macos.sh snapshot-active-theme-macos.sh \
-  theme-content-fingerprint.mjs theme-switch-lock-macos.sh; do
+  theme-content-fingerprint.mjs theme-switch-lock-macos.sh localization-macos.sh; do
   /usr/bin/grep -F -q "$required_runtime" "$ROOT/scripts/build-dmg.sh"
 done
 UPDATE_JSON="$({
@@ -776,13 +789,17 @@ if [ -z "$HOT_LINE" ] || [ -z "$CONFIRM_LINE" ] || [ -z "$START_LINE" ] ||
 fi
 MENU_SOURCE="$ROOT/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift"
 OPEN_CODEX_BODY="$(/usr/bin/sed -n '/@objc private func openCodex()/,/@objc private func openDreamSkinWebsite()/p' "$MENU_SOURCE")"
-/usr/bin/grep -F -q 'addActionItem("打开 ChatGPT", action: #selector(openCodex), enabled: !busy)' "$MENU_SOURCE"
-/usr/bin/grep -F -q 'showError(title: "未找到 ChatGPT", message: "请先安装并至少启动一次官方 ChatGPT / Codex 桌面应用。")' "$MENU_SOURCE"
+/usr/bin/grep -F -q 'addActionItem(copy.text(.openChatGPT), action: #selector(openCodex), enabled: !busy)' "$MENU_SOURCE"
+/usr/bin/grep -F -q 'showError(title: copy.text(.notFoundTitle), message: copy.text(.notFoundMessage))' "$MENU_SOURCE"
+/usr/bin/grep -F -q 'addLanguageMenu()' "$MENU_SOURCE"
+/usr/bin/grep -F -q 'DreamSkinLanguage.defaultsKey' "$MENU_SOURCE"
+/usr/bin/grep -F -q 'environment["DREAMSKIN_LANG"] = DreamSkinLanguage.stored().environmentValue' \
+  "$ROOT/menubar-app/Sources/CodexDreamSkinMenuBar/ScriptRunner.swift"
 /usr/bin/grep -F -q 'guard !engineNeedsInstall(),' "$MENU_SOURCE"
 /usr/bin/grep -F -q 'let script = installedScript(named: "start-dream-skin-macos.sh") else {' "$MENU_SOURCE"
 /usr/bin/grep -F -q 'NSWorkspace.shared.openApplication(at: appURL, configuration: configuration)' "$MENU_SOURCE"
 /usr/bin/grep -F -q 'ScriptRunner.run(script: script)' "$MENU_SOURCE"
-/usr/bin/grep -F -q 'title: "无法打开 ChatGPT",' "$MENU_SOURCE"
+/usr/bin/grep -F -q 'title: self.copy.text(.openFailedTitle),' "$MENU_SOURCE"
 if /usr/bin/grep -F -q 'applyTitle = "打开并应用皮肤"' "$MENU_SOURCE" ||
    /usr/bin/grep -F -q 'runInstalledScript(named: "apply-from-menubar-macos.sh", operation: "打开 ChatGPT")' "$MENU_SOURCE" ||
    /usr/bin/printf '%s\n' "$OPEN_CODEX_BODY" | /usr/bin/grep -F -q 'installBundledEngineIfNeeded(force:'; then

--- a/runtime/renderer-inject.js
+++ b/runtime/renderer-inject.js
@@ -173,9 +173,9 @@
     if (!foreground) return background;
     const alpha = clamp(foreground.alpha ?? 1, 0, 1);
     return {
-      r: foreground.r * alpha + background.r * (1 - alpha),
-      g: foreground.g * alpha + background.g * (1 - alpha),
-      b: foreground.b * alpha + background.b * (1 - alpha),
+      r: clamp(foreground.r, 0, 255) * alpha + background.r * (1 - alpha),
+      g: clamp(foreground.g, 0, 255) * alpha + background.g * (1 - alpha),
+      b: clamp(foreground.b, 0, 255) * alpha + background.b * (1 - alpha),
     };
   };
 

--- a/runtime/renderer-inject.js
+++ b/runtime/renderer-inject.js
@@ -168,10 +168,10 @@
     return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
   };
 
-  const compositeColor = (value, background) => {
+  const compositeColor = (value, background, alphaOverride = null) => {
     const foreground = parseRgb(value);
     if (!foreground) return background;
-    const alpha = clamp(foreground.alpha ?? 1, 0, 1);
+    const alpha = clamp(alphaOverride ?? foreground.alpha ?? 1, 0, 1);
     return {
       r: clamp(foreground.r, 0, 255) * alpha + background.r * (1 - alpha),
       g: clamp(foreground.g, 0, 255) * alpha + background.g * (1 - alpha),
@@ -179,16 +179,20 @@
     };
   };
 
-  const readableAccentInk = (accent, panel, background, shell) => {
-    let rendered = shell === "light"
-      ? { r: 250, g: 251, b: 251 }
-      : { r: 17, g: 19, b: 24 };
-    rendered = compositeColor(background, rendered);
-    rendered = compositeColor(panel, rendered);
-    rendered = compositeColor(accent, rendered);
-    const luminance = relativeLuminance(rendered);
-    const whiteContrast = 1.05 / (luminance + 0.05);
-    const blackContrast = (luminance + 0.05) / 0.05;
+  const readableAccentInk = (accent, panel) => {
+    // The send button sits on the composer surface, which renders panel RGB
+    // at 94% regardless of the panel color's declared alpha. Compare against
+    // both possible backdrop extremes so artwork cannot flip the decision.
+    const luminances = [0, 255].map((backdrop) => {
+      const surface = compositeColor(
+        panel,
+        { r: backdrop, g: backdrop, b: backdrop },
+        0.94,
+      );
+      return relativeLuminance(compositeColor(accent, surface));
+    });
+    const whiteContrast = Math.min(...luminances.map((value) => 1.05 / (value + 0.05)));
+    const blackContrast = Math.min(...luminances.map((value) => (value + 0.05) / 0.05));
     return whiteContrast >= blackContrast ? "rgb(255 255 255)" : "rgb(0 0 0)";
   };
 
@@ -320,8 +324,6 @@
       const accentInk = readableAccentInk(
         accent,
         variables["--ds-panel"],
-        variables["--ds-bg"],
-        shell,
       );
       if (accentInk) setStyleProperty(root, "--ds-on-accent", accentInk);
     }

--- a/runtime/renderer-inject.js
+++ b/runtime/renderer-inject.js
@@ -118,15 +118,31 @@
     if (!value || value === "transparent") return null;
     const hex = String(value).trim().match(/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i);
     if (hex) {
-      const rgbHex = hex[1].length <= 4
-        ? hex[1].slice(0, 3).split("").map((digit) => `${digit}${digit}`).join("")
-        : hex[1].slice(0, 6);
+      const digits = hex[1];
+      const rgbHex = digits.length <= 4
+        ? digits.slice(0, 3).split("").map((digit) => `${digit}${digit}`).join("")
+        : digits.slice(0, 6);
+      const alphaHex = digits.length === 4
+        ? `${digits[3]}${digits[3]}`
+        : digits.length === 8 ? digits.slice(6, 8) : "ff";
       const number = Number.parseInt(rgbHex, 16);
-      return { r: number >> 16, g: (number >> 8) & 255, b: number & 255 };
+      return {
+        r: number >> 16,
+        g: (number >> 8) & 255,
+        b: number & 255,
+        alpha: Number.parseInt(alphaHex, 16) / 255,
+      };
     }
-    const m = String(value).match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i);
+    const m = String(value).trim().match(
+      /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i,
+    );
     if (!m) return null;
-    return { r: Number(m[1]), g: Number(m[2]), b: Number(m[3]) };
+    return {
+      r: Number(m[1]),
+      g: Number(m[2]),
+      b: Number(m[3]),
+      alpha: m[4] === undefined ? 1 : Math.min(1, Math.max(0, Number(m[4]))),
+    };
   };
 
   const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
@@ -152,10 +168,25 @@
     return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
   };
 
-  const readableAccentInk = (accent) => {
-    const rgb = parseRgb(accent);
-    if (!rgb) return null;
-    const luminance = relativeLuminance(rgb);
+  const compositeColor = (value, background) => {
+    const foreground = parseRgb(value);
+    if (!foreground) return background;
+    const alpha = clamp(foreground.alpha ?? 1, 0, 1);
+    return {
+      r: foreground.r * alpha + background.r * (1 - alpha),
+      g: foreground.g * alpha + background.g * (1 - alpha),
+      b: foreground.b * alpha + background.b * (1 - alpha),
+    };
+  };
+
+  const readableAccentInk = (accent, panel, background, shell) => {
+    let rendered = shell === "light"
+      ? { r: 250, g: 251, b: 251 }
+      : { r: 17, g: 19, b: 24 };
+    rendered = compositeColor(background, rendered);
+    rendered = compositeColor(panel, rendered);
+    rendered = compositeColor(accent, rendered);
+    const luminance = relativeLuminance(rendered);
     const whiteContrast = 1.05 / (luminance + 0.05);
     const blackContrast = (luminance + 0.05) / 0.05;
     return whiteContrast >= blackContrast ? "rgb(255 255 255)" : "rgb(0 0 0)";
@@ -286,7 +317,12 @@
       if (typeof value === "string" && value) setStyleProperty(root, name, value);
     }
     if (explicit.has("accent")) {
-      const accentInk = readableAccentInk(accent);
+      const accentInk = readableAccentInk(
+        accent,
+        variables["--ds-panel"],
+        variables["--ds-bg"],
+        shell,
+      );
       if (accentInk) setStyleProperty(root, "--ds-on-accent", accentInk);
     }
     const publicColors = {

--- a/runtime/renderer-inject.js
+++ b/runtime/renderer-inject.js
@@ -22,7 +22,7 @@
     ? THEME.artMetadata : null;
   const ANALYSIS_CACHE_KEY = "__CODEX_DREAM_SKIN_ANALYSIS_CACHE__";
   const THEME_VARIABLES = [
-    "--ds-bg", "--ds-panel", "--ds-panel-2", "--ds-green", "--ds-lime",
+    "--ds-bg", "--ds-panel", "--ds-panel-2", "--ds-green", "--ds-lime", "--ds-on-accent",
     "--ds-cyan", "--ds-purple", "--ds-text", "--ds-muted", "--ds-line",
     "--ds-bg-rgb", "--ds-panel-rgb", "--ds-panel-2-rgb", "--ds-accent-rgb",
     "--ds-accent-alt-rgb", "--ds-secondary-rgb", "--ds-highlight-rgb",
@@ -141,6 +141,25 @@
   const rgbToHex = ({ r, g, b }) => `#${[r, g, b]
     .map((value) => clamp(Math.round(value), 0, 255).toString(16).padStart(2, "0"))
     .join("")}`;
+
+  const relativeLuminance = ({ r, g, b }) => {
+    const channels = [r, g, b].map((value) => {
+      const normalized = clamp(value, 0, 255) / 255;
+      return normalized <= 0.04045
+        ? normalized / 12.92
+        : ((normalized + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  };
+
+  const readableAccentInk = (accent) => {
+    const rgb = parseRgb(accent);
+    if (!rgb) return null;
+    const luminance = relativeLuminance(rgb);
+    const whiteContrast = 1.05 / (luminance + 0.05);
+    const blackContrast = (luminance + 0.05) / 0.05;
+    return whiteContrast >= blackContrast ? "rgb(255 255 255)" : "rgb(0 0 0)";
+  };
 
   const rgbToHsl = ({ r, g, b }) => {
     const values = [r, g, b].map((value) => value / 255);
@@ -265,6 +284,10 @@
 
     for (const [name, value] of Object.entries(variables)) {
       if (typeof value === "string" && value) setStyleProperty(root, name, value);
+    }
+    if (explicit.has("accent")) {
+      const accentInk = readableAccentInk(accent);
+      if (accentInk) setStyleProperty(root, "--ds-on-accent", accentInk);
     }
     const publicColors = {
       "--ds-theme-color-background": variables["--ds-bg"],

--- a/tools/renderer-runtime.test.mjs
+++ b/tools/renderer-runtime.test.mjs
@@ -553,11 +553,14 @@ export async function runRendererRuntimeTest(assetRoot) {
   }
 
   const contrastCases = [
-    { accent: "#ffffff", expectedInk: "rgb(0 0 0)" },
-    { accent: "#000000", expectedInk: "rgb(255 255 255)" },
+    { accent: "#ffffff", lightInk: "rgb(0 0 0)", darkInk: "rgb(0 0 0)" },
+    { accent: "#000000", lightInk: "rgb(255 255 255)", darkInk: "rgb(255 255 255)" },
+    { accent: "#fff0", lightInk: "rgb(0 0 0)", darkInk: "rgb(255 255 255)" },
+    { accent: "#00000000", lightInk: "rgb(0 0 0)", darkInk: "rgb(255 255 255)" },
+    { accent: "rgba(255, 255, 255, 0.05)", lightInk: "rgb(0 0 0)", darkInk: "rgb(255 255 255)" },
   ];
   for (const nativeAppearance of ["light", "dark"]) {
-    for (const { accent, expectedInk } of contrastCases) {
+    for (const { accent, lightInk, darkInk } of contrastCases) {
       const contrast = makeFixture({ nativeAppearance });
       vm.runInNewContext(contrast.payloadFor({
         appearance: "auto",
@@ -568,7 +571,7 @@ export async function runRendererRuntimeTest(assetRoot) {
       assert.equal(contrast.rootStyle.values.get("--ds-green"), accent);
       assert.equal(
         contrast.rootStyle.values.get("--ds-on-accent"),
-        expectedInk,
+        nativeAppearance === "light" ? lightInk : darkInk,
         `Explicit ${accent} must keep readable button text in the ${nativeAppearance} shell`,
       );
     }

--- a/tools/renderer-runtime.test.mjs
+++ b/tools/renderer-runtime.test.mjs
@@ -346,6 +346,11 @@ export async function runRendererRuntimeTest(assetRoot) {
   assert.match(css, /background-image:\s*var\(--ds-task-full-veil\),\s*var\(--dream-skin-art\)/);
   assert.match(
     css,
+    /(?:__DREAM_SELECTOR_COMPOSER_CHROME__|\.composer-surface-chrome)\s*\{[^}]*background:\s*rgb\(var\(--ds-panel-rgb\) \/ \.94\)/,
+    "Accent foreground contrast must model the composer panel's 94% RGB surface",
+  );
+  assert.match(
+    css,
     /:not\(:has\(main:is\(\.main-surface, \[data-app-shell-main-surface\], \[class\*=\"_MainContentSurface_\"\]\)\)\)[\s\S]{0,120}\[data-ds-part="sidebar"\]/,
     "Core CSS must style the validated generic sidebar when the exact shell selector is absent.",
   );
@@ -578,22 +583,24 @@ export async function runRendererRuntimeTest(assetRoot) {
     }
   }
 
-  for (const nativeAppearance of ["light", "dark"]) {
+  for (const { nativeAppearance, panel, expectedInk } of [
+    { nativeAppearance: "light", panel: "#0000", expectedInk: "rgb(255 255 255)" },
+    { nativeAppearance: "dark", panel: "#fff0", expectedInk: "rgb(0 0 0)" },
+  ]) {
     const transparentSurfaces = makeFixture({ nativeAppearance });
     vm.runInNewContext(transparentSurfaces.payloadFor({
       appearance: "auto",
       colorMode: "explicit",
-      explicitColorKeys: ["background", "panel", "accent"],
+      explicitColorKeys: ["panel", "accent"],
       colors: {
-        background: "rgba(255, 255, 255, 0)",
-        panel: "#0000",
+        panel,
         accent: "rgba(0, 0, 0, 0)",
       },
     }), transparentSurfaces.context);
     assert.equal(
       transparentSurfaces.rootStyle.values.get("--ds-on-accent"),
-      nativeAppearance === "light" ? "rgb(0 0 0)" : "rgb(255 255 255)",
-      `Transparent theme surfaces must fall back to the ${nativeAppearance} shell canvas`,
+      expectedInk,
+      `Transparent accent ink must model the ${panel} composer RGB surface`,
     );
   }
 

--- a/tools/renderer-runtime.test.mjs
+++ b/tools/renderer-runtime.test.mjs
@@ -558,6 +558,7 @@ export async function runRendererRuntimeTest(assetRoot) {
     { accent: "#fff0", lightInk: "rgb(0 0 0)", darkInk: "rgb(255 255 255)" },
     { accent: "#00000000", lightInk: "rgb(0 0 0)", darkInk: "rgb(255 255 255)" },
     { accent: "rgba(255, 255, 255, 0.05)", lightInk: "rgb(0 0 0)", darkInk: "rgb(255 255 255)" },
+    { accent: "rgba(999, 999, 999, 0.1)", lightInk: "rgb(0 0 0)", darkInk: "rgb(255 255 255)" },
   ];
   for (const nativeAppearance of ["light", "dark"]) {
     for (const { accent, lightInk, darkInk } of contrastCases) {
@@ -575,6 +576,25 @@ export async function runRendererRuntimeTest(assetRoot) {
         `Explicit ${accent} must keep readable button text in the ${nativeAppearance} shell`,
       );
     }
+  }
+
+  for (const nativeAppearance of ["light", "dark"]) {
+    const transparentSurfaces = makeFixture({ nativeAppearance });
+    vm.runInNewContext(transparentSurfaces.payloadFor({
+      appearance: "auto",
+      colorMode: "explicit",
+      explicitColorKeys: ["background", "panel", "accent"],
+      colors: {
+        background: "rgba(255, 255, 255, 0)",
+        panel: "#0000",
+        accent: "rgba(0, 0, 0, 0)",
+      },
+    }), transparentSurfaces.context);
+    assert.equal(
+      transparentSurfaces.rootStyle.values.get("--ds-on-accent"),
+      nativeAppearance === "light" ? "rgb(0 0 0)" : "rgb(255 255 255)",
+      `Transparent theme surfaces must fall back to the ${nativeAppearance} shell canvas`,
+    );
   }
 
   const adaptiveAccent = makeFixture({ nativeAppearance: "dark" });

--- a/tools/renderer-runtime.test.mjs
+++ b/tools/renderer-runtime.test.mjs
@@ -552,6 +552,39 @@ export async function runRendererRuntimeTest(assetRoot) {
       `${variable} must support official hex forms and clamp RGB channels`);
   }
 
+  const contrastCases = [
+    { accent: "#ffffff", expectedInk: "rgb(0 0 0)" },
+    { accent: "#000000", expectedInk: "rgb(255 255 255)" },
+  ];
+  for (const nativeAppearance of ["light", "dark"]) {
+    for (const { accent, expectedInk } of contrastCases) {
+      const contrast = makeFixture({ nativeAppearance });
+      vm.runInNewContext(contrast.payloadFor({
+        appearance: "auto",
+        colorMode: "explicit",
+        explicitColorKeys: ["accent"],
+        colors: { accent },
+      }), contrast.context);
+      assert.equal(contrast.rootStyle.values.get("--ds-green"), accent);
+      assert.equal(
+        contrast.rootStyle.values.get("--ds-on-accent"),
+        expectedInk,
+        `Explicit ${accent} must keep readable button text in the ${nativeAppearance} shell`,
+      );
+    }
+  }
+
+  const adaptiveAccent = makeFixture({ nativeAppearance: "dark" });
+  vm.runInNewContext(adaptiveAccent.payloadFor({
+    colorMode: "explicit",
+    explicitColorKeys: ["accent"],
+    colors: { accent: "#ffffff" },
+  }), adaptiveAccent.context);
+  assert.equal(adaptiveAccent.rootStyle.values.get("--ds-on-accent"), "rgb(0 0 0)");
+  vm.runInNewContext(adaptiveAccent.payloadFor(), adaptiveAccent.context);
+  assert.equal(adaptiveAccent.rootStyle.values.has("--ds-on-accent"), false,
+    "Reapplying an adaptive accent must restore the shell-specific CSS foreground default");
+
   rootObserver.callback([]);
   home.flushTimers(64);
   assert.equal(state.metrics.routePasses, 2, "Attribute safety pass must not be a route pass");

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### 修复
 
+- 修复 Windows PowerShell 5.1 在中文、日文等非 ASCII 临时目录下读取
+  bundled Node.js `process.execPath` 时受控制台代码页影响，导致安装器错误
+  报告「Node.js executable path could not be validated」的问题。路径探针现在
+  通过 ASCII Base64 传输原始 UTF-8 字节并严格解码，仍保留签名、版本和文件
+  存在性校验；无效探针不会回退到未经确认的候选路径（#337）。
+
 - Windows 路径穿越校验此前会把合法的、以 `.` 开头的主题文件名也当作可疑路径拒绝；现在能正确区分它们与真正的 `..` 路径穿越（#296）。
 - Windows 运行时加载主题前强制校验 `schemaVersion` 必须是数字 `1`，拒绝缺失或未来版本的 schema（#299）。
 - 主题包 manifest 时间戳校验拒绝不合法的 RFC 3339 值（#297），双平台共享。

--- a/windows/assets/renderer-inject.js
+++ b/windows/assets/renderer-inject.js
@@ -173,9 +173,9 @@
     if (!foreground) return background;
     const alpha = clamp(foreground.alpha ?? 1, 0, 1);
     return {
-      r: foreground.r * alpha + background.r * (1 - alpha),
-      g: foreground.g * alpha + background.g * (1 - alpha),
-      b: foreground.b * alpha + background.b * (1 - alpha),
+      r: clamp(foreground.r, 0, 255) * alpha + background.r * (1 - alpha),
+      g: clamp(foreground.g, 0, 255) * alpha + background.g * (1 - alpha),
+      b: clamp(foreground.b, 0, 255) * alpha + background.b * (1 - alpha),
     };
   };
 

--- a/windows/assets/renderer-inject.js
+++ b/windows/assets/renderer-inject.js
@@ -168,10 +168,10 @@
     return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
   };
 
-  const compositeColor = (value, background) => {
+  const compositeColor = (value, background, alphaOverride = null) => {
     const foreground = parseRgb(value);
     if (!foreground) return background;
-    const alpha = clamp(foreground.alpha ?? 1, 0, 1);
+    const alpha = clamp(alphaOverride ?? foreground.alpha ?? 1, 0, 1);
     return {
       r: clamp(foreground.r, 0, 255) * alpha + background.r * (1 - alpha),
       g: clamp(foreground.g, 0, 255) * alpha + background.g * (1 - alpha),
@@ -179,16 +179,20 @@
     };
   };
 
-  const readableAccentInk = (accent, panel, background, shell) => {
-    let rendered = shell === "light"
-      ? { r: 250, g: 251, b: 251 }
-      : { r: 17, g: 19, b: 24 };
-    rendered = compositeColor(background, rendered);
-    rendered = compositeColor(panel, rendered);
-    rendered = compositeColor(accent, rendered);
-    const luminance = relativeLuminance(rendered);
-    const whiteContrast = 1.05 / (luminance + 0.05);
-    const blackContrast = (luminance + 0.05) / 0.05;
+  const readableAccentInk = (accent, panel) => {
+    // The send button sits on the composer surface, which renders panel RGB
+    // at 94% regardless of the panel color's declared alpha. Compare against
+    // both possible backdrop extremes so artwork cannot flip the decision.
+    const luminances = [0, 255].map((backdrop) => {
+      const surface = compositeColor(
+        panel,
+        { r: backdrop, g: backdrop, b: backdrop },
+        0.94,
+      );
+      return relativeLuminance(compositeColor(accent, surface));
+    });
+    const whiteContrast = Math.min(...luminances.map((value) => 1.05 / (value + 0.05)));
+    const blackContrast = Math.min(...luminances.map((value) => (value + 0.05) / 0.05));
     return whiteContrast >= blackContrast ? "rgb(255 255 255)" : "rgb(0 0 0)";
   };
 
@@ -320,8 +324,6 @@
       const accentInk = readableAccentInk(
         accent,
         variables["--ds-panel"],
-        variables["--ds-bg"],
-        shell,
       );
       if (accentInk) setStyleProperty(root, "--ds-on-accent", accentInk);
     }

--- a/windows/assets/renderer-inject.js
+++ b/windows/assets/renderer-inject.js
@@ -118,15 +118,31 @@
     if (!value || value === "transparent") return null;
     const hex = String(value).trim().match(/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i);
     if (hex) {
-      const rgbHex = hex[1].length <= 4
-        ? hex[1].slice(0, 3).split("").map((digit) => `${digit}${digit}`).join("")
-        : hex[1].slice(0, 6);
+      const digits = hex[1];
+      const rgbHex = digits.length <= 4
+        ? digits.slice(0, 3).split("").map((digit) => `${digit}${digit}`).join("")
+        : digits.slice(0, 6);
+      const alphaHex = digits.length === 4
+        ? `${digits[3]}${digits[3]}`
+        : digits.length === 8 ? digits.slice(6, 8) : "ff";
       const number = Number.parseInt(rgbHex, 16);
-      return { r: number >> 16, g: (number >> 8) & 255, b: number & 255 };
+      return {
+        r: number >> 16,
+        g: (number >> 8) & 255,
+        b: number & 255,
+        alpha: Number.parseInt(alphaHex, 16) / 255,
+      };
     }
-    const m = String(value).match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i);
+    const m = String(value).trim().match(
+      /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i,
+    );
     if (!m) return null;
-    return { r: Number(m[1]), g: Number(m[2]), b: Number(m[3]) };
+    return {
+      r: Number(m[1]),
+      g: Number(m[2]),
+      b: Number(m[3]),
+      alpha: m[4] === undefined ? 1 : Math.min(1, Math.max(0, Number(m[4]))),
+    };
   };
 
   const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
@@ -152,10 +168,25 @@
     return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
   };
 
-  const readableAccentInk = (accent) => {
-    const rgb = parseRgb(accent);
-    if (!rgb) return null;
-    const luminance = relativeLuminance(rgb);
+  const compositeColor = (value, background) => {
+    const foreground = parseRgb(value);
+    if (!foreground) return background;
+    const alpha = clamp(foreground.alpha ?? 1, 0, 1);
+    return {
+      r: foreground.r * alpha + background.r * (1 - alpha),
+      g: foreground.g * alpha + background.g * (1 - alpha),
+      b: foreground.b * alpha + background.b * (1 - alpha),
+    };
+  };
+
+  const readableAccentInk = (accent, panel, background, shell) => {
+    let rendered = shell === "light"
+      ? { r: 250, g: 251, b: 251 }
+      : { r: 17, g: 19, b: 24 };
+    rendered = compositeColor(background, rendered);
+    rendered = compositeColor(panel, rendered);
+    rendered = compositeColor(accent, rendered);
+    const luminance = relativeLuminance(rendered);
     const whiteContrast = 1.05 / (luminance + 0.05);
     const blackContrast = (luminance + 0.05) / 0.05;
     return whiteContrast >= blackContrast ? "rgb(255 255 255)" : "rgb(0 0 0)";
@@ -286,7 +317,12 @@
       if (typeof value === "string" && value) setStyleProperty(root, name, value);
     }
     if (explicit.has("accent")) {
-      const accentInk = readableAccentInk(accent);
+      const accentInk = readableAccentInk(
+        accent,
+        variables["--ds-panel"],
+        variables["--ds-bg"],
+        shell,
+      );
       if (accentInk) setStyleProperty(root, "--ds-on-accent", accentInk);
     }
     const publicColors = {

--- a/windows/assets/renderer-inject.js
+++ b/windows/assets/renderer-inject.js
@@ -22,7 +22,7 @@
     ? THEME.artMetadata : null;
   const ANALYSIS_CACHE_KEY = "__CODEX_DREAM_SKIN_ANALYSIS_CACHE__";
   const THEME_VARIABLES = [
-    "--ds-bg", "--ds-panel", "--ds-panel-2", "--ds-green", "--ds-lime",
+    "--ds-bg", "--ds-panel", "--ds-panel-2", "--ds-green", "--ds-lime", "--ds-on-accent",
     "--ds-cyan", "--ds-purple", "--ds-text", "--ds-muted", "--ds-line",
     "--ds-bg-rgb", "--ds-panel-rgb", "--ds-panel-2-rgb", "--ds-accent-rgb",
     "--ds-accent-alt-rgb", "--ds-secondary-rgb", "--ds-highlight-rgb",
@@ -141,6 +141,25 @@
   const rgbToHex = ({ r, g, b }) => `#${[r, g, b]
     .map((value) => clamp(Math.round(value), 0, 255).toString(16).padStart(2, "0"))
     .join("")}`;
+
+  const relativeLuminance = ({ r, g, b }) => {
+    const channels = [r, g, b].map((value) => {
+      const normalized = clamp(value, 0, 255) / 255;
+      return normalized <= 0.04045
+        ? normalized / 12.92
+        : ((normalized + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  };
+
+  const readableAccentInk = (accent) => {
+    const rgb = parseRgb(accent);
+    if (!rgb) return null;
+    const luminance = relativeLuminance(rgb);
+    const whiteContrast = 1.05 / (luminance + 0.05);
+    const blackContrast = (luminance + 0.05) / 0.05;
+    return whiteContrast >= blackContrast ? "rgb(255 255 255)" : "rgb(0 0 0)";
+  };
 
   const rgbToHsl = ({ r, g, b }) => {
     const values = [r, g, b].map((value) => value / 255);
@@ -265,6 +284,10 @@
 
     for (const [name, value] of Object.entries(variables)) {
       if (typeof value === "string" && value) setStyleProperty(root, name, value);
+    }
+    if (explicit.has("accent")) {
+      const accentInk = readableAccentInk(accent);
+      if (accentInk) setStyleProperty(root, "--ds-on-accent", accentInk);
     }
     const publicColors = {
       "--ds-theme-color-background": variables["--ds-bg"],

--- a/windows/installer/build-release.ps1
+++ b/windows/installer/build-release.ps1
@@ -407,6 +407,7 @@ try {
     'scripts\image-metadata.mjs',
     'scripts\injector.mjs',
     'scripts\install-dream-skin.ps1',
+    'scripts\localization-windows.ps1',
     'scripts\restore-dream-skin.ps1',
     'scripts\start-dream-skin.ps1',
     'scripts\theme-windows.ps1',

--- a/windows/installer/setup-bootstrap.ps1
+++ b/windows/installer/setup-bootstrap.ps1
@@ -128,6 +128,7 @@ try {
     'scripts\image-metadata.mjs',
     'scripts\injector.mjs',
     'scripts\install-dream-skin.ps1',
+    'scripts\localization-windows.ps1',
     'scripts\restore-dream-skin.ps1',
     'scripts\start-dream-skin.ps1',
     'scripts\theme-windows.ps1',

--- a/windows/scripts/apply-community-theme.ps1
+++ b/windows/scripts/apply-community-theme.ps1
@@ -9,6 +9,14 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 . (Join-Path $PSScriptRoot 'common-windows.ps1')
 . (Join-Path $PSScriptRoot 'theme-windows.ps1')
+. (Join-Path $PSScriptRoot 'localization-windows.ps1')
+$dreamSkinLanguage = Resolve-DreamSkinLanguage `
+  -StateRoot (Join-Path $env:LOCALAPPDATA 'CodexDreamSkin')
+
+function Get-DreamSkinCommunityText {
+  param([Parameter(Mandatory = $true)][string]$Key, [object[]]$FormatArguments = @())
+  Get-DreamSkinText -Key $Key -Language $dreamSkinLanguage -FormatArguments $FormatArguments
+}
 
 function Show-DreamSkinCommunityMessage {
   param(
@@ -36,9 +44,10 @@ function Format-DreamSkinCommunitySuccessMessage {
     [string]$Name,
     [string]$CleanupWarning = ''
   )
-  $message = "主题「$Name」已通过下载、SHA-256、主题包与 Safe CSS 校验，并已应用到 Codex。"
+  $message = Get-DreamSkinCommunityText -Key 'CommunitySuccess' -FormatArguments @($Name)
   if (-not [string]::IsNullOrWhiteSpace($CleanupWarning)) {
-    $message += "`r`n`r`n主题已成功应用，但旧备份目录未能自动清理；新主题不会因此回滚。请稍后重启客户端并查看日志。"
+    $message += [Environment]::NewLine + [Environment]::NewLine +
+      (Get-DreamSkinCommunityText -Key 'CommunityCleanup')
   }
   return $message
 }
@@ -47,18 +56,18 @@ function Confirm-DreamSkinCommunityApply {
   param([Parameter(Mandatory = $true)][object]$Metadata)
   Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
   $sizeMiB = [Math]::Round($Metadata.PackageBytes / 1MB, 2)
-  $message = @"
-从 DreamSkin.cc 下载并应用“$($Metadata.Name)”？
-
-作者：$($Metadata.AuthorDisplayName)
-版本：$($Metadata.Version) · $sizeMiB MiB
-SHA-256：$($Metadata.PackageSha256)
-
-客户端只会连接固定官方 API，并重新校验下载大小、SHA-256、ZIP、清单和 Safe CSS。应用时 Codex 可能重启，未保存的输入可能丢失。主题内容不会作为命令执行。
-"@
+  $message = @(
+    (Get-DreamSkinCommunityText -Key 'CommunityConfirm' -FormatArguments @($Metadata.Name)),
+    '',
+    (Get-DreamSkinCommunityText -Key 'CommunityAuthor' -FormatArguments @($Metadata.AuthorDisplayName)),
+    (Get-DreamSkinCommunityText -Key 'CommunityVersion' -FormatArguments @($Metadata.Version, $sizeMiB)),
+    (Get-DreamSkinCommunityText -Key 'CommunityHash' -FormatArguments @($Metadata.PackageSha256)),
+    '',
+    (Get-DreamSkinCommunityText -Key 'CommunitySafety')
+  ) -join [Environment]::NewLine
   $choice = [System.Windows.Forms.MessageBox]::Show(
     $message.Trim(),
-    '确认一键换肤',
+    (Get-DreamSkinCommunityText -Key 'CommunityConfirmTitle'),
     [System.Windows.Forms.MessageBoxButtons]::YesNo,
     [System.Windows.Forms.MessageBoxIcon]::Question,
     [System.Windows.Forms.MessageBoxDefaultButton]::Button2
@@ -797,24 +806,30 @@ try {
   $rollbackPath = "$($_.Exception.Data['DreamSkinRollbackPath'])"
   $workRootRetained = [bool]$_.Exception.Data['DreamSkinWorkRootRetained']
   $recoveryMessage = switch ($recovery) {
-    'Verified' { '新主题未能生效；此前主题已重新应用并完成可见渲染验证。' }
-    'Failed' { '新主题未能生效；此前主题的自动恢复或渲染验证未完成。请重新打开客户端检查。' }
-    'Superseded' { '检测到另一个换肤操作，客户端保留了较新的选择，没有覆盖它。' }
-    default { '新主题未写入已验证的活动状态。' }
+    'Verified' { Get-DreamSkinCommunityText -Key 'RecoveryVerified' }
+    'Failed' { Get-DreamSkinCommunityText -Key 'RecoveryFailed' }
+    'Superseded' { Get-DreamSkinCommunityText -Key 'RecoverySuperseded' }
+    default { Get-DreamSkinCommunityText -Key 'RecoveryUnconfirmed' }
   }
   $cleanupMessage = if ($workRootRetained) {
-    '恢复工作目录已保留，未自动删除。'
+    Get-DreamSkinCommunityText -Key 'RecoveryWorkRetained'
   } else {
-    '下载临时文件已清理。'
+    Get-DreamSkinCommunityText -Key 'DownloadCleaned'
   }
   $rollbackMessage = if ($rollbackPath) {
-    "`r`n回滚快照：$rollbackPath"
+    Get-DreamSkinCommunityText -Key 'RollbackSnapshot' -FormatArguments @($rollbackPath)
   } else {
     ''
   }
+  $summary = @(
+    (Get-DreamSkinCommunityText -Key 'CommunityApplyFailed'),
+    $cleanupMessage,
+    $recoveryMessage
+  )
+  if ($rollbackMessage) { $summary += $rollbackMessage }
   Show-DreamSkinCommunityMessage -Kind Error -Message (
-    "一键换肤失败。$cleanupMessage$recoveryMessage`r`n`r`n" +
-      $_.Exception.Message + $rollbackMessage
+    (($summary -join [Environment]::NewLine) + [Environment]::NewLine +
+      [Environment]::NewLine + $_.Exception.Message)
   )
   [Console]::Error.WriteLine($_.Exception.Message)
   if ($recovery -ceq 'Verified') { exit 20 }

--- a/windows/scripts/check-update.ps1
+++ b/windows/scripts/check-update.ps1
@@ -9,6 +9,14 @@ $engineRoot = Split-Path -Parent $PSScriptRoot
 $versionPath = Join-Path $engineRoot 'VERSION'
 $repository = 'Fei-Away/Codex-Dream-Skin'
 $releasePage = "https://github.com/$repository/releases/latest"
+. (Join-Path $PSScriptRoot 'localization-windows.ps1')
+$stateRoot = Join-Path $env:LOCALAPPDATA 'CodexDreamSkin'
+$language = Resolve-DreamSkinLanguage -StateRoot $stateRoot
+
+function Get-DreamSkinUpdateText {
+  param([Parameter(Mandatory = $true)][string]$Key, [object[]]$FormatArguments = @())
+  Get-DreamSkinText -Key $Key -Language $language -FormatArguments $FormatArguments
+}
 
 function ConvertTo-DreamSkinVersion {
   param([Parameter(Mandatory = $true)][string]$Value)
@@ -31,8 +39,10 @@ function Show-DreamSkinUpdateResult {
   Add-Type -AssemblyName System.Windows.Forms
   if ($Result.updateAvailable) {
     $choice = [System.Windows.Forms.MessageBox]::Show(
-      "Codex Dream Skin $($Result.latestVersion) is available.`r`n`r`nOpen the GitHub download page?",
-      'Codex Dream Skin Update',
+      ((Get-DreamSkinUpdateText -Key 'UpdateAvailable' -FormatArguments @($Result.latestVersion)) +
+        [Environment]::NewLine + [Environment]::NewLine +
+        (Get-DreamSkinUpdateText -Key 'UpdateQuestion')),
+      (Get-DreamSkinUpdateText -Key 'UpdateTitle'),
       [System.Windows.Forms.MessageBoxButtons]::YesNo,
       [System.Windows.Forms.MessageBoxIcon]::Information
     )
@@ -42,8 +52,8 @@ function Show-DreamSkinUpdateResult {
     return
   }
   [void][System.Windows.Forms.MessageBox]::Show(
-    "Codex Dream Skin $($Result.currentVersion) is up to date.",
-    'Codex Dream Skin Update',
+    (Get-DreamSkinUpdateText -Key 'UpToDate' -FormatArguments @($Result.currentVersion)),
+    (Get-DreamSkinUpdateText -Key 'UpdateTitle'),
     [System.Windows.Forms.MessageBoxButtons]::OK,
     [System.Windows.Forms.MessageBoxIcon]::Information
   )
@@ -84,8 +94,9 @@ try {
   if ($Interactive) {
     Add-Type -AssemblyName System.Windows.Forms
     [void][System.Windows.Forms.MessageBox]::Show(
-      "Could not check for updates.`r`n`r`n$($_.Exception.Message)",
-      'Codex Dream Skin Update',
+      ((Get-DreamSkinUpdateText -Key 'UpdateFailed') + [Environment]::NewLine +
+        [Environment]::NewLine + $_.Exception.Message),
+      (Get-DreamSkinUpdateText -Key 'UpdateTitle'),
       [System.Windows.Forms.MessageBoxButtons]::OK,
       [System.Windows.Forms.MessageBoxIcon]::Warning
     )

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -419,6 +419,18 @@ function Invoke-DreamSkinNative {
   }
 }
 
+function ConvertFrom-DreamSkinUtf8Base64 {
+  param(
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value
+  )
+  try {
+    $bytes = [Convert]::FromBase64String($Value.Trim())
+    return ([System.Text.UTF8Encoding]::new($false, $true)).GetString($bytes)
+  } catch {
+    throw 'The native UTF-8 probe returned invalid data.'
+  }
+}
+
 function Import-DreamSkinPowerShellSecurityModule {
   $command = Get-Command Get-AuthenticodeSignature -CommandType Cmdlet -ErrorAction SilentlyContinue
   if ($command) { return }
@@ -470,10 +482,33 @@ function Get-DreamSkinValidatedNodeRuntime {
   $versionProbe = Invoke-DreamSkinNative -FilePath $candidate -ArgumentList @('-p', 'process.versions.node') -DiscardStderr
   $version = ($versionProbe.Output -join '').Trim()
   if ($versionProbe.ExitCode -ne 0 -or -not $version) { throw 'The Node.js runtime could not be validated.' }
-  $pathProbe = Invoke-DreamSkinNative -FilePath $candidate -ArgumentList @('-p', 'process.execPath') -DiscardStderr
-  $runtimePath = ($pathProbe.Output -join '').Trim()
-  if ($pathProbe.ExitCode -ne 0 -or -not $runtimePath -or -not (Test-Path -LiteralPath $runtimePath)) {
-    throw 'The Node.js executable path could not be validated.'
+  # Windows PowerShell 5.1 decodes redirected native stdout through the active
+  # console code page. Node writes UTF-8, so a non-ASCII temporary path can be
+  # corrupted before Test-Path sees it. Keep the transport ASCII-only and
+  # decode the original UTF-8 bytes explicitly; never fall back to the
+  # candidate when the identity probe is invalid.
+  $pathProbe = Invoke-DreamSkinNative -FilePath $candidate -ArgumentList @(
+    '-e', "process.stdout.write(Buffer.from(process.execPath, 'utf8').toString('base64'))"
+  ) -DiscardStderr
+  $encodedRuntimePath = ($pathProbe.Output -join '').Trim()
+  $runtimePath = ''
+  if ($pathProbe.ExitCode -eq 0 -and $encodedRuntimePath) {
+    try {
+      $runtimePath = ConvertFrom-DreamSkinUtf8Base64 -Value $encodedRuntimePath
+    } catch {
+      $runtimePath = ''
+    }
+  }
+  $runtimePathExists = $false
+  if ($runtimePath) {
+    try { $runtimePathExists = Test-Path -LiteralPath $runtimePath -PathType Leaf } catch {}
+  }
+  if ($pathProbe.ExitCode -ne 0 -or -not $runtimePath -or -not $runtimePathExists) {
+    $reason = 'path-not-found'
+    if ($pathProbe.ExitCode -ne 0) { $reason = 'probe-exit' }
+    elseif (-not $encodedRuntimePath) { $reason = 'empty-output' }
+    elseif (-not $runtimePath) { $reason = 'invalid-output' }
+    throw "The Node.js executable path could not be validated ($reason)."
   }
   $major = 0
   if (-not [int]::TryParse(($version -split '\.')[0], [ref]$major) -or $major -lt $MinimumMajor) {

--- a/windows/scripts/common-windows.ps1
+++ b/windows/scripts/common-windows.ps1
@@ -200,6 +200,7 @@ function Install-DreamSkinRuntimeEngine {
     'scripts\image-metadata.mjs',
     'scripts\injector.mjs',
     'scripts\install-dream-skin.ps1',
+    'scripts\localization-windows.ps1',
     'scripts\restore-dream-skin.ps1',
     'scripts\start-dream-skin.ps1',
     'scripts\theme-windows.ps1',

--- a/windows/scripts/localization-windows.ps1
+++ b/windows/scripts/localization-windows.ps1
@@ -1,0 +1,177 @@
+﻿function Resolve-DreamSkinLanguage {
+  param(
+    [string]$Language = $env:DREAMSKIN_LANG,
+    [string]$StateRoot = ''
+  )
+  $requested = if ($null -eq $Language) { '' } else { $Language.Trim() }
+  if ($requested -match '^(?i:zh)(?:-|_|$)' -or $requested -ieq 'chinese') { return 'zh-CN' }
+  if ($requested -match '^(?i:en)(?:-|_|$)' -or $requested -ieq 'english') { return 'en-US' }
+
+  if ($StateRoot) {
+    $preferencePath = Join-Path $StateRoot 'language.txt'
+    if (Test-Path -LiteralPath $preferencePath -PathType Leaf) {
+      try {
+        $item = Get-Item -LiteralPath $preferencePath -Force -ErrorAction Stop
+        if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0 -and
+          $item.Length -le 16) {
+          $saved = [System.IO.File]::ReadAllText($item.FullName).Trim()
+          if ($saved -ceq 'zh-CN' -or $saved -ceq 'en-US') { return $saved }
+        }
+      } catch {}
+    }
+  }
+
+  $culture = [System.Globalization.CultureInfo]::CurrentUICulture.Name
+  if ($culture -match '^(?i:zh)(?:-|_|$)') { return 'zh-CN' }
+  return 'en-US'
+}
+
+function Set-DreamSkinLanguage {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('system', 'en-US', 'zh-CN')]
+    [string]$Language,
+    [Parameter(Mandatory = $true)][string]$StateRoot
+  )
+  $root = [System.IO.Path]::GetFullPath($StateRoot)
+  if (-not (Test-Path -LiteralPath $root -PathType Container)) {
+    [void][System.IO.Directory]::CreateDirectory($root)
+  }
+  $preferencePath = Join-Path $root 'language.txt'
+  if ($Language -ceq 'system') {
+    Remove-Item -LiteralPath $preferencePath -Force -ErrorAction SilentlyContinue
+    return
+  }
+  $temporary = Join-Path $root ('.language.' + [Guid]::NewGuid().ToString('N') + '.tmp')
+  try {
+    [System.IO.File]::WriteAllText(
+      $temporary,
+      $Language + [Environment]::NewLine,
+      [System.Text.UTF8Encoding]::new($false)
+    )
+    Move-Item -LiteralPath $temporary -Destination $preferencePath -Force
+  } finally {
+    Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Get-DreamSkinLanguagePreference {
+  param([Parameter(Mandatory = $true)][string]$StateRoot)
+  if ($env:DREAMSKIN_LANG -match '^(?i:zh)(?:-|_|$)' -or $env:DREAMSKIN_LANG -ieq 'chinese') {
+    return 'zh-CN'
+  }
+  if ($env:DREAMSKIN_LANG -match '^(?i:en)(?:-|_|$)' -or $env:DREAMSKIN_LANG -ieq 'english') {
+    return 'en-US'
+  }
+  $preferencePath = Join-Path $StateRoot 'language.txt'
+  if (Test-Path -LiteralPath $preferencePath -PathType Leaf) {
+    try {
+      $saved = [System.IO.File]::ReadAllText($preferencePath).Trim()
+      if ($saved -ceq 'zh-CN' -or $saved -ceq 'en-US') { return $saved }
+    } catch {}
+  }
+  return 'system'
+}
+
+function Get-DreamSkinText {
+  param(
+    [Parameter(Mandatory = $true)][string]$Key,
+    [string]$Language = '',
+    [object[]]$FormatArguments = @()
+  )
+  $resolved = Resolve-DreamSkinLanguage -Language $Language
+  $catalog = @{
+    'en-US' = @{
+      StatusPaused = 'Status: Paused'; StatusRunning = 'Status: Running'; StatusStopped = 'Status: Stopped'
+      Apply = 'Apply or reapply'; Resume = 'Resume skin'; Pause = 'Pause skin'
+      ChangeBackground = 'Change background image'; BackgroundTitle = 'Choose a Codex Dream Skin background image'
+      BackgroundUpdated = 'Background image updated.'; ImportZip = 'Import theme ZIP...'
+      ImportTitle = 'Choose a Codex Dream Skin theme ZIP'; SaveCurrent = 'Save current theme'
+      SavePrompt = 'Theme name:'; SaveTitle = 'Save Codex Dream Skin theme'; Saved = 'Saved: {0}'
+      SavedThemes = 'Saved themes'; NoSavedThemes = 'No saved themes'; Applied = 'Applied: {0}'
+      OpenThemes = 'Open themes folder'; OpenImages = 'Open images folder'; CheckUpdate = 'Check for updates...'
+      Gallery = 'Theme Gallery'; Studio = 'Online Studio'; OpenSite = 'Open DreamSkin.cc'
+      LaunchAtLogin = 'Launch at login'; Restore = 'Fully restore Codex'; Exit = 'Exit tray'
+      Language = 'Language / 语言'; LanguageSystem = 'System / 系统'; LanguageEnglish = 'English'; LanguageChinese = '中文'
+      ApplyStarted = 'Skin apply started'; Applying = 'Applying skin...'
+      ResumeStarted = 'Skin reapply started'; Reapplying = 'Reapplying skin...'
+      ThemeExists = 'Theme already exists: {0}. No duplicate was written.'
+      ThemeUpdated = 'Saved theme updated: {0}. The current theme did not change.'
+      ThemeImported = 'Imported: {0}. The current theme did not change.'
+      NewIdentifier = ' New identifier: {0}.'; NameCollision = ' A theme with the same name already exists.'
+      CssValidated = ' theme.css passed local Safe CSS validation and will apply with this theme.'
+      SignatureIgnored = ' manifest.sig is reserved and ignored by this version.'
+      CleanupWarning = ' The theme was saved, but an old backup folder could not be cleaned up. Restart the client later and check its logs.'
+      ImageFilter = 'Image files|*.png;*.jpg;*.jpeg;*.webp|All files|*.*'
+      PauseNoSession = 'Pause was recorded, but no active session could be reached. The current window may still show the skin.'
+      PauseSucceeded = 'Skin paused.'; PauseFailed = 'Pause was recorded, but removing the live skin failed. Retry pause or fully restore Codex.'
+      UpdateTitle = 'Codex Dream Skin Update'; UpdateAvailable = 'Codex Dream Skin {0} is available.'
+      UpdateQuestion = 'Open the GitHub download page?'; UpToDate = 'Codex Dream Skin {0} is up to date.'
+      UpdateFailed = 'Could not check for updates.'
+      RestartPrompt = 'Codex must restart once to enable Dream Skin. Unsaved input may be lost. Restart now?'
+      LaunchCancelled = 'Dream Skin launch was cancelled; Codex was not changed.'
+      RestoreClose = 'Restore will close Codex, remove Dream Skin and its CDP session, then reopen the official app. Continue?'
+      RestoreCloseNoRelaunch = 'Restore will close Codex and remove Dream Skin plus its CDP session. Continue?'
+      RestoreCancelled = 'Restore was cancelled; no state or configuration was changed.'
+      CommunitySuccess = 'Theme “{0}” passed download, SHA-256, package, and Safe CSS validation and is now active in Codex.'
+      CommunityCleanup = 'The theme was applied, but an old backup folder could not be cleaned up. The new theme will not be rolled back. Restart the client later and check its logs.'
+      CommunityConfirmTitle = 'Confirm one-click theme apply'; CommunityConfirm = 'Download and apply “{0}” from DreamSkin.cc?'
+      CommunityAuthor = 'Author: {0}'; CommunityVersion = 'Version: {0} · {1} MiB'; CommunityHash = 'SHA-256: {0}'
+      CommunitySafety = 'The client connects only to the fixed official API and revalidates download size, SHA-256, ZIP, manifest, and Safe CSS. Codex may restart while applying, and unsaved input may be lost. Theme content is never executed as commands.'
+      RecoveryVerified = 'The new theme did not become active. The previous theme was reapplied and passed visible-render verification.'
+      RecoveryFailed = 'The new theme did not become active. Automatic restore or render verification of the previous theme did not finish. Reopen the client and inspect it.'
+      RecoverySuperseded = 'Another theme operation was detected. The client kept the newer selection and did not overwrite it.'
+      RecoveryUnconfirmed = 'The new theme did not enter verified active state.'
+      RecoveryWorkRetained = 'The recovery work folder was retained and not deleted.'; DownloadCleaned = 'Temporary download files were cleaned up.'
+      RollbackSnapshot = 'Rollback snapshot: {0}'; CommunityApplyFailed = 'One-click theme apply failed.'
+    }
+    'zh-CN' = @{
+      StatusPaused = '状态：已暂停'; StatusRunning = '状态：运行中'; StatusStopped = '状态：未运行'
+      Apply = '应用或重新应用'; Resume = '继续显示皮肤'; Pause = '暂停皮肤'
+      ChangeBackground = '更换背景图'; BackgroundTitle = '选择 Codex Dream Skin 背景图'
+      BackgroundUpdated = '背景图已更新。'; ImportZip = '导入主题 ZIP…'
+      ImportTitle = '选择 Codex Dream Skin 主题 ZIP'; SaveCurrent = '保存当前主题'
+      SavePrompt = '输入主题名称：'; SaveTitle = '保存 Codex Dream Skin 主题'; Saved = '已保存：{0}'
+      SavedThemes = '已保存主题'; NoSavedThemes = '暂无已保存主题'; Applied = '已应用：{0}'
+      OpenThemes = '打开主题文件夹'; OpenImages = '打开图片文件夹'; CheckUpdate = '检查更新…'
+      Gallery = '主题库 Gallery'; Studio = '在线 Studio'; OpenSite = '打开 DreamSkin.cc'
+      LaunchAtLogin = '登录时启动'; Restore = '完全恢复 Codex'; Exit = '退出托盘'
+      Language = '语言 / Language'; LanguageSystem = '系统 / System'; LanguageEnglish = 'English'; LanguageChinese = '中文'
+      ApplyStarted = '已开始应用皮肤'; Applying = '正在应用皮肤…'
+      ResumeStarted = '已开始重新应用皮肤'; Reapplying = '正在重新应用皮肤…'
+      ThemeExists = '主题已存在：{0}。没有重复写入。'
+      ThemeUpdated = '已更新已保存主题：{0}。当前主题没有改变。'
+      ThemeImported = '已导入：{0}。当前主题没有改变。'
+      NewIdentifier = ' 新标识：{0}。'; NameCollision = ' 主题库中已有同名主题。'
+      CssValidated = ' theme.css 已通过本机 Safe CSS 校验，切换到该主题时会一并生效。'
+      SignatureIgnored = ' manifest.sig 是预留文件，当前版本已忽略。'
+      CleanupWarning = ' 主题已成功保存，但旧备份目录未能自动清理；新主题不会因此回滚。请稍后重启客户端并查看日志。'
+      ImageFilter = '图片文件|*.png;*.jpg;*.jpeg;*.webp|所有文件|*.*'
+      PauseNoSession = '没有可连接的活动会话；已记录暂停，当前窗口可能仍显示皮肤。'
+      PauseSucceeded = '皮肤已暂停。'; PauseFailed = '已记录暂停，但卸下当前皮肤失败；可重试暂停或完全恢复 Codex。'
+      UpdateTitle = 'Codex Dream Skin 更新'; UpdateAvailable = 'Codex Dream Skin {0} 已发布。'
+      UpdateQuestion = '是否打开 GitHub 下载页面？'; UpToDate = 'Codex Dream Skin {0} 已是最新版本。'
+      UpdateFailed = '无法检查更新。'
+      RestartPrompt = 'Codex 需要重启一次才能启用 Dream Skin，未保存的输入可能丢失。现在重启吗？'
+      LaunchCancelled = '已取消启动 Dream Skin；Codex 未发生改变。'
+      RestoreClose = '恢复操作将关闭 Codex，移除 Dream Skin 及其 CDP 会话，然后重新打开官方应用。是否继续？'
+      RestoreCloseNoRelaunch = '恢复操作将关闭 Codex，并移除 Dream Skin 及其 CDP 会话。是否继续？'
+      RestoreCancelled = '已取消恢复；状态和配置均未改变。'
+      CommunitySuccess = '主题“{0}”已通过下载、SHA-256、主题包与 Safe CSS 校验，并已应用到 Codex。'
+      CommunityCleanup = '主题已成功应用，但旧备份目录未能自动清理；新主题不会因此回滚。请稍后重启客户端并查看日志。'
+      CommunityConfirmTitle = '确认一键换肤'; CommunityConfirm = '从 DreamSkin.cc 下载并应用“{0}”？'
+      CommunityAuthor = '作者：{0}'; CommunityVersion = '版本：{0} · {1} MiB'; CommunityHash = 'SHA-256：{0}'
+      CommunitySafety = '客户端只会连接固定官方 API，并重新校验下载大小、SHA-256、ZIP、清单和 Safe CSS。应用时 Codex 可能重启，未保存的输入可能丢失。主题内容不会作为命令执行。'
+      RecoveryVerified = '新主题未能生效；此前主题已重新应用并完成可见渲染验证。'
+      RecoveryFailed = '新主题未能生效；此前主题的自动恢复或渲染验证未完成。请重新打开客户端检查。'
+      RecoverySuperseded = '检测到另一个换肤操作，客户端保留了较新的选择，没有覆盖它。'
+      RecoveryUnconfirmed = '新主题未写入已验证的活动状态。'
+      RecoveryWorkRetained = '恢复工作目录已保留，未自动删除。'; DownloadCleaned = '下载临时文件已清理。'
+      RollbackSnapshot = '回滚快照：{0}'; CommunityApplyFailed = '一键换肤失败。'
+    }
+  }
+  $value = $catalog[$resolved][$Key]
+  if ($null -eq $value) { throw "Unknown Dream Skin localization key: $Key" }
+  if ($FormatArguments.Count -gt 0) { return [string]::Format($value, $FormatArguments) }
+  return $value
+}

--- a/windows/scripts/restore-dream-skin.ps1
+++ b/windows/scripts/restore-dream-skin.ps1
@@ -13,6 +13,7 @@ $ErrorActionPreference = 'Stop'
 $PortExplicit = $PSBoundParameters.ContainsKey('Port')
 . (Join-Path $PSScriptRoot 'common-windows.ps1')
 . (Join-Path $PSScriptRoot 'theme-windows.ps1')
+. (Join-Path $PSScriptRoot 'localization-windows.ps1')
 
 $operationLock = Enter-DreamSkinOperationLock
 try {
@@ -22,6 +23,7 @@ try {
   Assert-DreamSkinPort -Port $Port
 
   $StateRoot = Join-Path $env:LOCALAPPDATA 'CodexDreamSkin'
+  $language = Resolve-DreamSkinLanguage -StateRoot $StateRoot
   $themePaths = Get-DreamSkinThemePaths -StateRoot $StateRoot
   Ensure-DreamSkinManagedDirectory -Path $themePaths.Root -Root $themePaths.Root
   $StatePath = Join-Path $StateRoot 'state.json'
@@ -77,13 +79,13 @@ try {
   $forceAuthorized = [bool]$ForceRestart
   if ($shouldCloseCodex -and $PromptRestart) {
     $restartMessage = if ($NoRelaunch) {
-      'Restore will close Codex and remove Dream Skin plus its CDP session. Continue?'
+      Get-DreamSkinText -Key 'RestoreCloseNoRelaunch' -Language $language
     } else {
-      'Restore will close Codex, remove Dream Skin and its CDP session, then reopen the official app. Continue?'
+      Get-DreamSkinText -Key 'RestoreClose' -Language $language
     }
     $forceAuthorized = Confirm-DreamSkinRestart -Message $restartMessage
     if (-not $forceAuthorized) {
-      Write-Host 'Restore was cancelled; no state or configuration was changed.'
+      Write-Host (Get-DreamSkinText -Key 'RestoreCancelled' -Language $language)
       exit 0
     }
   }

--- a/windows/scripts/start-dream-skin.ps1
+++ b/windows/scripts/start-dream-skin.ps1
@@ -14,6 +14,7 @@ $PortExplicit = $PSBoundParameters.ContainsKey('Port')
 $Injector = Join-Path $PSScriptRoot 'injector.mjs'
 . (Join-Path $PSScriptRoot 'common-windows.ps1')
 . (Join-Path $PSScriptRoot 'theme-windows.ps1')
+. (Join-Path $PSScriptRoot 'localization-windows.ps1')
 
 $operationLock = Enter-DreamSkinOperationLock `
   -TimeoutMilliseconds $OperationLockTimeoutMilliseconds
@@ -24,6 +25,7 @@ try {
   $currentCodex = Get-DreamSkinCodexInstall
   $codex = $currentCodex
   $StateRoot = Join-Path $env:LOCALAPPDATA 'CodexDreamSkin'
+  $language = Resolve-DreamSkinLanguage -StateRoot $StateRoot
   $themePaths = Get-DreamSkinThemePaths -StateRoot $StateRoot
   Ensure-DreamSkinManagedDirectory -Path $themePaths.Root -Root $themePaths.Root
   $StatePath = Join-Path $StateRoot 'state.json'
@@ -103,9 +105,10 @@ try {
   if (-not $debugReady -and $codexProcesses.Count -gt 0) {
     $restartAuthorized = [bool]$RestartExisting
     if (-not $restartAuthorized -and $PromptRestart) {
-      $restartAuthorized = Confirm-DreamSkinRestart -Message 'Codex must restart once to enable Dream Skin. Unsaved input may be lost. Restart now?'
+      $restartAuthorized = Confirm-DreamSkinRestart -Message `
+        (Get-DreamSkinText -Key 'RestartPrompt' -Language $language)
       if (-not $restartAuthorized) {
-        Write-Host 'Dream Skin launch was cancelled; Codex was not changed.'
+        Write-Host (Get-DreamSkinText -Key 'LaunchCancelled' -Language $language)
         exit 0
       }
     }

--- a/windows/scripts/theme-windows.ps1
+++ b/windows/scripts/theme-windows.ps1
@@ -2271,17 +2271,25 @@ function Show-DreamSkinOperationUi {
 function Invoke-DreamSkinLiveRemove {
   param(
     [string]$StateRoot = (Join-Path $env:LOCALAPPDATA 'CodexDreamSkin'),
-    [int]$TimeoutMs = 8000
+    [int]$TimeoutMs = 8000,
+    [string]$PauseNoSessionMessage = '没有可连接的活动会话；已记录暂停，当前窗口可能仍显示皮肤。',
+    [string]$PauseSucceededMessage = '皮肤已暂停',
+    [string]$PauseFailedMessage = '已记录暂停，但卸下当前皮肤失败；可重试暂停或完全恢复。'
   )
   if ($TimeoutMs -lt 250 -or $TimeoutMs -gt 120000) {
     throw "Invalid live-remove timeout: $TimeoutMs"
+  }
+  foreach ($message in @($PauseNoSessionMessage, $PauseSucceededMessage, $PauseFailedMessage)) {
+    if ([string]::IsNullOrWhiteSpace($message) -or $message.Length -gt 240 -or $message -match "[\r\n]") {
+      throw 'Invalid live-remove message.'
+    }
   }
   $session = Get-DreamSkinLiveSessionContext -StateRoot $StateRoot
   if ($null -eq $session) {
     return [pscustomobject]@{
       Attempted = $false
       Removed = $false
-      Message = '没有可连接的活动会话；已记录暂停，当前窗口可能仍显示皮肤。'
+      Message = $PauseNoSessionMessage
     }
   }
 
@@ -2305,21 +2313,21 @@ function Invoke-DreamSkinLiveRemove {
   if ($removal.ExitCode -eq 0) {
     if ($token) {
       $null = Show-DreamSkinOperationUi -Session $session -Phase finish -Token $token `
-        -UiState success -Message '皮肤已暂停' -TimeoutMs 1500
+        -UiState success -Message $PauseSucceededMessage -TimeoutMs 1500
     }
     return [pscustomobject]@{
       Attempted = $true
       Removed = $true
-      Message = '皮肤已暂停'
+      Message = $PauseSucceededMessage
     }
   }
   if ($token) {
     $null = Show-DreamSkinOperationUi -Session $session -Phase finish -Token $token `
-      -UiState error -Message '暂停失败，请重试' -TimeoutMs 1500
+      -UiState error -Message $PauseFailedMessage -TimeoutMs 1500
   }
   return [pscustomobject]@{
     Attempted = $true
     Removed = $false
-    Message = '已记录暂停，但卸下当前皮肤失败；可重试暂停或完全恢复。'
+    Message = $PauseFailedMessage
   }
 }

--- a/windows/scripts/tray-dream-skin.ps1
+++ b/windows/scripts/tray-dream-skin.ps1
@@ -5,6 +5,7 @@ $ErrorActionPreference = 'Stop'
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 Add-Type -AssemblyName Microsoft.VisualBasic
+. (Join-Path $PSScriptRoot 'localization-windows.ps1')
 . (Join-Path $PSScriptRoot 'common-windows.ps1')
 . (Join-Path $PSScriptRoot 'theme-windows.ps1')
 
@@ -57,12 +58,27 @@ try {
     )
   }
 
+  function Get-DreamSkinTrayText {
+    param(
+      [Parameter(Mandatory = $true)][string]$Key,
+      [object[]]$FormatArguments = @()
+    )
+    $language = Resolve-DreamSkinLanguage -StateRoot $StateRoot
+    Get-DreamSkinText -Key $Key -Language $language -FormatArguments $FormatArguments
+  }
+
   function Start-DreamSkinPowerShell {
     param([Parameter(Mandatory = $true)][string]$Script, [string[]]$Arguments = @())
     $scriptToken = ConvertTo-DreamSkinProcessArgument -Value $Script
     $argumentLine = '-NoProfile -WindowStyle Hidden -ExecutionPolicy RemoteSigned -File ' + $scriptToken
     if ($Arguments.Count -gt 0) { $argumentLine += ' ' + ($Arguments -join ' ') }
-    Start-Process -FilePath $powershell -ArgumentList $argumentLine -WindowStyle Hidden | Out-Null
+    $previousLanguage = $env:DREAMSKIN_LANG
+    try {
+      $env:DREAMSKIN_LANG = Resolve-DreamSkinLanguage -StateRoot $StateRoot
+      Start-Process -FilePath $powershell -ArgumentList $argumentLine -WindowStyle Hidden | Out-Null
+    } finally {
+      $env:DREAMSKIN_LANG = $previousLanguage
+    }
   }
 
   function Add-DreamSkinTrayItem {
@@ -85,6 +101,27 @@ try {
     }
     [void]$Items.Add($item)
     return $item
+  }
+
+  function Add-DreamSkinTrayLanguageMenu {
+    $preference = Get-DreamSkinLanguagePreference -StateRoot $StateRoot
+    $languageMenu = [System.Windows.Forms.ToolStripMenuItem]::new(
+      (Get-DreamSkinTrayText -Key 'Language')
+    )
+    foreach ($option in @(
+      @{ Value = 'system'; Label = (Get-DreamSkinTrayText -Key 'LanguageSystem') },
+      @{ Value = 'en-US'; Label = (Get-DreamSkinTrayText -Key 'LanguageEnglish') },
+      @{ Value = 'zh-CN'; Label = (Get-DreamSkinTrayText -Key 'LanguageChinese') }
+    )) {
+      $optionValue = $option.Value
+      $optionAction = {
+        Set-DreamSkinLanguage -Language $optionValue -StateRoot $StateRoot
+        Rebuild-DreamSkinTrayMenu
+      }.GetNewClosure()
+      $optionItem = Add-DreamSkinTrayItem -Items $languageMenu.DropDownItems -Text $option.Label -Action $optionAction
+      $optionItem.Checked = $preference -ceq $optionValue
+    }
+    [void]$menu.Items.Add($languageMenu)
   }
 
   function Invoke-DreamSkinTrayThemeOperation {
@@ -119,14 +156,20 @@ try {
     try { $state = Read-DreamSkinState -Path $paths.State } catch {}
     $active = $null
     try { $active = Read-DreamSkinTheme -ThemeDirectory $paths.Active -SkipImageMetadata } catch {}
-    $status = if ($paused) { '状态：已暂停' } elseif ($state) { '状态：运行中' } else { '状态：未运行' }
+    $status = if ($paused) {
+      Get-DreamSkinTrayText -Key 'StatusPaused'
+    } elseif ($state) {
+      Get-DreamSkinTrayText -Key 'StatusRunning'
+    } else {
+      Get-DreamSkinTrayText -Key 'StatusStopped'
+    }
     if ($null -ne $active -and $null -ne $active.Theme -and $active.Theme.name) {
       $status += " · $($active.Theme.name)"
     }
     $null = Add-DreamSkinTrayItem -Items $menu.Items -Text $status -Action $null -Enabled $false
     [void]$menu.Items.Add([System.Windows.Forms.ToolStripSeparator]::new())
 
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '应用或重新应用' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'Apply') -Action {
       $session = Get-DreamSkinLiveSessionContext -StateRoot $StateRoot
       $begin = $null
       if ($null -ne $session) {
@@ -136,14 +179,14 @@ try {
       # start-dream-skin is async; close the in-window loading so it does not stick for 180s.
       if ($null -ne $session -and $null -ne $begin -and $begin.Ok) {
         $null = Show-DreamSkinOperationUi -Session $session -Phase finish -Token $begin.Token `
-          -UiState success -Message '已开始应用皮肤' -TimeoutMs 1500
+          -UiState success -Message (Get-DreamSkinTrayText -Key 'ApplyStarted') -TimeoutMs 1500
       }
-      $notify.ShowBalloonTip(1800, 'Codex Dream Skin', '正在应用皮肤…', [System.Windows.Forms.ToolTipIcon]::Info)
+      $notify.ShowBalloonTip(1800, 'Codex Dream Skin', (Get-DreamSkinTrayText -Key 'Applying'), [System.Windows.Forms.ToolTipIcon]::Info)
     }
     # Match macOS menubar: pause = mark + live remove; resume lets the serialized
     # start path clear pause only after its safety checks and any restart consent.
     if ($paused) {
-      $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '继续显示皮肤' -Action {
+      $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'Resume') -Action {
         # Keep pause set while the start path validates and prompts; show in-window
         # loading when the existing CDP session is still reachable.
         $session = Get-DreamSkinLiveSessionContext -StateRoot $StateRoot
@@ -154,37 +197,44 @@ try {
         Start-DreamSkinPowerShell -Script $startScript -Arguments @('-Port', "$Port", '-PromptRestart')
         if ($null -ne $session -and $null -ne $begin -and $begin.Ok) {
           $null = Show-DreamSkinOperationUi -Session $session -Phase finish -Token $begin.Token `
-            -UiState success -Message '已开始重新应用皮肤' -TimeoutMs 1500
+          -UiState success -Message (Get-DreamSkinTrayText -Key 'ResumeStarted') -TimeoutMs 1500
         }
         $notify.ShowBalloonTip(
           1800,
           'Codex Dream Skin',
-          '正在重新应用皮肤…',
+          (Get-DreamSkinTrayText -Key 'Reapplying'),
           [System.Windows.Forms.ToolTipIcon]::Info
         )
       }
     } else {
-      $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '暂停皮肤' -Action {
+      $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'Pause') -Action {
         # Match macOS pause: marker + live remove with in-window loading / result.
+        $pauseNoSessionMessage = Get-DreamSkinTrayText -Key 'PauseNoSession'
+        $pauseSucceededMessage = Get-DreamSkinTrayText -Key 'PauseSucceeded'
+        $pauseFailedMessage = Get-DreamSkinTrayText -Key 'PauseFailed'
         $removal = Invoke-DreamSkinTrayThemeOperation -Action {
           Set-DreamSkinPaused -Paused $true -StateRoot $StateRoot | Out-Null
-          Invoke-DreamSkinLiveRemove -StateRoot $StateRoot
+          Invoke-DreamSkinLiveRemove -StateRoot $StateRoot `
+            -PauseNoSessionMessage $pauseNoSessionMessage `
+            -PauseSucceededMessage $pauseSucceededMessage `
+            -PauseFailedMessage $pauseFailedMessage
         }
         $icon = if ($removal.Removed) {
           [System.Windows.Forms.ToolTipIcon]::Info
         } else {
           [System.Windows.Forms.ToolTipIcon]::Warning
         }
-        $notify.ShowBalloonTip(2800, 'Codex Dream Skin', $removal.Message, $icon)
+        $removalMessage = $removal.Message
+        $notify.ShowBalloonTip(2800, 'Codex Dream Skin', $removalMessage, $icon)
         if (-not $removal.Removed -and $removal.Attempted) {
-          Show-DreamSkinTrayError -Message $removal.Message
+          Show-DreamSkinTrayError -Message $removalMessage
         }
       }
     }
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '更换背景图' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'ChangeBackground') -Action {
       $dialog = [System.Windows.Forms.OpenFileDialog]::new()
-      $dialog.Title = '选择 Codex Dream Skin 背景图'
-      $dialog.Filter = 'Image files|*.png;*.jpg;*.jpeg;*.webp|All files|*.*'
+      $dialog.Title = Get-DreamSkinTrayText -Key 'BackgroundTitle'
+      $dialog.Filter = Get-DreamSkinTrayText -Key 'ImageFilter'
       $dialog.Multiselect = $false
       try {
         if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
@@ -193,38 +243,40 @@ try {
               -StateRoot $StateRoot
             Set-DreamSkinPaused -Paused $false -StateRoot $StateRoot | Out-Null
           }
-          $notify.ShowBalloonTip(1800, 'Codex Dream Skin', '背景图已更新。', [System.Windows.Forms.ToolTipIcon]::Info)
+          $notify.ShowBalloonTip(1800, 'Codex Dream Skin', (Get-DreamSkinTrayText -Key 'BackgroundUpdated'), [System.Windows.Forms.ToolTipIcon]::Info)
         }
       } finally {
         $dialog.Dispose()
       }
     }
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '导入主题 ZIP…' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'ImportZip') -Action {
       $dialog = [System.Windows.Forms.OpenFileDialog]::new()
-      $dialog.Title = '选择 Codex Dream Skin 主题 ZIP'
+      $dialog.Title = Get-DreamSkinTrayText -Key 'ImportTitle'
       $dialog.Filter = 'Dream Skin theme ZIP|*.zip'
       $dialog.Multiselect = $false
       try {
         if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
           $imported = Import-DreamSkinThemeZip -ArchivePath $dialog.FileName -StateRoot $StateRoot
           if ($imported.Status -ceq 'Duplicate') {
-            $message = "主题已存在：$($imported.Name)。没有重复写入。"
+            $message = Get-DreamSkinTrayText -Key 'ThemeExists' -FormatArguments @($imported.Name)
           } elseif ($imported.Replaced) {
-            $message = "已更新已保存主题：$($imported.Name)。当前主题没有改变。"
+            $message = Get-DreamSkinTrayText -Key 'ThemeUpdated' -FormatArguments @($imported.Name)
           } else {
-            $message = "已导入：$($imported.Name)。当前主题没有改变。"
-            if ($imported.Renamed) { $message += " 新标识：$($imported.Id)。" }
-            if ($imported.NameCollision) { $message += ' 主题库中已有同名主题。' }
+            $message = Get-DreamSkinTrayText -Key 'ThemeImported' -FormatArguments @($imported.Name)
+            if ($imported.Renamed) {
+              $message += Get-DreamSkinTrayText -Key 'NewIdentifier' -FormatArguments @($imported.Id)
+            }
+            if ($imported.NameCollision) { $message += Get-DreamSkinTrayText -Key 'NameCollision' }
           }
           if ($imported.SafeCssStatus -ceq 'validated') {
-            $message += ' theme.css 已通过本机 Safe CSS 校验，切换到该主题时会一并生效。'
+            $message += Get-DreamSkinTrayText -Key 'CssValidated'
           }
-          if ($imported.SignatureIgnored) { $message += ' manifest.sig 是预留文件，当前版本已忽略。' }
+          if ($imported.SignatureIgnored) { $message += Get-DreamSkinTrayText -Key 'SignatureIgnored' }
           $cleanupProperty = $imported.PSObject.Properties['CleanupWarning']
           $hasCleanupWarning = $null -ne $cleanupProperty -and
             -not [string]::IsNullOrWhiteSpace("$($cleanupProperty.Value)")
           if ($hasCleanupWarning) {
-            $message += ' 主题已成功保存，但旧备份目录未能自动清理；新主题不会因此回滚。请稍后重启客户端并查看日志。'
+            $message += Get-DreamSkinTrayText -Key 'CleanupWarning'
           }
           $messageIcon = if ($hasCleanupWarning) {
             [System.Windows.Forms.ToolTipIcon]::Warning
@@ -237,20 +289,33 @@ try {
         $dialog.Dispose()
       }
     }
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '保存当前主题' -Action {
-      $name = [Microsoft.VisualBasic.Interaction]::InputBox('输入主题名称：', '保存 Codex Dream Skin 主题', '')
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'SaveCurrent') -Action {
+      $name = [Microsoft.VisualBasic.Interaction]::InputBox(
+        (Get-DreamSkinTrayText -Key 'SavePrompt'),
+        (Get-DreamSkinTrayText -Key 'SaveTitle'),
+        ''
+      )
       if ($name.Trim()) {
         $saved = Invoke-DreamSkinTrayThemeOperation -Action {
           Save-DreamSkinCurrentTheme -Name $name -StateRoot $StateRoot
         }
-        $notify.ShowBalloonTip(1800, 'Codex Dream Skin', "已保存：$($saved.Theme.name)", [System.Windows.Forms.ToolTipIcon]::Info)
+        $notify.ShowBalloonTip(
+          1800,
+          'Codex Dream Skin',
+          (Get-DreamSkinTrayText -Key 'Saved' -FormatArguments @($saved.Theme.name)),
+          [System.Windows.Forms.ToolTipIcon]::Info
+        )
       }
     }
 
-    $savedMenu = [System.Windows.Forms.ToolStripMenuItem]::new('已保存主题')
+    $savedMenu = [System.Windows.Forms.ToolStripMenuItem]::new(
+      (Get-DreamSkinTrayText -Key 'SavedThemes')
+    )
     $savedThemes = @(Get-DreamSkinSavedThemes -StateRoot $StateRoot -SkipImageMetadata)
     if ($savedThemes.Count -eq 0) {
-      $empty = [System.Windows.Forms.ToolStripMenuItem]::new('暂无已保存主题')
+      $empty = [System.Windows.Forms.ToolStripMenuItem]::new(
+        (Get-DreamSkinTrayText -Key 'NoSavedThemes')
+      )
       $empty.Enabled = $false
       [void]$savedMenu.DropDownItems.Add($empty)
     } else {
@@ -262,49 +327,55 @@ try {
             $null = Use-DreamSkinSavedTheme -ThemeDirectory $savedPath -StateRoot $StateRoot
             Set-DreamSkinPaused -Paused $false -StateRoot $StateRoot | Out-Null
           }
-          $notify.ShowBalloonTip(1800, 'Codex Dream Skin', "已应用：$savedName", [System.Windows.Forms.ToolTipIcon]::Info)
+          $notify.ShowBalloonTip(
+            1800,
+            'Codex Dream Skin',
+            (Get-DreamSkinTrayText -Key 'Applied' -FormatArguments @($savedName)),
+            [System.Windows.Forms.ToolTipIcon]::Info
+          )
         }.GetNewClosure()
         $null = Add-DreamSkinTrayItem -Items $savedMenu.DropDownItems -Text $savedName -Action $savedAction
       }
     }
     [void]$menu.Items.Add($savedMenu)
 
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '打开主题文件夹' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'OpenThemes') -Action {
       $themeDirectoryToken = ConvertTo-DreamSkinProcessArgument -Value $paths.Saved
       Start-Process -FilePath explorer.exe -ArgumentList $themeDirectoryToken | Out-Null
     }
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '打开图片文件夹' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'OpenImages') -Action {
       $imageDirectoryToken = ConvertTo-DreamSkinProcessArgument -Value $paths.Images
       Start-Process -FilePath explorer.exe -ArgumentList $imageDirectoryToken | Out-Null
     }
     [void]$menu.Items.Add([System.Windows.Forms.ToolStripSeparator]::new())
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '检查更新…' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'CheckUpdate') -Action {
       Start-DreamSkinPowerShell -Script $checkUpdateScript -Arguments @('-Interactive')
     }
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '主题库 Gallery' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'Gallery') -Action {
       Start-Process -FilePath 'https://dreamskin.cc/gallery' | Out-Null
     }
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '在线 Studio' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'Studio') -Action {
       Start-Process -FilePath 'https://dreamskin.cc/studio' | Out-Null
     }
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '打开 DreamSkin.cc' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'OpenSite') -Action {
       Start-Process -FilePath 'https://dreamskin.cc' | Out-Null
     }
     $autoStartEnabled = Test-Path -LiteralPath $startupShortcut -PathType Leaf
     $autoStartAction = {
       Set-DreamSkinAutoStart -Enabled:(-not $autoStartEnabled)
     }.GetNewClosure()
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '登录时启动' `
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'LaunchAtLogin') `
       -Action $autoStartAction -Checked $autoStartEnabled
+    Add-DreamSkinTrayLanguageMenu
     [void]$menu.Items.Add([System.Windows.Forms.ToolStripSeparator]::new())
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '完全恢复 Codex' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'Restore') -Action {
       Start-DreamSkinPowerShell -Script $restoreScript -Arguments @(
         '-Port', "$Port", '-RestoreBaseTheme', '-PromptRestart'
       )
       $notify.Visible = $false
       [System.Windows.Forms.Application]::Exit()
     }
-    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text '退出托盘' -Action {
+    $null = Add-DreamSkinTrayItem -Items $menu.Items -Text (Get-DreamSkinTrayText -Key 'Exit') -Action {
       $notify.Visible = $false
       [System.Windows.Forms.Application]::Exit()
     }

--- a/windows/tests/community-theme-link.tests.ps1
+++ b/windows/tests/community-theme-link.tests.ps1
@@ -4,6 +4,7 @@ param([Parameter(Mandatory = $true)][string]$Root)
 $ErrorActionPreference = 'Stop'
 . (Join-Path $Root 'scripts\common-windows.ps1')
 . (Join-Path $Root 'scripts\theme-windows.ps1')
+. (Join-Path $Root 'scripts\localization-windows.ps1')
 
 function Assert-CommunityValueRejected {
   param(
@@ -209,11 +210,19 @@ $successMessageHelperAst = $applyAst.Find({
   $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
     $node.Name -ceq 'Format-DreamSkinCommunitySuccessMessage'
 }, $true)
-if ($null -eq $requestHelperAst -or $null -eq $successMessageHelperAst) {
-  throw 'The fixed-origin request or success-message helper is missing.'
+$communityTextHelperAst = $applyAst.Find({
+  param($node)
+  $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $node.Name -ceq 'Get-DreamSkinCommunityText'
+}, $true)
+if ($null -eq $requestHelperAst -or $null -eq $successMessageHelperAst -or
+  $null -eq $communityTextHelperAst) {
+  throw 'The fixed-origin request or localized success-message helper is missing.'
 }
 Invoke-Expression $requestHelperAst.Extent.Text
+Invoke-Expression $communityTextHelperAst.Extent.Text
 Invoke-Expression $successMessageHelperAst.Extent.Text
+$dreamSkinLanguage = 'en-US'
 $successMessage = Format-DreamSkinCommunitySuccessMessage -Name 'Paper'
 if (-not $successMessage -or $successMessage -notmatch 'Paper' -or
   $successMessage -notmatch 'SHA-256' -or $successMessage -notmatch 'Safe CSS' -or
@@ -225,6 +234,13 @@ $cleanupWarningMessage = Format-DreamSkinCommunitySuccessMessage -Name 'Paper' `
 if ($cleanupWarningMessage.Length -le $successMessage.Length -or
   $cleanupWarningMessage -match 'simulated private path') {
   throw 'The community success warning is missing or leaks the raw cleanup failure.'
+}
+$dreamSkinLanguage = 'zh-CN'
+$chineseSuccessMessage = Format-DreamSkinCommunitySuccessMessage -Name 'Paper'
+if (-not $chineseSuccessMessage -or $chineseSuccessMessage -notmatch 'Paper' -or
+  $chineseSuccessMessage -notmatch 'SHA-256' -or $chineseSuccessMessage -notmatch 'Safe CSS' -or
+  $chineseSuccessMessage -notmatch 'Codex' -or $chineseSuccessMessage -ceq $successMessage) {
+  throw 'The localized community success message is empty, malformed, or not language-specific.'
 }
 $request = New-DreamSkinCommunityHttpRequest `
   -RequestUri 'https://api.dreamskin.cc/v1/themes/ver_1234abcd' -Accept 'application/json'

--- a/windows/tests/installer-static.tests.ps1
+++ b/windows/tests/installer-static.tests.ps1
@@ -189,6 +189,7 @@ foreach ($requiredRepairContract in @(
   'assets\safe-css-validator.mjs',
   'scripts\validate-safe-css-file.mjs',
   'scripts\apply-community-theme.ps1',
+  'scripts\localization-windows.ps1',
   'presets\preset-gothic-void-crusade\theme.json',
   'scripts\start-dream-skin.ps1',
   'scripts\check-update.ps1',

--- a/windows/tests/installer-static.tests.ps1
+++ b/windows/tests/installer-static.tests.ps1
@@ -236,6 +236,16 @@ $authenticodeIndex = $common.IndexOf('Get-AuthenticodeSignature -LiteralPath $Pa
 if ($securityImportIndex -lt 0 -or $authenticodeIndex -le $securityImportIndex) {
   throw 'Node signature validation can call Get-AuthenticodeSignature before the security module is loaded.'
 }
+$unicodeProbeContracts = @(
+  'ConvertFrom-DreamSkinUtf8Base64',
+  'Buffer.from(process.execPath, ''utf8'').toString(''base64'')',
+  'invalid-output', 'path-not-found', 'empty-output', 'probe-exit'
+)
+foreach ($contract in $unicodeProbeContracts) {
+  if (-not $common.Contains($contract)) {
+    throw "Unicode-safe bundled Node path validation contract is missing: $contract"
+  }
+}
 
 $iconGenerator = $builderAst.Find({
   param($node)

--- a/windows/tests/localization-contract.test.mjs
+++ b/windows/tests/localization-contract.test.mjs
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const localizationPath = join(root, "scripts", "localization-windows.ps1");
+const bytes = readFileSync(localizationPath);
+const source = bytes.subarray(3).toString("utf8");
+const tray = readFileSync(join(root, "scripts", "tray-dream-skin.ps1"), "utf8");
+const updateCheck = readFileSync(join(root, "scripts", "check-update.ps1"), "utf8");
+const start = readFileSync(join(root, "scripts", "start-dream-skin.ps1"), "utf8");
+const restore = readFileSync(join(root, "scripts", "restore-dream-skin.ps1"), "utf8");
+const communityApply = readFileSync(join(root, "scripts", "apply-community-theme.ps1"), "utf8");
+const bootstrap = readFileSync(join(root, "installer", "setup-bootstrap.ps1"), "utf8");
+const common = readFileSync(join(root, "scripts", "common-windows.ps1"), "utf8");
+const releaseBuilder = readFileSync(join(root, "installer", "build-release.ps1"), "utf8");
+const themeWindows = readFileSync(join(root, "scripts", "theme-windows.ps1"), "utf8");
+const runTests = readFileSync(join(root, "tests", "run-tests.ps1"), "utf8");
+
+const extractCatalog = (language, until) => {
+  const pattern = new RegExp(`'${language}'\\s*=\\s*@\\{([\\s\\S]*?)${until}`);
+  const match = source.match(pattern);
+  assert.ok(match, `missing ${language} localization catalog`);
+  return new Map(
+    [...match[1].matchAll(/([A-Za-z][A-Za-z0-9]*)\s*=\s*'([^']*)'/g)]
+      .map((entry) => [entry[1], entry[2]])
+  );
+};
+
+test("Windows localization source is PowerShell 5.1-safe UTF-8 with BOM", () => {
+  assert.deepEqual([...bytes.subarray(0, 3)], [0xef, 0xbb, 0xbf]);
+  for (const functionName of [
+    "Resolve-DreamSkinLanguage",
+    "Set-DreamSkinLanguage",
+    "Get-DreamSkinLanguagePreference",
+    "Get-DreamSkinText"
+  ]) {
+    assert.match(source, new RegExp(`function ${functionName}\\s*\\{`));
+  }
+  assert.doesNotMatch(source, /\?\?|\?\.|ForEach-Object\s+-Parallel/);
+});
+
+test("Windows English and Chinese catalogs have the same format contract", () => {
+  const english = extractCatalog("en-US", "\\n\\s*\\}\\s*\\n\\s*'zh-CN'");
+  const chinese = extractCatalog("zh-CN", "\\n\\s*\\}\\s*\\n\\s*\\}\\s*\\n");
+  assert.deepEqual([...english.keys()].sort(), [...chinese.keys()].sort());
+  assert.ok(english.size >= 35, "expected the primary tray surface to be translated");
+  for (const [key, englishText] of english) {
+    const chineseText = chinese.get(key);
+    assert.ok(englishText.trim(), `${key} English copy is empty`);
+    assert.ok(chineseText?.trim(), `${key} Chinese copy is empty`);
+    assert.equal(
+      (englishText.match(/\{\d+\}/g) ?? []).join(","),
+      (chineseText.match(/\{\d+\}/g) ?? []).join(","),
+      `${key} format placeholders differ`
+    );
+  }
+});
+
+test("Windows tray references only translated keys and packages the helper", () => {
+  const english = extractCatalog("en-US", "\\n\\s*\\}\\s*\\n\\s*'zh-CN'");
+  const localizedClients = [tray, updateCheck, start, restore, communityApply];
+  const referencedKeys = localizedClients.flatMap((client) => [
+    ...client.matchAll(/Get-DreamSkin(?:Tray|Update|Community)?Text\s+-Key\s+'([A-Za-z][A-Za-z0-9]*)'/g)
+  ].map((match) => match[1]));
+  assert.ok(referencedKeys.length >= 25, "expected localized tray actions");
+  for (const key of referencedKeys) {
+    assert.ok(english.has(key), `tray references unknown localization key ${key}`);
+  }
+  assert.match(tray, /Add-DreamSkinTrayLanguageMenu/);
+  assert.match(tray, /Set-DreamSkinLanguage -Language \$optionValue/);
+  assert.match(tray, /\$env:DREAMSKIN_LANG = Resolve-DreamSkinLanguage -StateRoot \$StateRoot/);
+  for (const packagingSource of [bootstrap, common, releaseBuilder]) {
+    assert.match(packagingSource, /'scripts\\localization-windows\.ps1'/);
+  }
+  for (const client of [updateCheck, start, restore, communityApply]) {
+    assert.match(client, /Join-Path \$PSScriptRoot 'localization-windows\.ps1'/);
+  }
+});
+
+test("Windows pause results use one localized message across tray and renderer", () => {
+  for (const parameter of [
+    "PauseNoSessionMessage",
+    "PauseSucceededMessage",
+    "PauseFailedMessage"
+  ]) {
+    assert.match(themeWindows, new RegExp(`\\[string\\]\\$${parameter}`));
+    assert.match(tray, new RegExp(`-${parameter} \\$${parameter[0].toLowerCase()}${parameter.slice(1)}`));
+  }
+  assert.match(tray, /\$removalMessage = \$removal\.Message/);
+  const liveRemove = themeWindows.match(/function Invoke-DreamSkinLiveRemove\s*\{([\s\S]*?)\n\}/)?.[1] ?? "";
+  assert.ok(liveRemove, "missing live remove implementation");
+  assert.doesNotMatch(liveRemove, /-Message '(?:皮肤已暂停|暂停失败，请重试)'/);
+  assert.match(liveRemove, /Message = \$PauseNoSessionMessage/);
+  assert.match(liveRemove, /Message = \$PauseSucceededMessage/);
+  assert.match(liveRemove, /Message = \$PauseFailedMessage/);
+  for (const token of [
+    "'[string]$PauseNoSessionMessage'",
+    "'[string]$PauseSucceededMessage'",
+    "'[string]$PauseFailedMessage'",
+    "Get-DreamSkinTrayText -Key 'PauseNoSession'",
+    "Get-DreamSkinTrayText -Key 'PauseSucceeded'",
+    "Get-DreamSkinTrayText -Key 'PauseFailed'"
+  ]) {
+    assert.ok(runTests.includes(token), `Windows static gate is missing ${token}`);
+  }
+});

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -5,6 +5,34 @@ $ErrorActionPreference = 'Stop'
 $Root = Split-Path -Parent $PSScriptRoot
 . (Join-Path $Root 'scripts\common-windows.ps1')
 . (Join-Path $Root 'scripts\theme-windows.ps1')
+. (Join-Path $Root 'scripts\localization-windows.ps1')
+
+if ((Resolve-DreamSkinLanguage -Language 'zh-CN') -cne 'zh-CN' -or
+  (Resolve-DreamSkinLanguage -Language 'en-US') -cne 'en-US') {
+  throw 'Explicit Windows language overrides did not resolve deterministically.'
+}
+if ((Get-DreamSkinText -Key 'Apply' -Language 'zh-CN') -cne '应用或重新应用' -or
+  (Get-DreamSkinText -Key 'Apply' -Language 'en-US') -cne 'Apply or reapply' -or
+  (Get-DreamSkinText -Key 'Applied' -Language 'en-US' -FormatArguments @('Paper')) -cne 'Applied: Paper') {
+  throw 'Windows tray localization returned incorrect copy.'
+}
+$languageState = Join-Path ([System.IO.Path]::GetTempPath()) ('dreamskin-language-' + [Guid]::NewGuid().ToString('N'))
+$originalLanguageOverride = $env:DREAMSKIN_LANG
+try {
+  $env:DREAMSKIN_LANG = $null
+  Set-DreamSkinLanguage -Language 'zh-CN' -StateRoot $languageState
+  if ((Resolve-DreamSkinLanguage -Language '' -StateRoot $languageState) -cne 'zh-CN' -or
+    (Get-DreamSkinLanguagePreference -StateRoot $languageState) -cne 'zh-CN') {
+    throw 'Windows language preference did not persist.'
+  }
+  Set-DreamSkinLanguage -Language 'system' -StateRoot $languageState
+  if ((Get-DreamSkinLanguagePreference -StateRoot $languageState) -cne 'system') {
+    throw 'Windows system-language preference did not clear the override.'
+  }
+} finally {
+  $env:DREAMSKIN_LANG = $originalLanguageOverride
+  Remove-Item -LiteralPath $languageState -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 $temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) "codex-dream-skin-tests-$PID-$([guid]::NewGuid().ToString('N'))"
 New-Item -ItemType Directory -Path $temporaryRoot | Out-Null
@@ -1099,6 +1127,7 @@ try {
   Copy-Item -LiteralPath (Join-Path $Root 'scripts\image-metadata.mjs') -Destination $releaseFixtureScripts -Force
   Copy-Item -LiteralPath (Join-Path $Root 'scripts\injector.mjs') -Destination $releaseFixtureScripts -Force
   Copy-Item -LiteralPath (Join-Path $Root 'scripts\install-dream-skin.ps1') -Destination $releaseFixtureScripts -Force
+  Copy-Item -LiteralPath (Join-Path $Root 'scripts\localization-windows.ps1') -Destination $releaseFixtureScripts -Force
   Copy-Item -LiteralPath (Join-Path $Root 'scripts\restore-dream-skin.ps1') -Destination $releaseFixtureScripts -Force
   Copy-Item -LiteralPath (Join-Path $Root 'scripts\start-dream-skin.ps1') -Destination $releaseFixtureScripts -Force
   Copy-Item -LiteralPath (Join-Path $Root 'scripts\theme-windows.ps1') -Destination $releaseFixtureScripts -Force
@@ -1232,7 +1261,15 @@ try {
     throw 'macOS and Windows selector contract assets are not byte-identical.'
   }
   $traySource = Read-DreamSkinUtf8File -Path (Join-Path $Root 'scripts\tray-dream-skin.ps1')
-  foreach ($requiredTrayAction in @('System.Windows.Forms.NotifyIcon', '暂停皮肤', '继续显示皮肤', '更换背景图', '已保存主题', '完全恢复 Codex')) {
+  foreach ($requiredTrayAction in @(
+    'System.Windows.Forms.NotifyIcon',
+    "Get-DreamSkinTrayText -Key 'Pause'",
+    "Get-DreamSkinTrayText -Key 'Resume'",
+    "Get-DreamSkinTrayText -Key 'ChangeBackground'",
+    "Get-DreamSkinTrayText -Key 'SavedThemes'",
+    "Get-DreamSkinTrayText -Key 'Restore'",
+    'Add-DreamSkinTrayLanguageMenu'
+  )) {
     if (-not $traySource.Contains($requiredTrayAction)) { throw "Tray action is missing: $requiredTrayAction" }
   }
   if (-not $traySource.Contains('Invoke-DreamSkinLiveRemove') -or
@@ -1244,6 +1281,9 @@ try {
   $themeWindowsSource = Read-DreamSkinUtf8File -Path (Join-Path $Root 'scripts\theme-windows.ps1')
   foreach ($requiredLiveRemoveToken in @(
     'function Invoke-DreamSkinLiveRemove',
+    '[string]$PauseNoSessionMessage',
+    '[string]$PauseSucceededMessage',
+    '[string]$PauseFailedMessage',
     'function Show-DreamSkinOperationUi',
     "'--remove'",
     "'--browser-id'",
@@ -1252,6 +1292,19 @@ try {
   )) {
     if (-not $themeWindowsSource.Contains($requiredLiveRemoveToken)) {
       throw "Live remove helper is missing required token: $requiredLiveRemoveToken"
+    }
+  }
+  if ([regex]::IsMatch($themeWindowsSource, "-Message\s+'(?:皮肤已暂停|暂停失败，请重试)'")) {
+    throw 'Live remove renderer result still embeds a Chinese-only hard-coded message.'
+  }
+  foreach ($requiredPauseMessageToken in @(
+    "Get-DreamSkinTrayText -Key 'PauseNoSession'",
+    "Get-DreamSkinTrayText -Key 'PauseSucceeded'",
+    "Get-DreamSkinTrayText -Key 'PauseFailed'",
+    '$removalMessage = $removal.Message'
+  )) {
+    if (-not $traySource.Contains($requiredPauseMessageToken)) {
+      throw "Tray pause localization is missing: $requiredPauseMessageToken"
     }
   }
   $injectorSource = Read-DreamSkinUtf8File -Path (Join-Path $Root 'scripts\injector.mjs')
@@ -1279,7 +1332,12 @@ try {
     -not $traySource.Contains('Get-DreamSkinSavedThemes -StateRoot $StateRoot -SkipImageMetadata')) {
     throw 'Tray menu metadata enumeration still performs full image parsing on every open.'
   }
-  foreach ($requiredReleaseAction in @('check-update.ps1', '检查更新', '打开 DreamSkin.cc', '登录时启动')) {
+  foreach ($requiredReleaseAction in @(
+    'check-update.ps1',
+    "Get-DreamSkinTrayText -Key 'CheckUpdate'",
+    "Get-DreamSkinTrayText -Key 'OpenSite'",
+    "Get-DreamSkinTrayText -Key 'LaunchAtLogin'"
+  )) {
     if (-not $traySource.Contains($requiredReleaseAction)) {
       throw "Tray release action is missing: $requiredReleaseAction"
     }
@@ -1325,7 +1383,7 @@ try {
   $stateReadIndex = $startSource.IndexOf('$previousState = Read-DreamSkinState', [System.StringComparison]::Ordinal)
   $restartPromptIndex = $startSource.IndexOf('$restartAuthorized = Confirm-DreamSkinRestart', [System.StringComparison]::Ordinal)
   $recordedStopIndex = $startSource.IndexOf('$recordedInjectorStopped = Stop-DreamSkinRecordedInjector', [System.StringComparison]::Ordinal)
-  $cancelIndex = $startSource.IndexOf("Write-Host 'Dream Skin launch was cancelled", [System.StringComparison]::Ordinal)
+  $cancelIndex = $startSource.IndexOf("Get-DreamSkinText -Key 'LaunchCancelled'", [System.StringComparison]::Ordinal)
   $pauseClearIndex = $startSource.IndexOf('Set-DreamSkinPaused -Paused $false', [System.StringComparison]::Ordinal)
   if ($stateReadIndex -lt 0 -or $pauseClearIndex -le $stateReadIndex -or
     ($restartPromptIndex -ge 0 -and $pauseClearIndex -le $restartPromptIndex) -or

--- a/windows/tests/run-tests.ps1
+++ b/windows/tests/run-tests.ps1
@@ -23,7 +23,44 @@ try {
   New-Item -ItemType Directory -Path $runtimeNodeDirectory -Force | Out-Null
   $pathNode = Get-Command node.exe -ErrorAction SilentlyContinue
   if (-not $pathNode) { $pathNode = Get-Command node -ErrorAction Stop }
-  Copy-Item -LiteralPath $pathNode.Source -Destination (Join-Path $runtimeNodeDirectory 'node.exe') -Force
+  $unicodeNodePath = Join-Path $runtimeNodeDirectory 'node.exe'
+  Copy-Item -LiteralPath $pathNode.Source -Destination $unicodeNodePath -Force
+  $unicodeNode = Get-DreamSkinValidatedNodeRuntime -Path $unicodeNodePath
+  if (-not (Test-DreamSkinPathEqual -Left $unicodeNode.Path -Right $unicodeNodePath)) {
+    throw "Node executable path did not survive a Unicode PowerShell round-trip: $($unicodeNode.Path)"
+  }
+  try {
+    $null = ConvertFrom-DreamSkinUtf8Base64 -Value '////'
+    throw 'Invalid UTF-8 from the Node path probe was accepted.'
+  } catch {
+    if ($_.Exception.Message -notmatch 'invalid data') { throw }
+  }
+  $realNativeInvoker = (Get-Command Invoke-DreamSkinNative -CommandType Function).ScriptBlock
+  try {
+    function Invoke-DreamSkinNative {
+      param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [string[]]$ArgumentList = @(),
+        [switch]$DiscardStderr
+      )
+      if ($ArgumentList -contains 'process.versions.node') {
+        return [pscustomobject]@{ Output = @('22.23.1'); ExitCode = 0 }
+      }
+      return [pscustomobject]@{ Output = @('////'); ExitCode = 0 }
+    }
+    $invalidPathProbeRejected = $false
+    try {
+      $null = Get-DreamSkinValidatedNodeRuntime -Path $unicodeNodePath
+    } catch {
+      if ($_.Exception.Message -notmatch '\(invalid-output\)') { throw }
+      $invalidPathProbeRejected = $true
+    }
+    if (-not $invalidPathProbeRejected) {
+      throw 'Invalid Node path probe output fell back to the candidate executable.'
+    }
+  } finally {
+    Set-Item -Path Function:\Invoke-DreamSkinNative -Value $realNativeInvoker
+  }
   [System.IO.File]::WriteAllText(
     (Join-Path $runtimeNodeDirectory 'LICENSE'),
     'Node.js runtime license fixture',
@@ -212,6 +249,15 @@ try {
   )
   if ($trustIndex -lt 0 -or $probeIndex -le $trustIndex) {
     throw 'The Node.js runtime is executed before its signature is verified.'
+  }
+  foreach ($requiredUnicodeProbeContract in @(
+    'ConvertFrom-DreamSkinUtf8Base64',
+    'Buffer.from(process.execPath, ''utf8'').toString(''base64'')',
+    'invalid-output', 'path-not-found', 'empty-output', 'probe-exit'
+  )) {
+    if (-not $commonSource.Contains($requiredUnicodeProbeContract)) {
+      throw "Unicode-safe Node path probe is missing: $requiredUnicodeProbeContract"
+    }
   }
   $trayGuardIndex = $installSource.IndexOf('if (Test-DreamSkinTrayActive)', [System.StringComparison]::Ordinal)
   $engineInstallIndex = $installSource.IndexOf('$engine = Install-DreamSkinRuntimeEngine', [System.StringComparison]::Ordinal)

--- a/windows/tests/start-renderer-readiness.tests.ps1
+++ b/windows/tests/start-renderer-readiness.tests.ps1
@@ -2,11 +2,12 @@
 param([Parameter(Mandatory = $true)][string]$Root)
 
 $ErrorActionPreference = 'Stop'
+. (Join-Path $Root 'scripts\localization-windows.ps1')
 $startPath = Join-Path $Root 'scripts\start-dream-skin.ps1'
 $source = [System.IO.File]::ReadAllText($startPath)
-$dotSourcePattern = '(?m)^\.\s+\(Join-Path \$PSScriptRoot ''(?:common-windows|theme-windows)\.ps1''\)\r?\n'
-if ([regex]::Matches($source, $dotSourcePattern).Count -ne 2) {
-  throw 'Start readiness fixture could not isolate the two runtime imports.'
+$dotSourcePattern = '(?m)^\.\s+\(Join-Path \$PSScriptRoot ''(?:common-windows|theme-windows|localization-windows)\.ps1''\)\r?\n'
+if ([regex]::Matches($source, $dotSourcePattern).Count -ne 3) {
+  throw 'Start readiness fixture could not isolate the three runtime imports.'
 }
 $source = [regex]::Replace($source, $dotSourcePattern, '')
 $source = $source.Replace(

--- a/windows/tests/start-verified-skin-preserved.tests.ps1
+++ b/windows/tests/start-verified-skin-preserved.tests.ps1
@@ -11,11 +11,12 @@ param([Parameter(Mandatory = $true)][string]$Root)
 # must still restart it when the renderer reports a genuinely broken session.
 
 $ErrorActionPreference = 'Stop'
+. (Join-Path $Root 'scripts\localization-windows.ps1')
 $startPath = Join-Path $Root 'scripts\start-dream-skin.ps1'
 $rawSource = [System.IO.File]::ReadAllText($startPath)
-$dotSourcePattern = '(?m)^\.\s+\(Join-Path \$PSScriptRoot ''(?:common-windows|theme-windows)\.ps1''\)\r?\n'
-if ([regex]::Matches($rawSource, $dotSourcePattern).Count -ne 2) {
-  throw 'Preserved-skin fixture could not isolate the two runtime imports.'
+$dotSourcePattern = '(?m)^\.\s+\(Join-Path \$PSScriptRoot ''(?:common-windows|theme-windows|localization-windows)\.ps1''\)\r?\n'
+if ([regex]::Matches($rawSource, $dotSourcePattern).Count -ne 3) {
+  throw 'Preserved-skin fixture could not isolate the three runtime imports.'
 }
 $rawSource = [regex]::Replace($rawSource, $dotSourcePattern, '')
 $rawSource = $rawSource.Replace(


### PR DESCRIPTION
## What changed

- Add System / English / Chinese localization for the macOS menu bar client and Windows tray, including persistence, packaging, tests, and localized child-process workflows.
- Keep explicit accent button text readable in the shared renderer, including alpha composition, browser-equivalent RGB clamping, and the real composer panel surface over unknown artwork.
- Fix the #337 bundled Node handoff by transporting `process.execPath` as ASCII Base64 and decoding strict UTF-8 under Windows PowerShell 5.1.
- Consolidate the Windows validation procedure in [docs/pr-351-windows-validation.md](https://github.com/Fei-Away/Codex-Dream-Skin/blob/codex/fix-337-unicode-node-path/docs/pr-351-windows-validation.md).

## Why

The client needed one coherent bilingual candidate across both platforms, a Unicode-safe Windows installer/runtime handoff, and contrast behavior that matches the actual rendered composer surface instead of treating transparent theme colors as opaque.

## Verification

- Exact head: `1b7c759c1af9cf84878f5d27b0654a8d7e6417d4`.
- [CI run 31522162828](https://github.com/Fei-Away/Codex-Dream-Skin/actions/runs/31522162828): all four jobs passed.
- Static checks and portable macOS/Windows/tools regressions: 103/103 passed, plus both payload checks.
- macOS repository regressions, native menu app tests, and universal DMG build passed in CI.
- Windows PowerShell 7 and Windows PowerShell 5.1 full suites passed; the 5.1 job installed pinned Inno Setup 6.7.1 and compiled a non-empty candidate Setup.exe.
- Independent renderer review found no remaining code blocker; runtime and both generated platform assets are synchronized.

## Remaining acceptance boundary

Real GUI Setup execution under a CJK `TEMP`/`TMP` path and real Store Codex L1 interaction remain external release evidence. This merge does not prove those checks, close #337, create a tag, publish a Release, or deploy anything.
