### PR TITLE
docs: define stability-first controller implementation plan

### DIFF
--- a/.github/CONTRIBUTING.en.md
+++ b/.github/CONTRIBUTING.en.md
@@ -29,9 +29,40 @@ A feature request should explain the use case, expected behavior, alternatives c
 
 Fork the repository and base your branch on the latest upstream `main`. Reuse existing scripts and platform helpers where possible. A small change should not require a new dependency.
 
+### Ownership and shared sources
+
+| Change | Editable source |
+| --- | --- |
+| Renderer, base CSS, image and package validation | `runtime/`; generate both platform copies with `node tools/sync-runtime-assets.mjs` |
+| Selectors | `tools/selectors.json`; update provenance, fixtures and generated assets |
+| System discovery, launch, permissions and recovery | Platform helpers; preserve existing locks, state and rollback |
+| Theme schema, limits, public parts and tokens | `dreamskin-cc` packages `theme-schema` / `skin-api`; coordinate client consumers |
+
+Do not edit generated files in `macos/assets` or `windows/assets` independently.
+Shared changes require both platform checks even when no platform script changed:
+
+```bash
+node tools/sync-runtime-assets.mjs --check
+node --test macos/tests/*.test.mjs windows/tests/*.test.mjs tools/*.test.mjs
+node macos/scripts/injector.mjs --check-payload
+node windows/scripts/injector.mjs --check-payload
+```
+
+Optional features must define enabling, disabling, cancellation, failure and
+resource cleanup. Reuse operation state and keep background work bounded. Split
+visual changes, platform additions and state bridges into separate PRs. The
+[implementation plan](../docs/controller-implementation-plan.md) describes the
+future Controller migration; planned interfaces are not available APIs yet.
+Use the existing modules above until their replacements are implemented.
+
 ### macOS
 
-Run the full test suite:
+Run the full suite in a dedicated test session. It includes native installer
+fixtures and Doctor; Doctor can connect to the installed client and clean theme
+state from excluded windows. When that client hosts active work, use the
+portable checks above and reviewed isolated fixtures, and record native
+acceptance as pending. A temporary HOME does not isolate loopback CDP ports;
+process-identity fixtures use an inert injector with no network activity.
 
 ```bash
 (cd macos && npm test)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,9 +29,36 @@ Bug 报告应包含：
 
 请先 fork 仓库，并让分支基于最新的上游 `main`。尽量复用现有脚本和平台 helper，不要为小改动增加新依赖。
 
+### 代码归属与共享源
+
+| 改动 | 修改入口 |
+| --- | --- |
+| renderer、基础 CSS、图片与主题包校验 | `runtime/`；用 `node tools/sync-runtime-assets.mjs` 生成双端副本 |
+| 选择器 | `tools/selectors.json`；同步 provenance、fixture 和生成资产 |
+| 系统发现、启动、权限、恢复 | 对应平台 helper；复用现有锁、状态和回滚 |
+| 主题 schema、限制、公开 part/token | `dreamskin-cc` 的 `packages/theme-schema` / `packages/skin-api`，协调客户端消费者 |
+
+不要只修改 `macos/assets` 或 `windows/assets` 中由同步工具生成的文件。共享源改动
+需要同时验证两个平台，即使改动没有落在平台脚本目录：
+
+```bash
+node tools/sync-runtime-assets.mjs --check
+node --test macos/tests/*.test.mjs windows/tests/*.test.mjs tools/*.test.mjs
+node macos/scripts/injector.mjs --check-payload
+node windows/scripts/injector.mjs --check-payload
+```
+
+新增可选功能要说明启用、停用、取消、失败和资源清理；不要另建一套操作状态或
+无界轮询。把视觉调整、平台扩展和状态桥接拆成独立 PR。Controller 的迁移阶段与
+未来接口见 [实施方案](../docs/controller-implementation-plan.md)，尚未落地的接口
+不能当作当前可用 API。现阶段仍复用上述已有模块。
+
 ### macOS
 
-运行完整测试：
+在专用测试会话运行完整测试。该入口包含原生安装 fixture 和 Doctor；Doctor 会
+连接已安装客户端，可能清理被排除窗口的主题。如果当前客户端承载工作对话，
+使用上面的 portable 检查和已审阅的隔离 fixture，并把原生验收记录为待完成。
+临时 HOME 不隔离本机 CDP 端口；进程身份测试使用不联网的假 injector。
 
 ```bash
 (cd macos && npm test)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,6 +38,13 @@ Check what you actually ran. Skip items that do not apply and say so under Notes
 
 - [ ] Links and wording reviewed / 已检查链接与表述
 
+### Shared source / 共享源（when applicable / 如适用）
+
+- [ ] Edited canonical runtime/selectors and regenerated platform copies / 修改规范源并生成双端副本
+- [ ] Runtime sync, portable regressions and both payload checks passed / 同步、共享回归和双端 payload 检查通过
+- [ ] Contract changes list affected site/server/client consumers / 合同改动列明网站、服务端和客户端影响
+- [ ] New background work defines cancellation, failure and cleanup / 新后台功能有取消、失败和清理行为
+
 ### macOS (when code under `macos/` changes)
 
 - [ ] `macos/tests/run-tests.sh` passed / 已通过

--- a/docs/compat-profile-design.md
+++ b/docs/compat-profile-design.md
@@ -1,6 +1,7 @@
 # 兼容档案（compat profile）设计草案
 
-状态：**草案，未实现**。本文只定义契约与边界，供后续按 P1 落地。
+状态：**草案，未实现**。执行顺序以 [实施方案](./controller-implementation-plan.md)
+为准，先完成稳定性批次和统一 payload 装配。第一版只分发 selector，不含远端 CSS。
 背景问题见 `tools/selectors.json` 的 `verifiedAgainst.gaps` 与 issue #277。
 
 ## 为什么需要它
@@ -22,9 +23,9 @@
 也是"发版粒度不对"最直白的证据。
 
 结构性结论：**选择器契约的变更频率由上游决定，不该由我们的发版节奏决定。**
-运行时其实已经具备解耦条件——安装后的 injector 是在运行时从磁盘读
-`assets/selectors.json` 的（`macos/scripts/injector.mjs`、`windows/scripts/injector.mjs`），
-它只是没有第二个来源。
+现有 injector 在运行时读取 `assets/selectors.json`，但生成的 CSS 和 renderer
+也各自编入了 selector。实施前必须统一装配，使 CSS、renderer 与 Verify 使用
+同一份有效合同；仅增加 JSON 下载来源不足以完成热更新。
 
 ## 契约
 
@@ -47,7 +48,6 @@ GET https://api.dreamskin.cc/v1/compat/profile
   "expiresAt": "2026-09-26T00:00:00Z", // 过期即整份作废，回落到内置合同
   "minClient": "1.5.16",               // 低于此版本的客户端必须忽略本档案
   "selectors": [ /* 与 tools/selectors.json 的 selectors[] 同构 */ ],
