### PR TITLE
fix(windows): fail verification on horizontal overflow

### DIFF
--- a/windows/scripts/injector.mjs
+++ b/windows/scripts/injector.mjs
@@ -1318,8 +1318,8 @@ export async function verifySession(
       ))
     );
     result.pass = result.installed && result.version === result.expectedVersion &&
-      result.stylePresent && result.businessClassPollution === 0 && windowPass &&
-      documentPass && viewportPass && structurePass &&
+      result.stylePresent && result.businessClassPollution === 0 && !result.documentOverflow.x &&
+      windowPass && documentPass && viewportPass && structurePass &&
       payloadPass && homePass;
     return result;
   })()`);

--- a/windows/tests/injector-window-readiness.test.mjs
+++ b/windows/tests/injector-window-readiness.test.mjs
@@ -94,12 +94,14 @@ function makeDomFixture({
   hidden = false,
   viewportWidth = 1280,
   viewportHeight = 800,
+  scrollWidth = viewportWidth,
+  scrollHeight = viewportHeight,
 } = {}) {
   const styleNode = {};
   const documentElement = {
-    scrollWidth: viewportWidth,
+    scrollWidth,
     clientWidth: viewportWidth,
-    scrollHeight: viewportHeight,
+    scrollHeight,
     clientHeight: viewportHeight,
     getAttribute: (name) => name === "data-dream-skin" ? "active" : null,
   };
@@ -455,6 +457,27 @@ test("hidden documents and unreasonable viewports cannot pass", async () => {
   });
   assert.equal(tiny.result.pass, false);
   assert.equal(tiny.result.readiness.viewportPass, false);
+});
+
+test("horizontal document overflow cannot be reported as a verified skin", async () => {
+  const boundary = await verify({
+    dom: makeDomFixture({ scrollWidth: 1280 }),
+  });
+  assert.equal(boundary.result.documentOverflow.x, false);
+  assert.equal(boundary.result.pass, true, "Equal document and viewport widths are not overflow.");
+
+  const horizontal = await verify({
+    dom: makeDomFixture({ scrollWidth: 1281 }),
+  });
+  assert.equal(horizontal.result.documentOverflow.x, true);
+  assert.equal(horizontal.result.pass, false);
+
+  const verticalOnly = await verify({
+    dom: makeDomFixture({ scrollHeight: 1600 }),
+  });
+  assert.equal(verticalOnly.result.documentOverflow.y, true);
+  assert.equal(verticalOnly.result.documentOverflow.x, false);
+  assert.equal(verticalOnly.result.pass, true, "Vertical scrolling is expected for long conversations.");
 });
 
 test("zero-size and CSS-hidden shell anchors cannot satisfy L1", async () => {


### PR DESCRIPTION
## Summary

Replacement for #287. The original PR source branch is owned by rwang23 and cannot be updated by the current account.

- Rebased onto origin/main at 816e565 (v1.5.16).
- Kept a single commit and a two-file diff.
- Made verification fail when documentElement.scrollWidth exceeds clientWidth; vertical overflow remains allowed.
- Added regression coverage for the equal-width boundary, horizontal overflow, and vertical-only overflow.

## Validation

- Node syntax checks: passed.
- node --test windows/tests/*.test.mjs: 29/29 passed.
- Windows PowerShell 5.1 and PowerShell 7 full suites: passed serially.
- Installer static checks on PowerShell 5.1 and 7: passed.
- Real Codex renderer smoke on 26.820.7780.0: wide 1708x1020 and narrow 1000x800 both reported documentOverflow.x=false.

## Notes

The overall verifier remains false in the current app only because the latest main home check observes the existing suggestion-label color mismatch (rgb(223,223,223) vs expected rgb(238,237,237)); the overflow assertion itself passed in both real-renderer runs. No message was sent during the smoke test.

Please review this as the replacement for #287; issue #298 remains the tracking issue until the fix is merged.