### PR TITLE
fix(runtime): preserve native colored remote icons

### DIFF
--- a/macos/assets/dream-skin.css
+++ b/macos/assets/dream-skin.css
@@ -248,8 +248,9 @@ html[data-dream-skin="active"] aside.app-shell-left-panel [class*="text-token-in
   color: rgb(var(--ds-muted-rgb) / .92) !important;
 }
 
-/* Preserve native inline semantic colors for sidebar indicators. */
-html[data-dream-skin="active"] aside.app-shell-left-panel svg:not([style*="color"]) {
+/* Preserve native inline color declarations for sidebar indicators without
+   mistaking background-color or custom properties for a foreground color. */
+html[data-dream-skin="active"] aside.app-shell-left-panel svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]) {
   color: rgb(var(--ds-muted-rgb) / .96) !important;
 }
 
@@ -260,8 +261,8 @@ html[data-dream-skin="active"] aside.app-shell-left-panel a:hover {
   transform: none !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel button:hover svg:not([style*="color"]),
-html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg:not([style*="color"]) {
+html[data-dream-skin="active"] aside.app-shell-left-panel button:hover svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]),
+html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]) {
   color: var(--ds-accent) !important;
 }
 
@@ -288,7 +289,7 @@ html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] 
   color: var(--ds-text) !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] svg:not([style*="color"]) {
+html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]) {
   color: var(--ds-accent) !important;
 }
 

--- a/macos/assets/dream-skin.css
+++ b/macos/assets/dream-skin.css
@@ -248,7 +248,8 @@ html[data-dream-skin="active"] aside.app-shell-left-panel [class*="text-token-in
   color: rgb(var(--ds-muted-rgb) / .92) !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel svg {
+/* Preserve native inline semantic colors for sidebar indicators. */
+html[data-dream-skin="active"] aside.app-shell-left-panel svg:not([style*="color"]) {
   color: rgb(var(--ds-muted-rgb) / .96) !important;
 }
 
@@ -259,8 +260,8 @@ html[data-dream-skin="active"] aside.app-shell-left-panel a:hover {
   transform: none !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel button:hover svg,
-html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg {
+html[data-dream-skin="active"] aside.app-shell-left-panel button:hover svg:not([style*="color"]),
+html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg:not([style*="color"]) {
   color: var(--ds-accent) !important;
 }
 
@@ -287,7 +288,7 @@ html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] 
   color: var(--ds-text) !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] svg {
+html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] svg:not([style*="color"]) {
   color: var(--ds-accent) !important;
 }
 

--- a/runtime/dream-skin.css
+++ b/runtime/dream-skin.css
@@ -248,7 +248,8 @@ html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ [class*="text-token
   color: rgb(var(--ds-muted-rgb) / .92) !important;
 }
 
-html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ svg {
+/* Preserve native inline semantic colors for sidebar indicators. */
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ svg:not([style*="color"]) {
   color: rgb(var(--ds-muted-rgb) / .96) !important;
 }
 
@@ -259,8 +260,8 @@ html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ a:hover {
   transform: none !important;
 }
 
-html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ button:hover svg,
-html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ a:hover svg {
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ button:hover svg:not([style*="color"]),
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ a:hover svg:not([style*="color"]) {
   color: var(--ds-accent) !important;
 }
 
@@ -287,7 +288,7 @@ html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ [aria-current="page
   color: var(--ds-text) !important;
 }
 
-html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ [aria-current="page"] svg {
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ [aria-current="page"] svg:not([style*="color"]) {
   color: var(--ds-accent) !important;
 }
 

--- a/runtime/dream-skin.css
+++ b/runtime/dream-skin.css
@@ -248,8 +248,9 @@ html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ [class*="text-token
   color: rgb(var(--ds-muted-rgb) / .92) !important;
 }
 
-/* Preserve native inline semantic colors for sidebar indicators. */
-html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ svg:not([style*="color"]) {
+/* Preserve native inline color declarations for sidebar indicators without
+   mistaking background-color or custom properties for a foreground color. */
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]) {
   color: rgb(var(--ds-muted-rgb) / .96) !important;
 }
 
@@ -260,8 +261,8 @@ html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ a:hover {
   transform: none !important;
 }
 
-html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ button:hover svg:not([style*="color"]),
-html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ a:hover svg:not([style*="color"]) {
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ button:hover svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]),
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ a:hover svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]) {
   color: var(--ds-accent) !important;
 }
 
@@ -288,7 +289,7 @@ html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ [aria-current="page
   color: var(--ds-text) !important;
 }
 
-html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ [aria-current="page"] svg:not([style*="color"]) {
+html[data-dream-skin="active"] __DREAM_SELECTOR_LEFT_PANEL__ [aria-current="page"] svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]) {
   color: var(--ds-accent) !important;
 }
 