-  "css": "…",                          // 可选，必须整体通过 dreamskin-safe-css/1
   "signature": "ed25519:…"             // 对上面全部字段规范化后的签名
 }
 ```
@@ -58,10 +58,13 @@ GET https://api.dreamskin.cc/v1/compat/profile
 2. **fail-closed 校验顺序**：HTTPS 固定 origin → 有界读取 → 签名 → `schema` → `revision`
    单调 → `expiresAt` 未过期 → `minClient` 满足 → 每条 selector 的 `key` 在内置合同里存在。
    任何一步不过，整份丢弃，不做部分应用。
-3. **只允许覆盖 `selector` 字符串**，不允许新增 key、不允许改 `tier`、不允许改 `required`。
-   降级面因此是有界的：最坏情况等于"某个锚点选不中"，也就是今天已经能处理的 L2 缺失。
-4. **`css` 必须整份通过既有 `dreamskin-safe-css/1` 白名单**，与社区主题走同一个验证器。
-   验证失败 → 丢弃整份档案（不是只丢 CSS）。
+3. **只允许覆盖 `selector` 字符串**，不允许新增 key，或改变 `tier`、`scope`、`required`。
+   selector 也可能错误命中业务节点，因此签名不能代替兼容性验收。发布档案前用
+   对应版本的脱敏 DOM fixture 验证作用域、命中数量、可见性与业务节点未被污染；
+   客户端继续执行原有 readiness 和精确主题/payload 验证，不降低成功条件。
+4. **第一版不接受 `css` 字段**。样式来自可信本地模板，以有效 selector 装配。
+   CSS、renderer、Verify 必须报告同一 revision；校验或装配失败时三者一起回退。
+   不在一个操作执行途中切换合同，下一次安全装配边界才激活新 revision。
 5. **绝不接受脚本、URL、文件路径、命令。** 这是硬边界：档案是数据，不是代码。
    服务端也不得把用户可控内容拼进档案。
 

--- a/docs/controller-implementation-plan.md
+++ b/docs/controller-implementation-plan.md
@@ -1,0 +1,250 @@
+# Dream Skin 长期实施方案
+
+日期：2026-09-05。当前执行阶段：A，稳定性 Issue / PR 批次。
+
+本方案承接 [Controller 迁移路线](./controller-migration-roadmap.md)。根目录
+`TASK_PROGRESS.md` 是执行事实来源，记录分支、提交、PR、CI、发布、测试证据和下一步。
+本文件定义目标与验收，不把计划中的模块描述为已实现。
+
+## 1. 目标与架构决策
+
+目标是提高操作效率、恢复可靠性和修改可预测性，让新增功能有明确归属。
+用户操作最终由一个 Controller 负责完整生命周期；Shell / PowerShell 退出默认
+用户运行时，保留确有需要的安装、构建、迁移和离线恢复工具。
+
+| 层 | 唯一职责 | 代码归属 |
+| --- | --- | --- |
+| 菜单栏 / 托盘 | 提交操作、显示进度和真实结果 | macOS AppKit / Windows 原生 UI |
+| Controller | 串行写操作、取消、超时、状态、恢复、子进程生命周期 | macOS Swift / Windows 受支持 .NET LTS |
+| 平台 adapter | 应用发现、身份、启动、窗口、系统注册、文件权限 | 各平台目录 |
+| 共享 runtime | 主题解释、payload 装配、renderer、通用 CDP 数据与 readiness 判定 | `runtime/` 规范源 |
+| 合同与 fixture | 主题包、Safe CSS、公开 part / token、操作语义 | 版本化数据与共享测试样本 |
+| 网站与 Go API | 制作、预览、审核、分发、平台与版本兼容声明 | `dreamskin-cc` |
+
+Windows Controller 首先以普通用户权限运行，复用受管 Node injector；不在 C#
+重新实现 renderer 或一套主题校验器。macOS 复用现有 Swift App。SDK 版本在原生
+阶段开始时按目标 Windows 版本与支持周期选定并固定，CI 验证相同工具链。
+
+现有两仓继续分别发布。主题 schema / limits / Safe CSS 的规范源沿用网站
+`packages/theme-schema`，公开 part / token 沿用 `packages/skin-api`；客户端以
+固定来源版本生成或带入副本。客户端 `runtime/` 是 renderer 和 injector 共同逻辑
+的规范源。先建立来源记录与一致性测试，再按实际需求决定是否独立发布包。
+
+## 2. 阶段 A：稳定性批次优先
+
+先完成本批的修复、组合回归和发布验收，再切换默认运行时架构。审阅范围保持在
+下面几项；等待外部证据的项目不扩张为清理整个 GitHub 队列。
+
+| 项目 | 动作 | 验收与退出条件 |
+| --- | --- | --- |
+| #398 | 修复 macOS 取消后强制退出 | 热重载优先；两层取消都终止；未确认退出时不发 TERM/KILL，不重启、不继续配置写入 |
+| #399 | 保留 Codex 原生字体 | 删除基础皮肤对 body 字体的强制覆盖；界面和代码字体分别保留；颜色/背景与 Safe CSS 边界不变 |
+| #396 / #394 | 审阅已有圆角 PR | 共享源与双端资产同步；Home utility/composer 四角正确，任务页无回归 |
+| #401 | 审阅已有更新回退 PR | API 正常、限流、固定仓库跳转、HTTP 头大小写、错误跳转及无版本时结果明确 |
+| #356 / #280 | 审阅当前 CDP 有界读取 PR | 数组单元素/空数组、异常 JSON、大小/超时、字段与端点身份约束；双端安装资产齐全 |
+| #387 / #218 | 核对已合并未发布的 watcher 修复 | 空闲退避有效，Codex 重开仍恢复；记录请求次数与 CPU，不用停止 watcher 掩盖重连缺陷 |
+| #390 / #235 / #395 | 验证已合并的 Windows profile 路径 | Store 来源和版本明确；CDP 在 runtime 交接后仍可用；首次登录及第二次启动、恢复均有实机证据 |
+
+各修复独立 PR。现有外部贡献优先沿原 PR 审阅与补充，记录来源，避免重复提交。
+`action_required` 只说明 CI 等待运行许可；审核 workflow 后才能放行。CI 成功后
+仍按改动需要做 native smoke。无法复现的上游 CDP 问题保持未验证状态。
+
+贡献署名是交付验收的一部分：优先合并贡献者原 PR，审阅产生的补充修复单独
+记录。合并时核对最终提交保留原作者身份；采用 squash 或必须转入替代 PR 时，
+使用经核对的原作者信息保留 author 或 `Co-authored-by`，并引用原 PR。Changelog
+和 Release notes 写明贡献者账号及对应 PR；发布后核对 GitHub 的贡献归属。
+本地整合与再生成平台资产不改变原补丁的贡献归属。未采用的 PR 保留清楚的
+审阅结论和后续要求，不把审阅等同于已合并或已完成贡献者登记。
+
+发布 gate：准确主线提交、六处版本一致、release workflow 构建 DMG / Setup.exe、
+tag 对应提交、校验和、公开且可下载的 Release 分别核对。网站随后更新下载 pin
+并部署验证。发布所需 Windows/native 证据缺失时保留候选；可并行准备后续纯逻辑
+合同和 fixture，但不切换用户入口。
+
+## 3. 阶段 B：先收敛共享逻辑与合同
+
+| PR 单元 | 实现范围 | 验收 |
+| --- | --- | --- |
+| B1 readiness | 从两份 injector 提取 signals 到 verdict 的纯判定，平台探测仍留 adapter | 同一 fixture 双端同一语义；覆盖 overflow、晚到 composer、主页/任务页、隐藏窗口 |
+| B2 payload | 统一主题解释和 payload 装配，保留已验证的模板替换、图片与 Safe CSS 校验 | 双端 payload 检查；重复应用与完整清理；主题名特殊字符与既有包回归 |
+| B3 合同同步 | 固定规范来源版本，生成 limits / policy / parts / tokens 副本；建立共同包样本 | 浏览器、Go、客户端对同一包结果一致；平台和 minClient 差异显式断言 |
+| B4 操作合同 | 实现第 5 节的协议及旧状态读取 adapter，先用于 status / verify | 旧状态 fixture、缺失/损坏状态、陈旧结果、UI 重连、重复请求 |
+
+提取一个模块就迁移其所有消费者并删除被替代的重复逻辑；保留运行行为，不同时
+改变 schema、视觉规则和启动方式。现有 JS runtime 的业务规则继续共用，避免
+为了原生化把同一套策略分别翻译成 Swift、C#、PowerShell。
+
+## 4. 阶段 C 至 F：逐步接管和删除旧入口
+
+### C：Windows Controller
+
+1. 新增可安装的 Controller，先接管 `status`、`verify` 和诊断。旧入口仍可使用。
+2. 统一旧、新执行器的操作互斥和状态 adapter，验证安装升级与回退。尚不写新
+   schema 到旧脚本只能读取的状态文件。
+3. 接管主题导入和库操作，沿用现有安全导入器；导入成功不自动激活。
+4. 成对准备 `start/reapply/apply-theme` 与 `restore`，每个操作单独 PR，但必须
+   恢复路径已验证才能切换对应写入口。托盘只提交命令和订阅结果。
+5. 接管暂停、主题切换和更新检查；最后修改快捷方式、协议处理和登录启动注册。
+
+每一步需有旧版安装升级、干净安装、重复点击、慢请求、进程中断与恢复证据。
+新执行器失败不能自动并行启动旧脚本。fallback 的先决条件是未产生副作用，或
+本次事务恢复已经验证。保留可独立运行的 Repair / Recovery 路径。
+
+### D：macOS 操作编排收敛
+
+Swift App 逐项接管与 Windows 相同的操作语义，保留系统特定权限、应用激活和
+签名验证。阶段 A 的取消回归必须持续通过；迁移冷启动一键换肤、导入后显式应用、
+独立恢复官方外观时，分别覆盖取消与失败。替代一个脚本调用后再移除对应入口。
+
+### E：兼容档案单独落地
+
+在 B2 完成后才接远端档案。第一版只允许替换既有 selector，不含远端 CSS。
+可信本地模板用同一有效合同装配 CSS、renderer 与 Verify；命中和回退必须一致。
+若改变已签名有效版本，下一次安全装配边界生效，不在操作途中替换规则。
+
+服务端分发固定来源、已签名的有界数据；客户端验证签名、目标平台/上游版本、
+最低客户端版本、有效期与版本递增。签名密钥、轮换、撤销和回退流程需可验证。
+失效时整份丢弃并使用内置合同；异步获取不得阻塞启动。远端档案不能修复官方
+关闭 CDP，也不能用未知版本的 selector 命中替代已验证兼容声明。
+
+### F：退出用户运行时脚本
+
+至少经过一个完整安装、升级、使用与恢复的 Release 周期，并在全部声明支持的
+平台上完成验收，才能删除被替代的用户运行时脚本。删除前核对快捷方式、登录项、
+协议入口、安装清单、调用者和恢复文档没有残留引用。构建与受控恢复工具按用途保留。
+
+## 5. 操作、状态与恢复合同
+
+- UI 请求包括协议版本、`requestId`、操作名和有限参数。相同请求重试返回同一
+  `operationId`；新的用户意图使用新请求。写操作串行；读取状态不排在长导入后面。
+- 操作状态为 `queued/running/succeeded/failed/cancelled`；阶段单独记录为
+  `preflight/downloading/importing/launching/connecting/applying/verifying/recovering`。
+  只走当前操作需要的阶段，导入不假装经过启动。
+- `effect` 表达 `applied-live/selected-next-launch/imported/paused/restored/unknown`；
+  `recovery` 表达 `not-needed/pending/verified/failed/unknown`。失败且恢复未确认
+  进入需要处理状态，保留 journal，不删除诊断现场。
+- 快照带会话身份、操作代次、当前主题、观测时间和兼容证据。旧操作晚到的事件
+  不能覆盖新操作；UI 重连先取快照，再订阅后续事件。
+- 取消是有结果的请求。在副作用前结束；副作用后先完成必要恢复，再返回取消
+  结果和恢复状态。官方拒绝退出不等于授权强制退出。超时不等于成功或已恢复。
+- 状态写入保留原子 staging 和现有 journal 顺序。按本操作所有权恢复所改配置键，
+  保留用户并发修改；PID 必须连同启动时间、程序路径和受控身份一起校验。
+- 共存期复用旧操作互斥或统一移交门，列出旧 reader 支持的 schema 范围。用旧版
+  真实状态 fixture 验证升级/降级，不能只验证新 Controller 自写自读。
+- 本地 IPC 限当前用户，使用结构化、有界消息。公开 `dreamskin://` 仍只携带版本 ID，
+  由客户端确认并从固定 API 获取；网站失焦只能表示交接，不能表示已应用。
+
+## 6. 社区功能扩展规则
+
+| 功能类型 | 修改入口 | 必需证据 |
+| --- | --- | --- |
+| 主题效果/视觉兼容 | `runtime/` 与 selector 合同 | 双端生成资产、同主题首页/任务页、清理与性能 |
+| 系统行为/新操作 | 平台 adapter 与操作合同 | 取消、并发、失败、恢复、真实结果 |
+| 主题包/公开变量 | 两仓规范源与其消费者 | 同包跨语言 fixture、旧客户端与旧包兼容 |
+| 可选扩展 | 明确生命周期的独立模块 | 开启/关闭、资源释放、错误隔离与有界工作 |
+| 新平台 | 新 adapter、安装器、CI 和跨仓平台合同 | 安装/升级/恢复、发布产物、网站行为 |
+
+共享生成资产不接受独立手改。PR 模板需列来源模块、平台、合同影响与实际验证；
+使用现有操作和事件接口，不另起一套状态文件、常驻轮询或子进程编排。
+新增后台功能定义启动/停止、取消、超时、订阅释放和停用后的零工作状态。
+
+#369 的纯状态桥接可单独讨论，先拆出混入的生成资产/视觉修改；#370 涉及新平台
+的跨仓协调，按独立计划推进。壁纸轮换、遮罩设置等在所依赖的操作和持久化合同
+稳定后逐项接入，不必等待所有脚本删除，但不能阻塞阶段 A。
+
+## 7. 效率与验收记录
+
+当前工作主机同时承载本次 GPT 对话与其他项目。不得退出、重启、恢复、替换安装
+或修改正在使用的 GPT / ChatGPT / Codex 客户端，也不得按通用进程名批量清理。
+本机生命周期回归只运行临时 HOME、测试专用状态与已隔离系统命令的 fixture；
+执行完整测试脚本前须核对所有启动、退出、launchd 和安装调用。需要真实客户端
+的验收放在独立测试会话或专用主机，缺少证据就保持待验证，不在工作客户端上补跑。
+
+改动前后使用同一脱敏 fixture / 应用版本记录：冷启动到可交互耗时、热应用耗时、
+子进程数、无 Codex 时的发现请求次数、长时间空闲 CPU/内存，以及失败恢复耗时。
+先记录基线，再为被修改的路径设定不退化标准，不编造未测量的数值。
+新增 Controller 不引入每次点击启动一组脚本的路径；事件可订阅，读取与 UI 线程
+不执行同步 ZIP、网络或进程等待。
+
+每个 PR 运行适用的语法/类型检查、共享资产校验、portable regressions 与平台
+回归。共享 runtime 改动必须跑双端 payload。写状态/启动/恢复改动添加在 journal、
+配置、激活、验证边界的中断用例。平台编译与安装器检查交给对应 CI，真实桌面
+交互由原生或 Playwriter 工具验证，证据标注真实客户端或受控 fixture。
+
+## 8. 执行与上下文恢复
+
+`TASK_PROGRESS.md` 顶部维护当前阶段、工作目录/分支、文件所有权、正在运行的
+测试会话、已完成证据、阻塞与下一条可执行动作。每个实现、验证、交接、提交、
+PR、CI 或发布检查点更新一次。保留旧记录，不把尚未验证的事项标为完成。
+压缩或任务恢复后先读取该文件及本方案，从记录的下一步继续。
+
+Git 状态逐项记录：本地修改、提交、推送、PR、合并、tag、构建、公开 Release、
+网站部署相互独立。只有用户可下载且对应平台验收通过，才能将发布阶段关闭。
+
+## 9. 脚本迁移清单
+
+基线为 `64d1fd3` 加本次稳定性修改。这里只列两个 `scripts/` 目录的 38 个
+Shell / PowerShell 文件，构建目录、测试、`.command` 与 SwiftBar 插件另外核对。
+下表是职责和调用入口清单，不是删除许可。共享 helper 按函数职责逐步迁移，
+不能将整个 `common` 或 `theme` 文件原样搬进一个新的大类。
+
+### Windows：11 个 PowerShell 文件
+
+路径均相对 `windows/scripts/`。阶段 C 迁移，阶段 F 核对删除条件。
+
+| 文件 | 当前职责 / 主要调用入口 | 目标归属 |
+| --- | --- | --- |
+| `tray-dream-skin.ps1` | 托盘菜单、快捷方式；Setup bootstrap / 安装器启动 | 原生托盘，只保留 UI 与 Controller 客户端 |
+| `start-dream-skin.ps1` | 托盘、快捷方式、社区应用调用；启动/CDP/注入/验证 | Controller 操作 + 平台启动 adapter |
+| `restore-dream-skin.ps1` | 托盘和恢复快捷方式；停用、配置恢复 | Controller 恢复操作 + 独立 Recovery 入口 |
+| `verify-dream-skin.ps1` | CLI 验证入口；调用 injector | Controller Verify，判定逻辑来自 B1 |
+| `apply-community-theme.ps1` | `dreamskin://` 协议入口；下载/导入/应用/恢复 | Controller 社区操作，复用同一导入和应用服务 |
+| `check-update.ps1` | 托盘调用；查询版本、显示结果 | 有界更新服务 + UI 结果展示 |
+| `install-dream-skin.ps1` | bootstrap / CLI；引擎部署、配置、快捷方式 | 安装迁移 adapter，迁移前保留 |
+| `common-windows.ps1` | 平台脚本共用；进程、CDP、锁、状态、引擎部署 | 按职责拆入 adapter / 操作状态 / 安装服务 |
+| `theme-windows.ps1` | 托盘、社区、安装、启动共用；主题库/图片/导入/快照 | 主题服务与事务；继续使用共享 Node 校验 |
+| `config-utf8.ps1` | common/theme 共用；UTF-8、TOML、原子写入和恢复 | 配置 adapter；保留并发修改和编码 fixture |
+| `localization-windows.ps1` | 托盘与命令反馈共用 | 原生 UI 资源，稳定 messageKey 与错误码 |
+
+额外删除检查入口：`windows/installer/setup-bootstrap.ps1`、
+`windows/installer/build-release.ps1`、安装器项目、登录项和协议注册。
+不能只修改托盘按钮而留下旧快捷方式继续并发写状态。
+
+### macOS：27 个 Shell 文件
+
+路径均相对 `macos/scripts/`。App 的实际调用与资源清单在
+`macos/menubar-app/Sources/CodexDreamSkinMenuBar/AppDelegate.swift`。
+
+| 文件 | 当前职责 / 主要调用入口 | 目标归属 |
+| --- | --- | --- |
+| `apply-from-menubar-macos.sh` | App / SwiftBar Apply；确认、热应用、冷启动回退 | D：Swift 操作编排 |
+| `start-dream-skin-macos.sh` | App、CLI、切换/背景脚本；启动与精确验证 | D：启动 adapter + 应用操作 |
+| `restore-dream-skin-macos.sh` | App / CLI 恢复 | D：恢复操作；保留独立 Recovery |
+| `pause-dream-skin-macos.sh` | App / SwiftBar 暂停、等待 ACK | D：操作服务，保留真实 ACK 条件 |
+| `verify-dream-skin-macos.sh` | CLI 调用 injector Verify | D：Verify adapter，复用 B1 |
+| `status-dream-skin-macos.sh` | App / SwiftBar / 社区事务查询 | B4/D：旧状态 adapter，统一可信快照 |
+| `apply-community-theme-macos.sh` | App 社区操作；快照、切换、恢复 | D：复用主题事务服务 |
+| `import-theme-zip-macos.sh` | App / CLI；提取和保存，不自动激活 | D：导入服务，继续共用 Node 校验 |
+| `extract-theme-zip-macos.sh` | 导入器调用；归档提取边界 | D：受限提取 adapter；安全 fixture 保留 |
+| `recover-theme-imports-macos.sh` | App 启动时清理/恢复中断导入 | D：恢复服务，保留未确认快照 |
+| `snapshot-active-theme-macos.sh` | 社区事务；快照与内容身份 | D：主题事务内部步骤 |
+| `switch-theme-macos.sh` | App / SwiftBar / 社区事务；选择、应用和恢复 | D：统一 ApplyTheme |
+| `load-image-theme-macos.sh` | App / SwiftBar 更换背景 | D：主题服务，保留当前主题配置与 CSS |
+| `customize-theme-macos.sh` | CLI 自定义主题入口 | D：主题服务 + 兼容包装 |
+| `theme-switch-lock-macos.sh` | switch/snapshot/community 共用操作锁 | B4/D：新旧共用互斥，迁移期间不得双锁并行 |
+| `common-macos.sh` | 状态、身份、签名、launchd、配置等平台 helper | D：按职责拆入 Swift adapter / 操作服务 |
+| `localization-macos.sh` | 多个脚本共用中英文反馈 | D：Swift UI 资源 + messageKey |
+| `check-update-macos.sh` | App 优先执行包内版本；CLI | D：有界更新服务 |
+| `doctor-macos.sh` | CLI 诊断入口 | D：诊断 adapter，保留只读 CLI |
+| `install-dream-skin-macos.sh` | App / CLI 引擎部署与入口生成 | D/F：安装迁移服务，最后核对旧入口 |
+| `install-menubar-macos.sh` | 旧 SwiftBar 安装与配置 | F：核对存量插件迁移后退出旧入口 |
+| `build-menubar-app.sh` | 编译 App、装配引擎资产 | 保留构建用途，更新资源清单 |
+| `build-dmg.sh` | CI 的 DMG 构建与静态检查 | 保留正式发布构建 |
+| `build-release.sh` | 源码/独立分发 ZIP 构建 | 保留构建用途，确认与正式 Release 分工 |
+| `build-client-release.sh` | 旧独立客户端 ZIP 与 `.command` 入口生成 | F：核对仍支持的分发渠道后决定退役 |
+| `prepare-standalone-docs.sh` | 构建期独立文档与引用装配 | 保留构建用途 |
+| `generate-app-icon.sh` | App 图标生成 | 保留构建用途 |
+
+删除验收必须搜索 App 资源清单、双端安装清单、CLI/快捷方式、SwiftBar 插件、
+测试和文档里的全部调用。以“旧入口已无调用者且恢复可用”为标准，不以脚本数量
+下降为完成指标。

