### PR TITLE
fix(css): preserve Home Composer rounded corners

### DIFF
--- a/macos/assets/dream-skin.css
+++ b/macos/assets/dream-skin.css
@@ -1173,7 +1173,7 @@ html[data-dream-skin="active"] :is([class*="_homeUtilityBar_"], [class*="_Compos
 html[data-dream-skin="active"] [role="main"]:has([data-testid="home-icon"]):has(:is([class*="_homeUtilityBar_"], [class*="_ComposerHomeUtilityBar_"]))
   :is(.composer-surface-chrome, [class*="_ComposerLayoutRoot_"], [data-composer-surface-variant][data-composer-radius-variant]) {
   border: 0 !important;
-  border-radius: 0 0 22px 22px !important;
+  border-radius: 22px !important;
   box-shadow:
     0 10px 28px rgb(var(--ds-bg-rgb) / .24),
     inset 1px 0 rgb(var(--ds-muted-rgb) / .18),

--- a/runtime/dream-skin.css
+++ b/runtime/dream-skin.css
@@ -1173,7 +1173,7 @@ html[data-dream-skin="active"] __DREAM_SELECTOR_HOME_UTILITY__ {
 html[data-dream-skin="active"] __DREAM_SELECTOR_HOME_ROUTE__:has(__DREAM_SELECTOR_HOME_UTILITY__)
   __DREAM_SELECTOR_COMPOSER_CHROME__ {
   border: 0 !important;
-  border-radius: 0 0 22px 22px !important;
+  border-radius: 22px !important;
   box-shadow:
     0 10px 28px rgb(var(--ds-bg-rgb) / .24),
     inset 1px 0 rgb(var(--ds-muted-rgb) / .18),

--- a/tools/renderer-runtime.test.mjs
+++ b/tools/renderer-runtime.test.mjs
@@ -442,6 +442,11 @@ export async function runRendererRuntimeTest(assetRoot) {
   );
   assert.match(
     css,
+    /\[role="main"\]:has\(\[data-testid="home-icon"\]\):has\(:is\(\[class\*="_homeUtilityBar_"\], \[class\*="_ComposerHomeUtilityBar_"\]\)\)\s*:is\(\.composer-surface-chrome,[^)]*\)\s*\{[^}]*border-radius:\s*22px\s*!important;/,
+    "The Home Composer must keep rounded corners below the utility bar.",
+  );
+  assert.match(
+    css,
     /\[class~="h-full"\]\[class~="bg-gradient-to-t"\]\[class~="from-surface"\]\[class~="via-surface"\]/,
     "The current 148px sticky composer fade must be removed by its full utility signature.",
   );

--- a/windows/assets/dream-skin.css
+++ b/windows/assets/dream-skin.css
@@ -1173,7 +1173,7 @@ html[data-dream-skin="active"] :is([class*="_homeUtilityBar_"], [class*="_Compos
 html[data-dream-skin="active"] [role="main"]:has([data-testid="home-icon"]):has(:is([class*="_homeUtilityBar_"], [class*="_ComposerHomeUtilityBar_"]))
   :is(.composer-surface-chrome, [class*="_ComposerLayoutRoot_"], [data-composer-surface-variant][data-composer-radius-variant]) {
   border: 0 !important;
-  border-radius: 0 0 22px 22px !important;
+  border-radius: 22px !important;
   box-shadow:
     0 10px 28px rgb(var(--ds-bg-rgb) / .24),
     inset 1px 0 rgb(var(--ds-muted-rgb) / .18),


### PR DESCRIPTION
## Summary / 摘要

- Preserve all four 22px corners on the Home Composer when the native project utility bar is present.
- Keep the change in the shared runtime CSS and synchronize the macOS and Windows generated assets.
- Add a focused renderer regression assertion for the exact Home utility-bar/Composer selector.

Refs #394. Maintainer note: keep the issue open until the fix is included in a verified public Release.

## Type / 类型

- [x] Bug fix / 缺陷修复
- [ ] Feature / 新功能
- [ ] Docs / 文档
- [x] Theme / CSS / visual / 主题或视觉
- [ ] Scripts / install / restore / 脚本或安装恢复
- [ ] Chore / 杂项

## Platform / 平台

- [ ] macOS
- [ ] Windows
- [x] Both / 双平台
- [ ] Docs / repo only / 仅文档或仓库元数据

## Self-check / 自测

### Docs-only / 仅文档

- [ ] Links and wording reviewed / 已检查链接与表述

### macOS (when code under `macos/` changes)

- [ ] `macos/tests/run-tests.sh` passed / 已通过
- [ ] Doctor (optional): `macos/scripts/doctor-macos.sh`
- [ ] Live verify (if inject/CSS/start path): `verify-dream-skin-macos.sh` or Desktop **Verify**
- [ ] Restore / re-apply smoke (if install/restore/start changed) / 若改了安装恢复启动则做过恢复再应用

### Windows (when code under `windows/` changes)

- [x] Relevant `install` / `start` / `verify` / `restore` scripts exercised / 已按改动跑过对应脚本
- [x] Environment noted below (OS build, Codex source) / 下方注明环境

### User-facing / 用户可见变更

- [ ] Updated `macos/CHANGELOG.md` (and `macos/VERSION` if release-worthy) / 已更新 changelog（发版时再 bump VERSION）
- [ ] N/A — no user-facing change / 无用户可见变更

## Security / 安全

- [x] Does **not** modify official Codex install / asar / signatures / 未修改官方安装与签名
- [x] Does **not** silently write API Base URL or keys / 未静默写入 API Base URL 或 Key
- [x] CDP remains loopback-oriented (`127.0.0.1`) where applicable / CDP 仍仅本机回环（如适用）

## Notes / 补充

- Windows 11 with Codex 26.825: visually verified on a real installation after restarting the packaged client.
- `node tools/sync-runtime-assets.mjs --check`: passed.
- macOS and Windows renderer runtime tests: passed. The regression assertion was also verified red/green against the old and corrected radius values.
- macOS and Windows injector payload integrity checks: passed.
- Windows PowerShell 5.1 test suite: passed.
- Cross-platform Node run on Windows: 119 passed, 2 macOS-only tests skipped, and 3 macOS-only fixtures could not run because Windows does not provide the required directory `fsync`, symlink permission, and native macOS window probe behavior.
- I do not have access to a macOS device. The shared runtime and synchronized macOS asset are covered by automated renderer tests, but macOS visual verification is still requested from the issue reporter or a maintainer.
- Changelog and version files are intentionally unchanged so this focused bug fix remains minimal; release notes/versioning can be handled in the maintainer release commit.