--- a/tools/renderer-runtime.test.mjs
+++ b/tools/renderer-runtime.test.mjs
@@ -330,20 +330,37 @@ export async function runRendererRuntimeTest(assetRoot) {
   // and the measured fossil selector must be absent from the canonical CSS.
   assert.doesNotMatch(css, /(?:^|[.#\s])(?:codex-dream-skin|dream-skin-home|dream-home|dream-task)(?:[\s.#:{>]|$)|home-suggestion-list-item/);
   assert.match(css, /html\[data-dream-skin="active"\]/);
+  const sidebar = "(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\\.app-shell-left-panel)";
+  const noInlineColor = "svg:not\\(\\[style\\^=[\"']color:[\"']\\]\\):not\\(\\[style\\*=[\"'];color:[\"']\\]\\):not\\(\\[style\\*=[\"']; color:[\"']\\]\\)";
   assert.match(
     css,
-    /(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) svg:not\(\[style\*="color"\]\)\s*\{\s*color:\s*rgb\(var\(--ds-muted-rgb\) \/ \.96\) !important;/,
-    "Sidebar base icon tint must preserve native inline semantic colors.",
+    new RegExp(`${sidebar} ${noInlineColor}\\s*\\{\\s*color:\\s*rgb\\(var\\(--ds-muted-rgb\\) / \\.96\\) !important;`),
+    "Sidebar base icon tint must exempt only an inline color declaration.",
   );
   assert.match(
     css,
-    /(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) button:hover svg:not\(\[style\*="color"\]\),\s*[\s\S]{0,160}(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) a:hover svg:not\(\[style\*="color"\]\)\s*\{\s*color:\s*var\(--ds-accent\) !important;/,
-    "Sidebar hover tint must preserve native inline semantic colors.",
+    new RegExp(`${sidebar} button:hover ${noInlineColor},\\s*[\\s\\S]{0,160}${sidebar} a:hover ${noInlineColor}\\s*\\{\\s*color:\\s*var\\(--ds-accent\\) !important;`),
+    "Sidebar hover tint must exempt only an inline color declaration.",
   );
   assert.match(
     css,
-    /(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) \[aria-current="page"\] svg:not\(\[style\*="color"\]\)\s*\{\s*color:\s*var\(--ds-accent\) !important;/,
-    "Sidebar current-page tint must preserve native inline semantic colors.",
+    new RegExp(`${sidebar} \\[aria-current=\\\"page\\\"\\] ${noInlineColor}\\s*\\{\\s*color:\\s*var\\(--ds-accent\\) !important;`),
+    "Sidebar current-page tint must exempt only an inline color declaration.",
+  );
+  assert.doesNotMatch(
+    css,
+    /(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) svg\s*\{\s*color:\s*rgb\(var\(--ds-muted-rgb\) \/ \.96\) !important;/,
+    "Sidebar base tint must not override every SVG.",
+  );
+  assert.doesNotMatch(
+    css,
+    /(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) button:hover svg\s*,\s*[\s\S]{0,160}(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) a:hover svg\s*\{\s*color:\s*var\(--ds-accent\) !important;/,
+    "Sidebar hover tint must not override every SVG.",
+  );
+  assert.doesNotMatch(
+    css,
+    /(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) \[aria-current="page"\] svg\s*\{\s*color:\s*var\(--ds-accent\) !important;/,
+    "Sidebar current-page tint must not override every SVG.",
   );
   // Home gating must stay single-level: CSS forbids :has() inside :has(),
   // and Chromium drops any rule that nests it (the v1.3.1 regression).  The

--- a/tools/renderer-runtime.test.mjs
+++ b/tools/renderer-runtime.test.mjs
@@ -330,6 +330,21 @@ export async function runRendererRuntimeTest(assetRoot) {
   // and the measured fossil selector must be absent from the canonical CSS.
   assert.doesNotMatch(css, /(?:^|[.#\s])(?:codex-dream-skin|dream-skin-home|dream-home|dream-task)(?:[\s.#:{>]|$)|home-suggestion-list-item/);
   assert.match(css, /html\[data-dream-skin="active"\]/);
+  assert.match(
+    css,
+    /(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) svg:not\(\[style\*="color"\]\)\s*\{\s*color:\s*rgb\(var\(--ds-muted-rgb\) \/ \.96\) !important;/,
+    "Sidebar base icon tint must preserve native inline semantic colors.",
+  );
+  assert.match(
+    css,
+    /(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) button:hover svg:not\(\[style\*="color"\]\),\s*[\s\S]{0,160}(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) a:hover svg:not\(\[style\*="color"\]\)\s*\{\s*color:\s*var\(--ds-accent\) !important;/,
+    "Sidebar hover tint must preserve native inline semantic colors.",
+  );
+  assert.match(
+    css,
+    /(?:__DREAM_SELECTOR_LEFT_PANEL__|aside\.app-shell-left-panel) \[aria-current="page"\] svg:not\(\[style\*="color"\]\)\s*\{\s*color:\s*var\(--ds-accent\) !important;/,
+    "Sidebar current-page tint must preserve native inline semantic colors.",
+  );
   // Home gating must stay single-level: CSS forbids :has() inside :has(),
   // and Chromium drops any rule that nests it (the v1.3.1 regression).  The
   // canonical CSS therefore gates on the :has()-free home-route-css alias.

--- a/windows/assets/dream-skin.css
+++ b/windows/assets/dream-skin.css
@@ -248,8 +248,9 @@ html[data-dream-skin="active"] aside.app-shell-left-panel [class*="text-token-in
   color: rgb(var(--ds-muted-rgb) / .92) !important;
 }
 
-/* Preserve native inline semantic colors for sidebar indicators. */
-html[data-dream-skin="active"] aside.app-shell-left-panel svg:not([style*="color"]) {
+/* Preserve native inline color declarations for sidebar indicators without
+   mistaking background-color or custom properties for a foreground color. */
+html[data-dream-skin="active"] aside.app-shell-left-panel svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]) {
   color: rgb(var(--ds-muted-rgb) / .96) !important;
 }
 
@@ -260,8 +261,8 @@ html[data-dream-skin="active"] aside.app-shell-left-panel a:hover {
   transform: none !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel button:hover svg:not([style*="color"]),
-html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg:not([style*="color"]) {
+html[data-dream-skin="active"] aside.app-shell-left-panel button:hover svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]),
+html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]) {
   color: var(--ds-accent) !important;
 }
 
@@ -288,7 +289,7 @@ html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] 
   color: var(--ds-text) !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] svg:not([style*="color"]) {
+html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] svg:not([style^="color:"]):not([style*=";color:"]):not([style*="; color:"]) {
   color: var(--ds-accent) !important;
 }
 

--- a/windows/assets/dream-skin.css
+++ b/windows/assets/dream-skin.css
@@ -248,7 +248,8 @@ html[data-dream-skin="active"] aside.app-shell-left-panel [class*="text-token-in
   color: rgb(var(--ds-muted-rgb) / .92) !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel svg {
+/* Preserve native inline semantic colors for sidebar indicators. */
+html[data-dream-skin="active"] aside.app-shell-left-panel svg:not([style*="color"]) {
   color: rgb(var(--ds-muted-rgb) / .96) !important;
 }
 
@@ -259,8 +260,8 @@ html[data-dream-skin="active"] aside.app-shell-left-panel a:hover {
   transform: none !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel button:hover svg,
-html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg {
+html[data-dream-skin="active"] aside.app-shell-left-panel button:hover svg:not([style*="color"]),
+html[data-dream-skin="active"] aside.app-shell-left-panel a:hover svg:not([style*="color"]) {
   color: var(--ds-accent) !important;
 }
 
@@ -287,7 +288,7 @@ html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] 
   color: var(--ds-text) !important;
 }
 
-html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] svg {
+html[data-dream-skin="active"] aside.app-shell-left-panel [aria-current="page"] svg:not([style*="color"]) {
   color: var(--ds-accent) !important;
 }
 


### PR DESCRIPTION
## Summary / 摘要

- Preserve native inline colors on remote-control device indicators in the sidebar.
- Scope the base, hover, and selected-row sidebar SVG tint rules to icons without a native inline color.
- Add shared runtime regression coverage and regenerate the macOS and Windows CSS assets.

Closes #367

## Type / 类型

- [x] Bug fix / 缺陷修复
- [x] Theme / CSS / visual / 主题或视觉

## Platform / 平台

- [x] Both / 双平台

## Self-check / 自测

- [x] Relevant install / start / verify scripts exercised / 已按改动跑过对应脚本
- [x] Environment noted below / 下方注明环境
- [x] N/A — no user-facing changelog entry; this is a focused runtime compatibility fix pending release / 无需独立用户可见 changelog 条目

## Security / 安全

- [x] Does not modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does not silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (127.0.0.1) / CDP 仍仅本机回环

## Notes / 补充

Root cause: the sidebar's broad SVG rules used high-precedence theme colors, overriding native inline semantic colors. The opt-out is applied consistently to normal, hover, and selected states so a remote-control indicator does not lose its color during interaction.

Validation performed on Windows 11 x64 with Codex Desktop 26.803.10989.0 from the Microsoft Store and Dream Skin 1.5.14:

- `node windows/tests/renderer-inject.test.mjs` passed.
- `node macos/tests/renderer-inject.test.mjs` passed.
- `node --test windows/tests/*.test.mjs` passed: 27/27.
- `powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File .\windows\tests\run-tests.ps1` passed.
- `node tools/sync-runtime-assets.mjs --check`, JavaScript syntax checks, and `git diff --check` passed.
- Live Windows renderer check found 8 native inline-color sidebar indicators and 0 computed-color mismatches after the focused fix.

The full macOS Node suite was also attempted on Windows. Three pre-existing platform-incompatible tests fail identically on an unmodified upstream checkout because Windows denies `fsync`/symlink operations and lacks the macOS native-window behavior; the focused shared runtime test passed on both generated asset trees. CI remains the macOS platform gate.

No private conversation content, credentials, or user paths are included.