--- a/docs/controller-migration-roadmap.md
+++ b/docs/controller-migration-roadmap.md
@@ -1,0 +1,247 @@
+# Dream Skin Controller 迁移路线
+
+> 状态：目标架构已完成审阅；当前先执行稳定性批次，Controller 尚未切换
+>
+> 记录日期：2026-09-05
+>
+> 适用范围：Codex Dream Skin macOS / Windows 客户端，与 DreamSkin.cc 的主题合同
+>
+> 执行顺序、验收门槛和贡献边界见 [实施方案](./controller-implementation-plan.md)。当前分支、证据和下一步见根目录 `TASK_PROGRESS.md`。
+
+## 1. 结论先行
+
+当前客户端的问题不是单纯的“PowerShell 文件太多”，而是**用户控制层没有一个统一的负责人**：菜单栏或托盘会启动多个 Shell/PowerShell 子流程，进程生命周期、主题状态、回滚、错误反馈和 Codex 兼容逻辑分散在不同文件中。
+
+长期目标是：
+
+```text
+菜单栏 / 系统托盘
+        |
+        v
+DreamSkin Controller
+        |
+        +-- 平台适配层：启动、进程、配置、CDP、回滚
+        |
+        +-- 共享 Runtime：renderer、Safe CSS、主题包校验
+        |
+        +-- 兼容档案：版本化 selector 数据，样式模板随客户端发布
+```
+
+用户入口最终只调用 Controller 的操作，不再由 UI 自己启动一串隐藏脚本。
+
+这不是立即删除所有 `.ps1` / `.sh` 的任务。正确顺序是先建立新边界，再迁移入口，最后删除**用户运行时**脚本。构建、CI、安装迁移和故障恢复脚本是否保留，单独评估。
+
+## 2. 当前事实与问题
+
+评审基线为 `main@64d1fd36d08530a803e08728652ef27328bf26e1`（2026-09-05，公开 Release 为 `v1.5.16`）。当前 `windows/scripts` 有 11 个 PowerShell 文件，约 355 KB；macOS `scripts` 有 27 个 Shell 文件。文件数量本身不是缺陷，真正的问题是职责边界和跨进程契约不清晰。
+
+### 2.1 控制层分散
+
+- Windows 的托盘、启动、恢复、主题库、配置、更新和校验分别由多个 `.ps1` 负责。
+- macOS 的菜单栏 App、Shell 启动器、`launchd`、恢复脚本和 AppleScript 共同编排一次操作。
+- UI 启动隐藏子进程后，部分路径只能显示“已开始”，不能取得最终成功、失败或取消结果。
+- 取消、超时、恢复失败和状态读取失败的语义没有统一模型。
+- 同一个动作在 macOS 与 Windows 上的菜单、状态和错误文本不完全一致。
+
+### 2.2 官方更新造成两类不同风险
+
+官方 Codex 更新影响的是两个独立边界，不能用一个“大重写”混为一谈：
+
+1. **启动 / CDP 边界**：官方可能改变参数传递、用户数据目录要求、进程关系或直接关闭调试端点。控制器可以改善发现、身份校验、回滚和诊断，但不能安全地制造官方已经移除的 CDP 能力。
+2. **Renderer / DOM 边界**：官方可能更换 DOM 结构、CSS Modules hash、composer 结构或渐进渲染顺序。需要稳定选择器、版本化兼容档案和降级策略，而不是每次都复制修改两份注入器。
+
+因此，“换成原生 exe”只能显著改善安装、编码、进程控制和维护成本，不能单独解决 DOM 漂移或官方关闭 CDP。
+
+### 2.3 已有的好基础
+
+共享 Runtime 已经部分建立：
+
+- `runtime/renderer-inject.js` 是 renderer 的规范源；
+- `runtime/dream-skin.css` 是 CSS 的规范源；
+- `runtime/theme-package-validator.mjs`、`runtime/safe-css-validator.mjs` 和图片解析器是共享校验源；
+- `tools/sync-runtime-assets.mjs` 生成 macOS / Windows 资产；
+- `tools/selectors.json` 维护选择器合同；
+- `docs/compat-profile-design.md` 已定义远端兼容档案的草案边界，但尚未实现。
+
+后续不应再复制一套 renderer 逻辑，而应继续扩展这条共享 Runtime 路径。
+
+## 3. 当前 PR / Issue 各自解决什么
+
+这些项目不能都叫“新功能”。大部分是稳定性、兼容性或维护性修复：
+
+| 项目 | 类型 | 解决的问题 | 当前判断 |
+| --- | --- | --- | --- |
+| #387 | 稳定性 / 工程 | watcher 在 CDP 消失后高频空转；选择器 provenance 不真实；Windows CI 没有可下载的 Setup 产物 | 已合入 `main`，尚未随新 Release 发出 |
+| #390 | Windows 兼容 | Chromium 136+ 可能忽略默认数据目录上的 CDP 参数；为调试会话增加受管 `cdp-profile` | 已合入 `main`，首次可能需要登录一次，尚未随新 Release 发出 |
+| #356 | CDP 安全 / 稳定 | 限制 `/json/list`、`/json/version` 的响应大小、根类型和字段边界，避免异常响应拖垮解析 | 已有绿色 CI，但基线较旧，需基于当前 `main` 重审 |
+| #396 | 视觉兼容 | Codex 更新后 Home Composer 四角变直角 | 小范围候选，需 review 后合入 |
+| #401 | 更新稳定性 | GitHub API 被共享出口限流时，更新检查仍能从固定 Releases URL 获取版本 | 小范围候选，需 review 后合入 |
+| #398 | 用户信任 / bug | 用户取消官方退出确认后，Dream Skin 仍可能继续 `TERM/KILL` 并重启 Codex | 稳定性批次前置修复，不等待 Controller |
+| #399 | 原生设置兼容 | 基础 CSS 强制覆盖用户在 Codex 中选择的界面字体 | 稳定性批次，与 #396 分别验证 |
+| #391 | 交互结构 | Windows 托盘一级菜单过于扁平，和 macOS 信息架构不一致 | 应在 Controller 结果反馈之后处理 |
+| #237 | 长期架构 | 用原生控制器替代 Windows 用户运行时 PowerShell 控制层 | 接受方向，但应拆成多个可回滚阶段，不做一次性大 PR |
+
+明确暂不纳入 Controller 第一批的项目：壁纸库/轮换、用户侧遮罩滑块、宠物状态桥接、Linux 大范围支持和旧冲突 PR。这些不是当前稳定性与维护性问题的最短路径。
+
+## 4. 目标职责边界
+
+### 4.1 Controller 负责什么
+
+Controller 是每个平台的长期用户运行时入口，负责：
+
+- 单实例锁和操作队列；
+- `start`、`reapply`、`apply-theme`、`import-theme`、`pause`、`restore`、`verify`、`status`；
+- 官方 Codex 的发现、启动和退出确认；
+- 进程身份、CDP 端点、Browser ID 和 renderer readiness 校验；
+- 原子配置写入、事务状态、回滚和恢复；
+- 启动 Node injector，并记录它的受控身份；
+- 向菜单栏 / 托盘持续发送结构化进度和最终结果；
+- 脱敏日志、诊断导出和错误分类。
+
+Controller 不负责：
+
+- 修改官方 `.app`、`app.asar`、WindowsApps 或代码签名；
+- 修改 API Key、Base URL 或模型供应商设置；
+- 把远端内容当作脚本、命令或任意路径执行；
+- 将 renderer 的平台差异重新复制到两份业务逻辑中。
+
+### 4.2 平台实现方式
+
+- **Windows**：一个签名的原生 Controller（使用实现时的受支持 .NET LTS），直接调用 AppX、进程、文件、命名管道和通知 API。
+- **macOS**：现有 Swift 菜单栏 App 逐步接管操作编排，Shell 仅保留为迁移、安装和必要的兼容包装层。
+- **共享部分**：主题包 schema、Safe CSS、renderer、选择器合同、操作事件 envelope、状态 schema 和跨平台 fixture。
+
+不强求 macOS / Windows 共用一个二进制。两个系统的菜单、签名、应用激活和进程 API 不同；应共用**协议和测试**，而不是强行共用所有平台代码。
+
+## 5. Controller 操作契约
+
+UI 只提交操作请求，Controller 拥有整个生命周期。每个操作都必须有稳定的 `operationId` 和终态：
+
+```json
+{
+  "schema": "dreamskin-operation/1",
+  "operationId": "op_20260905_0001",
+  "operation": "apply-theme",
+  "phase": "verifying",
+  "state": "running",
+  "themeId": "preset-gothic-void-crusade",
+  "messageKey": "verifyRenderer",
+  "errorCode": null,
+  "updatedAt": "2026-09-05T00:00:00Z"
+}
+```
+
+操作状态与执行阶段分别记录，不把所有操作强行排成同一条流程：
+
+```text
+state: queued -> running -> succeeded / failed / cancelled
+phase: preflight, downloading, importing, launching, connecting,
+       applying, verifying, recovering
+```
+
+例如导入只经过下载（如需要）和导入；重启后应用经过启动、连接、应用与验证。
+副作用后的取消先完成必要恢复，再报告取消结果与恢复状态。精确定义见
+[实施方案第 5 节](./controller-implementation-plan.md#5-操作状态与恢复合同)。
+
+用户可见状态必须区分：
+
+- `applied-live`：已验证当前 renderer 生效；
+- `selected-next-launch`：只写入下次启动使用的主题；
+- `paused`：明确暂停；
+- `status-unavailable`：无法取得可信实时状态；
+- `needs-attention`：需要用户 Verify、Repair 或 Restore。
+
+错误信息分为稳定错误码和可选诊断详情，例如：
+
+```text
+codex-not-found
+cdp-endpoint-unavailable
+renderer-not-ready
+user-cancelled
+restore-unverified
+operation-busy
+compatibility-unknown
+```
+
+原始异常、完整路径和技术细节只进入脱敏日志或“复制诊断”，不直接塞进普通提示框。
+
+Windows 可使用用户级 named pipe，macOS 可使用 XPC 或 Unix socket；传输方式可以不同，但事件 envelope 和状态语义必须相同。
+
+## 6. 官方更新兼容策略
+
+### 6.1 L0 / L1 / L2 降级
+
+把注入能力分成三个等级：
+
+- **L0**：背景、CSS 变量、基础可读性层。尽量不依赖业务 DOM。
+- **L1**：`role`、`data-testid`、稳定语义属性和壳层锚点。预设必须保证 L0 + L1。
+- **L2**：CSS Modules 前缀、精细 utility bar、局部间距和装饰细节。找到就增强，找不到就静默降级。
+
+未知 Codex 版本不应被报告为“已成功”。正确行为是保留安全的 L0/L1（如果能验证），并显示“兼容性待验证”或“需要检查”。L2 缺失不应让整套主题失效。
+
+### 6.2 兼容档案
+
+兼容档案是**数据，不是代码**：
+
+- 由固定官方 API 分发，带签名、版本、过期时间和最低客户端版本；
+- 第一版只允许覆盖内置合同中已有 selector 的字符串，不带远端 CSS；
+- 必须先建立统一 payload 装配点，使 CSS、renderer 和 Verify 同时使用同一有效 selector revision，并一起回退；构建时已编译的资产不能仅靠替换 `selectors.json` 更新；
+- 不允许新增命令、脚本、URL、文件路径或任意执行逻辑；
+- 完整校验失败时整份丢弃，回退到内置合同；
+- 启动时异步获取，不能阻塞换肤；
+- 远端档案只能缓解 DOM/选择器变化，不能修复官方关闭 CDP 或改变 AppX 启动协议。
+
+`tools/selectors.json` 仍是源码中的唯一可编辑选择器来源。每次选择器变化都要同步 provenance、fixture 和 doctor 结果。
+
+### 6.3 每个官方版本的发布门槛
+
+适配新版本时按固定顺序：
+
+1. 读取官方版本和平台来源；
+2. 运行 selector doctor，逐项输出 L0/L1/L2 命中；
+3. 验证 CDP 端点和进程归属；
+4. 记录脱敏 DOM fixture / readiness 证据；
+5. 只有必要的选择器或 adapter 变化才进入代码；
+6. 未知版本保持明确降级，不假装像素级兼容。
+
+## 7. 分阶段迁移计划
+
+阶段编号和验收以 [实施方案](./controller-implementation-plan.md) 为唯一执行来源；
+本节保留路线摘要，避免两份文档维护不同的迁移顺序。
+
+| 阶段 | 交付内容 | 用户入口切换条件 |
+| --- | --- | --- |
+| A | 稳定性批次：#398、#399、#396、#401、#356 审阅，以及 #387/#390 发布证据 | 保持既有入口，先修复现有行为 |
+| B | 共享 readiness、payload、跨仓合同和操作协议 | 纯逻辑提取与兼容 adapter 验收通过，不切原生入口 |
+| C | Windows Controller，读取/诊断先行，再逐项迁移写操作和安装注册 | 新旧互斥、状态兼容、取消与恢复已验证 |
+| D | macOS Swift 接管操作编排 | 复用相同操作语义，保留 A 的取消回归 |
+| E | selectors-only 签名兼容档案 | B2 统一 CSS/renderer/Verify 装配完成，整体校验与回退通过 |
+| F | 删除被替代的用户运行时脚本 | 至少一个完整 Release 周期、全部支持平台验收、独立恢复路径可用 |
+
+阶段 C/D 的每个写操作只有在尚未产生副作用，或恢复已验证后，才允许移交旧
+执行器；不能在新执行器写到一半时启动另一条路径。真实启动/退出/恢复验收在
+专用测试环境完成，不得退出或修改承载当前工作对话的客户端。
+
+## 8. 明确不走的路线
+
+- 不直接删除所有 `.ps1` / `.sh`，避免失去恢复路径；
+- 不把 Controller 重写、renderer 重写、兼容档案、主题 schema 和菜单重构塞进一个 PR；
+- 不修改官方 `app.asar`、`.app`、WindowsApps 或签名；
+- 不用透明 overlay 取代原生 Codex 控件作为主线；
+- 不把远端兼容档案设计成可执行脚本或任意 CSS 注入通道；
+- 不承诺原生 Controller 能解决上游完全关闭 CDP 的问题；
+- 不为了“适配所有版本”而悄悄降低身份校验、回滚校验或安全 CSS 边界。
+
+## 9. 完成标准
+
+这项架构迁移完成的标志不是“仓库里没有 PowerShell 文件”，而是：
+
+1. 用户只面对一个稳定的 Controller 入口；
+2. 每个操作都有可追踪的开始、进度、成功、失败或取消；
+3. 状态、日志和错误码在 macOS / Windows 语义一致；
+4. renderer 逻辑只有一份共享规范源，平台差异位于薄 adapter；
+5. Codex DOM 变化先由 doctor / compat profile 识别，L2 失败不会拖垮 L0/L1；
+6. 官方更新、失败启动和恢复都能回滚到可验证状态；
+7. PowerShell / Shell 只剩安装、构建、迁移和受控恢复等有明确理由的用途。
+
+在此之前，最有价值的第一批不是“删脚本”，而是建立 Controller 合同并处理 #398、Apply/Restore 最终结果和状态可信度问题。


### PR DESCRIPTION
Define an incremental path from the current script-based control flow to maintainable native Controllers, beginning with the selected stability Issue/PR batch. The plan assigns shared runtime and cross-project contract ownership, operation/recovery semantics, platform migration gates, and all 38 existing platform scripts to a migration destination.

The revised roadmap uses the same A-F stage order. The compatibility-profile draft now requires selectors-only data and one effective contract for CSS, renderer and Verify. Contributor guides and the PR template document canonical sources, generated assets, attribution and isolated testing of lifecycle behavior.

This PR changes documentation only. No Controller entry point, runtime state schema, platform version or release behavior is switched. Document paths, script inventory and git diff checks were verified; native/platform acceptance remains a gate for the implementation stages.
